### PR TITLE
Add bfd dependency to worker module

### DIFF
--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -21,6 +21,11 @@
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>gov.cms.ab2d</groupId>
+            <artifactId>bfd</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-integration</artifactId>
         </dependency>

--- a/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 
-@SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.common", "gov.cms.ab2d.worker"})
+@SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.common", "gov.cms.ab2d.worker", "gov.cms.ab2d.bfd.client"})
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model"})
 @EnableJpaRepositories("gov.cms.ab2d.common.repository")
 @PropertySource("classpath:application.common.properties")

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/WorkerConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/WorkerConfig.java
@@ -1,10 +1,12 @@
 package gov.cms.ab2d.worker.config;
 
+import gov.cms.ab2d.bfd.client.BFDClientConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessageSource;
@@ -28,6 +30,7 @@ import javax.sql.DataSource;
 @Slf4j
 @Configuration
 @EnableIntegration
+@Import(BFDClientConfiguration.class)
 public class WorkerConfig {
 
     @Autowired


### PR DESCRIPTION
Add `BFD` dependency to `worker` module

### Summary

The worker module would need to use the BFD  client to get the Explanations of Benefit associated with a given patient id from BB. So need to incorporate the `bfd` module as a dependency in the worker module.
Also, since the configuration for BFD beans is not defined in the worker module, the bdf bean configuration needs to be imported into the worker bean configuration file.


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A