### PR TITLE
AB2D-498 Filter out all authorized_keys entries with regex

### DIFF
--- a/trufflehog-excludes.txt
+++ b/trufflehog-excludes.txt
@@ -1,11 +1,6 @@
 .travis.yml
-Deploy/terraform/environments/ab2d-dev/authorized_keys
-Deploy/terraform/environments/ab2d-impl/authorized_keys
-Deploy/terraform/environments/ab2d-prod/authorized_keys
-Deploy/terraform/environments/ab2d-sbdemo-dev/authorized_keys
-Deploy/terraform/environments/ab2d-sbdemo-sbx/authorized_keys
-Deploy/terraform/environments/ab2d-sbdemo-shared/authorized_keys
-Deploy/terraform/environments/ab2d-sbx/authorized_keys
+(.*/)?/authorized_keys
+Deploy/documentation/Internal_Test_Environment_Appendices.md
 bfd/src/test/resources/bb-test-data/(.*/)?
 optout/src/test/resources/test-data/(.*/)?
 website/_layouts/default.html


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Filter out all authorized_keys entries with regex

<!-- A more detailed multi line description of the pr. -->
New false positive was reported by a commit to the branch:
`feature/ab2d-355-automate-aws-waf-and-shield-configuration-deployment`
This PR filters out all authorized_keys entries with regex and filters additional false positives that were identified during analysis of the results. We won't be able to exclude every file that comes along, but this one highlighted a key area where we can drastically reduce false positives that flag on authorized keys and is worth updating our excludes for.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
This improves the security posture of the code base by reducing false positives for our secrets scanner. Public keys like authorized_keys are high entropy strings, but are not secret and do not need to be alerted on.

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->