### PR TITLE
When output files already exist, delete it and create new ones during the job execution

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/service/FileService.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/FileService.java
@@ -33,6 +33,10 @@ public class FileService {
         final Path filePath = Path.of(outputDir.toString(), filename);
         Path outputFile = null;
         try {
+            //Delete file from previous run - Allows for a job can be restarted on failure.
+            Files.deleteIfExists(filePath);
+
+            // create a brand new file for the current run.
             outputFile = Files.createFile(filePath);
             log.info("Created file: {} ", outputFile.toAbsolutePath());
         } catch (IOException e) {

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
@@ -1,0 +1,61 @@
+package gov.cms.ab2d.worker.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+public class FileServiceIntegrationTest {
+
+    private FileService cut;
+
+
+    @TempDir
+    File tmpDir;
+
+    @BeforeEach
+    void setup() {
+        cut = new FileService();
+    }
+
+
+    @Test
+    void createFile_shouldRecreateNewFile_whenFileAlreadyExists() throws IOException {
+        final Path path = tmpDir.toPath();
+        final String output_filename = "contract_name.ndjson";
+
+        // pre-create file & write some text into file
+        final Path filePath = Path.of(path.toString(), output_filename);
+        final Path outputfile1 = Files.createFile(filePath);
+
+        final List<String> lines = List.of("Just", "another", "day", "in", "paradise");
+        Files.write(outputfile1, lines);
+
+        assertAll(
+                () -> assertTrue(Files.exists(outputfile1)),
+                () -> assertLinesMatch(lines, Files.readAllLines(outputfile1))
+        );
+
+        //createFile method will delete and recreate a new empty file with the same name.
+        final Path outputfile2 = cut.createFile(path, output_filename);
+
+        assertAll(
+                () -> assertTrue(Files.exists(outputfile2)),
+                () -> assertTrue(Files.readAllLines(outputfile2).isEmpty()),
+                () -> assertThat(outputfile1, equalTo(outputfile2))
+        );
+    }
+
+
+}


### PR DESCRIPTION
When output files already exist when a job executes, delete it and create a new file during the job execution

### Summary

During the execution of the job, if the output files already exist, delete them. This would happen when a job ends in a failure and it needs to be restarted


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A