### PR TITLE
Rename user table to user_account table

### DIFF
--- a/domain/src/main/java/gov/cms/ab2d/domain/User.java
+++ b/domain/src/main/java/gov/cms/ab2d/domain/User.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "`user`")
+@Table(name = "user_account")
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)


### PR DESCRIPTION
Rename user table to user_account table as user is a reserved keyword in PG SQL

### Summary

`user` is a reserved keyword in postgres and SQL so renaming the table to remove any ambiguity and awkwardness while querying the table.
https://www.postgresql.org/docs/10/sql-keywords-appendix.html



### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A