### PR TITLE
AB2D-498 Additional excludes to tune out false positives

### DIFF
--- a/trufflehog-excludes.txt
+++ b/trufflehog-excludes.txt
@@ -1,1 +1,10 @@
 .travis.yml
+Deploy/terraform/environments/ab2d-dev/authorized_keys
+Deploy/terraform/environments/ab2d-impl/authorized_keys
+Deploy/terraform/environments/ab2d-prod/authorized_keys
+Deploy/terraform/environments/ab2d-sbdemo-dev/authorized_keys
+Deploy/terraform/environments/ab2d-sbdemo-sbx/authorized_keys
+Deploy/terraform/environments/ab2d-sbdemo-shared/authorized_keys
+Deploy/terraform/environments/ab2d-sbx/authorized_keys
+bfd/src/test/resources/bb-test-data/(.*/)?
+website/_layouts/default.html


### PR DESCRIPTION


<!-- A concise one sentence description of the PR -->

### Additional excludes to tune out false positives in secrets scanning automation

<!-- A more detailed multi line description of the pr. -->
Additional excludes to tune out false positives in secrets scanning automation for trufflehog. Current scans pick up high entropy strings that are not secrets but are either public keys or integrity hashes/test data. These have been analyzed and added to the excludes file in the root of the repo with this PR.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?

This does remove some files from view of the scanner in an effort to reduce false positives. This means if someone commits a secret to an excluded file/directory, it could be ignored. That said, this is a low risk because only authorized users should be able to commit code, and each PR is reviewed manually. If someone intentionally hid a secret into an excluded directory this would constitute as an insider threat which is not a scenario this automation tool is capable of handling, nor is it the intent of the tool to handle it. 

What we gain is a baseline to identify new secrets that are accidentally committed to the repo as soon as they are pushed up, which is immensely valuable compared to the risk. This will always be the case whenever this excludes list is modified with new entries.
  
### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->