### PR TITLE
AB2D-498 Correcting URL for excludes fetch

### DIFF
--- a/.github/workflows/trufflehog_github_actions.yml
+++ b/.github/workflows/trufflehog_github_actions.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/CMSgov/ab2d/trufflehog-excludes.txt
+      REMOTE_EXCLUDES_URL: https://raw.githubusercontent.com/CMSgov/ab2d/master/trufflehog-excludes.txt
     steps:
     - name: Execute Trufflehog
       run: |


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Correcting URL for excludes fetch

<!-- A more detailed multi line description of the pr. -->
Correcting URL for excludes fetch. it was missing "master" in the URL to specify the branch in the original implementation from PR #72 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
This builds off of PR #72 to correct a bug that was caused by an incorrect URL being provided for excludes.

<!-- JIRA tickets not included in the PR title -->