### PR TITLE
set job completedAt & use jobUuid while logging

### DIFF
--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -66,6 +66,18 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>83%</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
                             <excludes>
                                 <exclude>**/gov/cms/ab2d/worker/SpringBootApp.java</exclude>
                                 <!-- exclude the bluebutton package from coverage as it only has a stub -->

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
@@ -75,7 +75,7 @@ public class JobProcessingServiceImpl implements JobProcessingService {
     public Job processJob(final String jobId) {
 
         final Job job = jobRepository.findByJobUuid(jobId);
-        log.info("Found job : {} - {}", job.getId(), job.getJobUuid());
+        log.info("Found job : {}", job.getJobUuid());
 
         final Sponsor sponsor = job.getUser().getSponsor();
 
@@ -100,8 +100,9 @@ public class JobProcessingServiceImpl implements JobProcessingService {
         } catch (Exception e) {
             job.setStatus(JobStatus.FAILED);
             job.setStatusMessage(e.getMessage());
+            job.setCompletedAt(OffsetDateTime.now());
             jobRepository.save(job);
-            log.info("Job: [{}] FAILED", job.getId());
+            log.info("Job: [{}] FAILED", job.getJobUuid());
         }
 
         return job;
@@ -201,9 +202,10 @@ public class JobProcessingServiceImpl implements JobProcessingService {
         job.setStatus(SUCCESSFUL);
         job.setStatusMessage("100%");
         job.setExpiresAt(OffsetDateTime.now().plusDays(1));
+        job.setCompletedAt(OffsetDateTime.now());
 
         jobRepository.save(job);
-        log.info("Job: [{}] is DONE", job.getId());
+        log.info("Job: [{}] is DONE", job.getJobUuid());
     }
 
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceTest.java
@@ -90,6 +90,7 @@ class JobProcessingServiceTest {
         assertThat(processedJob.getStatus(), is(JobStatus.SUCCESSFUL));
         assertThat(processedJob.getStatusMessage(), is("100%"));
         assertThat(processedJob.getExpiresAt(), notNullValue());
+        assertThat(processedJob.getCompletedAt(), notNullValue());
     }
 
     @Test
@@ -120,6 +121,7 @@ class JobProcessingServiceTest {
         assertThat(processedJob.getStatus(), is(JobStatus.SUCCESSFUL));
         assertThat(processedJob.getStatusMessage(), is("100%"));
         assertThat(processedJob.getExpiresAt(), notNullValue());
+        assertThat(processedJob.getCompletedAt(), notNullValue());
     }
 
     private Sponsor createSponsor() {


### PR DESCRIPTION
Upon completion of the job, set the value for  Job CompletedAt.
Also, adjust the logging statement to use job_uuid instead of jobId

### Summary

Upon completion of the job, set the value for  Job CompletedAt.
Also, adjust the logging statement to use job_uuid instead of jobId



### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A