### PR TITLE
Modified the Worker to write only the file name into JobOutput.filePath

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
@@ -206,11 +206,6 @@ public class JobProcessingServiceImpl implements JobProcessingService {
         log.info("Job: [{}] is DONE", job.getId());
     }
 
-
-    private Path getEfsMountPath() {
-        return Paths.get(efsMount);
-    }
-
     private void sleep() {
         try {
             Thread.sleep(100);

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/JobProcessingServiceImpl.java
@@ -191,7 +191,7 @@ public class JobProcessingServiceImpl implements JobProcessingService {
 
     private JobOutput createJobOutput(Path outputFile, boolean isError) {
         JobOutput jobOutput = new JobOutput();
-        jobOutput.setFilePath(getEfsMountPath().relativize(outputFile).toString());
+        jobOutput.setFilePath(outputFile.getFileName().toString());
         jobOutput.setFhirResourceType("ExplanationOfBenefits");
         jobOutput.setError(isError);
         return jobOutput;

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.integration.jdbc.initialize-schema=always
 
 ## --------------------------------------------------------------------------------------------------  MISC CONFIG
-bb-stub.page.size=100
+bb-stub.page.size=10
 bfd-client.core.pool.size=5
 bfd-client.max.pool.size=10
 bfd-client.queue.capacity=100


### PR DESCRIPTION
Modified the Worker to write only the file name into `JobOutput.filePath`to match the API's expectations.

<!-- A concise one sentence description of the PR -->

### Summary

Modified the Worker to write only the file name into `JobOutput.filePath`to match the API's expectations. The API is unable to download the files otherwise. 


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and linting pass
- [x] Code checked for PHI/PII exposure

### Security
NA

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->