### PR TITLE
Add missing JoinColumn annotations

### DIFF
--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -10,3 +10,4 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.jpa.hibernate.ddl-auto=create-drop
 
 api.retry-after.delay=30
+

--- a/domain/src/main/java/gov/cms/ab2d/domain/Job.java
+++ b/domain/src/main/java/gov/cms/ab2d/domain/Job.java
@@ -24,6 +24,7 @@ public class Job {
     private String jobID;
 
     @ManyToOne
+    @JoinColumn(name = "user_id")
     private User user;
 
     @OneToMany(

--- a/domain/src/main/java/gov/cms/ab2d/domain/JobOutput.java
+++ b/domain/src/main/java/gov/cms/ab2d/domain/JobOutput.java
@@ -15,6 +15,7 @@ public class JobOutput {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "job_id")
     private Job job;
 
     @Column(columnDefinition = "text")

--- a/domain/src/main/java/gov/cms/ab2d/domain/User.java
+++ b/domain/src/main/java/gov/cms/ab2d/domain/User.java
@@ -25,5 +25,6 @@ public class User {
     private Boolean accountDisabled;
 
     @ManyToOne
+    @JoinColumn(name = "sponsor_id")
     private Sponsor sponsor;
 }


### PR DESCRIPTION
Add missing `@JoinColumn` on  `@ManyToOne` associations.

### Summary

A few of the `@ManyToOne` associations are missing the `@JoinColumn`.  
Adding it for completeness.


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A