### PR TITLE
Upgrade spring boot

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${springboot.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,7 +1,9 @@
-spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_ON_EXIT=false
 spring.datasource.username=sa
 spring.datasource.password=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
 spring.integration.jdbc.initialize-schema=always
 
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -40,13 +39,11 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.8</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/domain/src/main/resources/application.properties
+++ b/domain/src/main/resources/application.properties
@@ -2,6 +2,8 @@ spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_D
 spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # In a Production system we would use Liquibase or a similar tool, but for the purposes of this exercise
 # we are keeping things simple and just using Hibernate DDL generator. Works just fine for our purposes.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>gov.cms.ab2d</groupId>
@@ -25,14 +25,12 @@
         <project.root>${basedir}</project.root>
         <java.version>12</java.version>
         <checkstyle.config>${project.root}/src/main/resources/checkstyle.xml</checkstyle.config>
-        <springboot.version>2.1.6.RELEASE</springboot.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Upgrade spring boot to 2.2

### Summary

Upgrade application to use the current version of spring-boot (2.2) -which includes junit5 and some performance improvement and upgrades to the numerous dependencies that spring-boot manages.


### Checklist

- [x] Tests and linting pass


### Security
N/A
### Additional JIRA Tickets (optional)

N/A