### PR TITLE
set postgres to version 11 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres
+    image: postgres:11
     environment:
       - POSTGRES_DB=ab2d
       - POSTGRES_USER=ab2d


### PR DESCRIPTION
Set the postgres version to 11 in the docker-compose file used for local development

### Summary

Since Amazon Aurora does not support the latest version of PostgreSQL (12) as of today, we should specify the version number of the postgres image in the docker-compose file used for local development.


### Checklist
N/A

### Security
N/A

### Additional JIRA Tickets (optional)

N/A