### PR TITLE
refine docker-compose command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 1. Start the container
 
    ```ShellSession
-   $ docker-compose up
+   $ docker-compose up --build
    ```
 
 1. Note that this starts up Postgres, and both API & Worker Spring Boot apps


### PR DESCRIPTION
Minor refinement to the docker-compose command in README

### Summary

I got an error, when I checked out the repository and ran the docker-compose command listed in the README.  For my first PR, updating the README to the pass the `--build` argument to the `docker-compose` command. No code changes


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)
