### PR TITLE
set postgres compatibility mode for H2 during test

### DIFF
--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_ON_EXIT=false
+spring.datasource.url=jdbc:h2:mem:db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=false
 spring.datasource.username=sa
 spring.datasource.password=sa
 spring.datasource.driver-class-name=org.h2.Driver

--- a/domain/src/test/resources/application.properties
+++ b/domain/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_ON_EXIT=false
+spring.datasource.url=jdbc:h2:mem:db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=false
 spring.datasource.username=sa
 spring.datasource.password=sa
 spring.integration.jdbc.initialize-schema=always


### PR DESCRIPTION
Set PostgreSQL compatibility mode for H2

### Summary

Set postgres compatibility mode for H2 during test
http://h2database.com/html/features.html#compatibility


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A