### PR TITLE
AB2D-373: Liquibase, not Hibernate's auto-DDL, should run in tests as well

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=none
 spring.integration.jdbc.initialize-schema=always
 
 api.retry-after.delay=30

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,15 +1,8 @@
 spring.datasource.url=jdbc:h2:mem:db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=false
-spring.datasource.username=sa
-spring.datasource.password=sa
-spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
-spring.integration.jdbc.initialize-schema=always
-
+spring.integration.jdbc.initialize-schema=never
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
-spring.jpa.hibernate.ddl-auto=create-drop
-
-#-- disable liquibase for junit test which uses H2 instead of postgres
-spring.liquibase.enabled=false
+spring.jpa.hibernate.ddl-auto=none
+spring.liquibase.enabled=true
 
 api.retry-after.delay=30

--- a/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
@@ -1,9 +1,10 @@
 package gov.cms.ab2d.common.service;
 
-import gov.cms.ab2d.common.repository.UserRepository;
 import gov.cms.ab2d.common.model.User;
+import gov.cms.ab2d.common.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,8 +17,10 @@ public class UserServiceImpl implements UserService {
     private UserRepository userRepository;
 
     public User getCurrentUser() {
-        Authentication auth =  null; //SecurityContextHolder.getContext().getAuthentication(); leave out for now, otherwise it will not be null, just an anonymous user
-        return auth != null ? userRepository.findByUserName(((org.springframework.security.core.userdetails.User) auth.getPrincipal()).getUsername()) : null;
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth != null ? userRepository.findByUserName(
+                ((org.springframework.security.core.userdetails.User) auth.getPrincipal())
+                        .getUsername()) : null;
     }
 
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
@@ -18,9 +18,12 @@ public class UserServiceImpl implements UserService {
 
     public User getCurrentUser() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        return auth != null ? userRepository.findByUserName(
-                ((org.springframework.security.core.userdetails.User) auth.getPrincipal())
-                        .getUsername()) : null;
+        return auth != null ? userRepository
+                .findByUserName(
+                        auth.getPrincipal() instanceof String ? (String) auth.getPrincipal() :
+                                ((org.springframework.security.core.userdetails.User) auth
+                                        .getPrincipal())
+                                        .getUsername()) : null;
     }
 
 }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,7 +2,3 @@
 databaseChangeLog:
   - include:
       file: db/changelog/v001/AB2D-291-create-initial-tables.sql
-  - include:
-      file: db/changelog/v001/AB2D-331-drop-constraint-add-column.sql
-  - include:
-      file: db/changelog/v001/AB2D-356-rename-columns.sql

--- a/common/src/main/resources/db/changelog/v001/AB2D-291-create-initial-tables.sql
+++ b/common/src/main/resources/db/changelog/v001/AB2D-291-create-initial-tables.sql
@@ -131,7 +131,7 @@ CREATE TABLE job
     user_account_id     BIGINT              NOT NULL,
     created_at          TIMESTAMP WITH TIME ZONE         NOT NULL,
     expires_at          TIMESTAMP WITH TIME ZONE,
-    resource_types      VARCHAR(255)        NOT NULL,
+    resource_types      VARCHAR(255),
     status              VARCHAR(32)         NOT NULL,
     status_message      TEXT,
     request_url         TEXT,

--- a/common/src/main/resources/db/changelog/v001/AB2D-291-create-initial-tables.sql
+++ b/common/src/main/resources/db/changelog/v001/AB2D-291-create-initial-tables.sql
@@ -2,11 +2,11 @@
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateSequence-hibernate_sequence failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateSequence-hibernate_sequence failOnError:true 
 CREATE SEQUENCE hibernate_sequence START WITH 1 INCREMENT BY 1;
 
 
---changeset spathiyil:AB2D-291-CreateTable-beneficiary failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-beneficiary failOnError:true 
 CREATE TABLE beneficiary
 (
     id                  BIGINT              NOT NULL,
@@ -19,7 +19,7 @@ ALTER TABLE beneficiary ADD CONSTRAINT "uc_beneficiary_patient_id" UNIQUE (patie
 --rollback DROP TABLE beneficiary;
 --  -------------------------------------------------------------------------------------------------------------------
 
---changeset spathiyil:AB2D-291-CreateTable-sponsor failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-sponsor failOnError:true 
 CREATE TABLE sponsor
 (
     id                  BIGINT              NOT NULL,
@@ -30,7 +30,6 @@ CREATE TABLE sponsor
 );
 
 ALTER TABLE sponsor ADD CONSTRAINT "pk_sponsor" PRIMARY KEY (id);
-ALTER TABLE sponsor ADD CONSTRAINT "uc_sponsor_hpms_id" UNIQUE (hpms_id);
 ALTER TABLE sponsor ADD CONSTRAINT "fk_sponsor_to_sponsor_parent" FOREIGN KEY (parent_id) REFERENCES sponsor (id);
 
 --rollback DROP TABLE sponsor;
@@ -38,24 +37,25 @@ ALTER TABLE sponsor ADD CONSTRAINT "fk_sponsor_to_sponsor_parent" FOREIGN KEY (p
 
 
 
---changeset spathiyil:AB2D-291-CreateTable-contract failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-contract failOnError:true 
 CREATE TABLE contract
 (
     id                  BIGINT              NOT NULL,
-    contract_id         VARCHAR(255)        NOT NULL,
+    contract_number     VARCHAR(255)        NOT NULL,
+    contract_name       VARCHAR(255)        NOT NULL,
     sponsor_id          BIGINT NOT NULL,
-    attested_on         TIMESTAMPTZ
+    attested_on         TIMESTAMP WITH TIME ZONE
 );
 
 ALTER TABLE contract ADD CONSTRAINT "pk_contract" PRIMARY KEY (id);
-ALTER TABLE contract ADD CONSTRAINT "uc_contract_contract_id" UNIQUE (contract_id);
+ALTER TABLE contract ADD CONSTRAINT "uc_contract_contract_number" UNIQUE (contract_number);
 ALTER TABLE contract ADD CONSTRAINT "fk_contract_to_sponsor" FOREIGN KEY (sponsor_id) REFERENCES sponsor (id);
 
 --rollback DROP TABLE contract;
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-coverage failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-coverage failOnError:true 
 CREATE TABLE coverage
 (
     beneficiary_id      BIGINT              NOT NULL,
@@ -70,7 +70,7 @@ ALTER TABLE coverage ADD CONSTRAINT "uc_coverage_beneficiary_id_contract_id" UNI
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-user_account failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-user_account failOnError:true 
 CREATE TABLE user_account
 (
     id                  BIGINT              NOT NULL,
@@ -92,7 +92,7 @@ ALTER TABLE user_account ADD CONSTRAINT "fk_user_account_to_sponsor"  FOREIGN KE
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-role failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-role failOnError:true 
 CREATE TABLE role
 (
     id                  BIGINT              NOT NULL,
@@ -107,7 +107,7 @@ ALTER TABLE role ADD CONSTRAINT "uc_role_name" UNIQUE (name);
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-user_role failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-user_role failOnError:true 
 CREATE TABLE user_role
 (
     user_account_id     BIGINT              NOT NULL,
@@ -123,25 +123,25 @@ ALTER TABLE user_role ADD CONSTRAINT "uc_user_role_user_account_id_role_id" UNIQ
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-job failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-job failOnError:true 
 CREATE TABLE job
 (
     id                  BIGINT              NOT NULL,
-    job_id              VARCHAR(255)        NOT NULL,
+    job_uuid            VARCHAR(255)        NOT NULL,
     user_account_id     BIGINT              NOT NULL,
-    created_at          TIMESTAMPTZ         NOT NULL,
-    expires_at          TIMESTAMPTZ         NOT NULL,
+    created_at          TIMESTAMP WITH TIME ZONE         NOT NULL,
+    expires_at          TIMESTAMP WITH TIME ZONE,
     resource_types      VARCHAR(255)        NOT NULL,
     status              VARCHAR(32)         NOT NULL,
     status_message      TEXT,
     request_url         TEXT,
     progress            INT,
-    last_poll_time      TIMESTAMPTZ,
-    completed_at        TIMESTAMPTZ
+    last_poll_time      TIMESTAMP WITH TIME ZONE,
+    completed_at        TIMESTAMP WITH TIME ZONE
 );
 
 ALTER TABLE job ADD CONSTRAINT "pk_job" PRIMARY KEY (id);
-ALTER TABLE job ADD CONSTRAINT "uc_job_job_id" UNIQUE (job_id);
+ALTER TABLE job ADD CONSTRAINT uc_job_job_uuid UNIQUE (job_uuid);
 
 ALTER TABLE job ADD CONSTRAINT "fk_job_to_user_account" FOREIGN KEY (user_account_id) REFERENCES user_account (id);
 
@@ -149,7 +149,7 @@ ALTER TABLE job ADD CONSTRAINT "fk_job_to_user_account" FOREIGN KEY (user_accoun
 --  -------------------------------------------------------------------------------------------------------------------
 
 
---changeset spathiyil:AB2D-291-CreateTable-job_output failOnError:true dbms:postgresql
+--changeset spathiyil:AB2D-291-CreateTable-job_output failOnError:true 
 CREATE TABLE job_output
 (
     id                  BIGINT              NOT NULL,

--- a/common/src/main/resources/db/changelog/v001/AB2D-331-drop-constraint-add-column.sql
+++ b/common/src/main/resources/db/changelog/v001/AB2D-331-drop-constraint-add-column.sql
@@ -1,8 +1,0 @@
---liquibase formatted sql
---  -------------------------------------------------------------------------------------------------------------------
-
---changeset adaykin:AB2D-331-DropUCSponsorHMPSIDConstraint failOnError:true dbms:postgresql
-ALTER TABLE sponsor DROP CONSTRAINT "uc_sponsor_hpms_id";
-
---changeset adaykin:AB2D-331-AddContractName failOnError:true dbms:postgresql
-ALTER TABLE contract ADD COLUMN contract_name VARCHAR(128) NOT NULL;

--- a/common/src/main/resources/db/changelog/v001/AB2D-356-rename-columns.sql
+++ b/common/src/main/resources/db/changelog/v001/AB2D-356-rename-columns.sql
@@ -1,8 +1,0 @@
---liquibase formatted sql
---  -------------------------------------------------------------------------------------------------------------------
-
---changeset adaykin:AB2D-356-ChangeColumnConstraintNames failOnError:true dbms:postgresql
-ALTER TABLE job DROP CONSTRAINT uc_job_job_id;
-ALTER TABLE job RENAME job_id TO job_uuid;
-ALTER TABLE job ADD CONSTRAINT "uc_job_job_uuid" UNIQUE (job_uuid);
-ALTER TABLE contract RENAME contract_id TO contract_number;

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -89,7 +89,7 @@ public class JobServiceTest {
         assertThat(job.getId()).isNotNull();
         assertThat(job.getJobUuid()).isNotNull();
         assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getUser(), userRepository.findByUserName("example@example.com")); // null for now since no authentication
+        assertEquals(job.getUser(), userRepository.findByUserName("example@example.com"));
         assertEquals(job.getResourceTypes(), "ExplanationOfBenefits");
         assertEquals(job.getRequestUrl(), "http://localhost:8080");
         assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -1,2 +1,4 @@
 efs.mount=${java.io.tmpdir}/jobdownloads/
-spring.liquibase.enabled=false
+spring.liquibase.enabled=true
+spring.jpa.hibernate.ddl-auto=none
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/processing/AttestationReportProcessorTests.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/processing/AttestationReportProcessorTests.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringBootApp.class)
-@TestPropertySource(locations = "/hpms-it.properties")
+@TestPropertySource(locations = "/application.hpms.properties")
 public class AttestationReportProcessorTests {
 
     @Autowired

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/processing/OrgStructureReportProcessorTests.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/processing/OrgStructureReportProcessorTests.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringBootApp.class)
-@TestPropertySource(locations = "/hpms-it.properties")
+@TestPropertySource(locations = "/application.hpms.properties")
 public class OrgStructureReportProcessorTests {
 
     @Autowired

--- a/hpms/src/test/resources/application.hpms.properties
+++ b/hpms/src/test/resources/application.hpms.properties
@@ -1,0 +1,1 @@
+spring.liquibase.enabled=true

--- a/hpms/src/test/resources/hpms-it.properties
+++ b/hpms/src/test/resources/hpms-it.properties
@@ -1,1 +1,0 @@
-spring.liquibase.enabled=false

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -1,26 +1,21 @@
 ## -------------------------------------------------------------------------------------------  DATA-SOURCE CONFIG
 spring.datasource.url=jdbc:h2:mem:db;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=false
-spring.datasource.username=sa
-spring.datasource.password=sa
-spring.datasource.driver-class-name=org.h2.Driver
 
 ## ---------------------------------------------------------------------------------------------------  JPA CONFIG
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 
 ## ------------------------------------------------------------------------------------  SPRING INTEGRATION CONFIG
 spring.integration.jdbc.initialize-schema=always
 
-#-- disable liquibase for junit test which uses H2 instead of postgres
-spring.liquibase.enabled=false
+spring.liquibase.enabled=true
 
 
 ## ------------------------------------------------------------------------------------------------  LOGGING LEVEL
 logging.level.root=WARN
 logging.level.gov.cms.ab2d=INFO
-
 logging.level.org.springframework=WARN
 logging.level.com.zaxxer.hikari=WARN
 logging.level.org.hibernate=WARN
-logging.level.liquibase=WARN
+logging.level.liquibase=INFO


### PR DESCRIPTION
Liquibase, not Hibernate's auto-DDL, should run in tests as well.

### Summary

All of the integration tests now run the actual Liquibase migrations to prep the database instead of relying on the DDL auto-generation. This ensures the tests execute against exactly the same schema that is used in the environments. The underlying database in tests is still H2 though (albeit in PostgreSQL-compatibility mode): we'll need to think about switching to Test Containers eventually.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and linting pass
- [x] Code checked for PHI/PII exposure

### Security
N/A

### Additional JIRA Tickets (optional)
N/A
<!-- JIRA tickets not included in the PR title -->