### PR TITLE
feature/ab2d-388-integrate-sast

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: 12


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Adds an LGTM config to correctly specify Java version 12 for SAST build

<!-- A more detailed multi line description of the pr. -->

LGTM was failing builds due to compiling using JDK 8 by default. Adding this YAML config allows LGTM to correctly specify Java version 12 that is required for our project.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?

This is a simple configuration file for specifying Java versions for SAST and does not have any substantial impact on our security posture

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->