### PR TITLE
AB2D 498 Regex Secrets Filter

### DIFF
--- a/trufflehog-excludes.txt
+++ b/trufflehog-excludes.txt
@@ -1,9 +1,5 @@
 .travis.yml
-<<<<<<< HEAD
 (.*/)?authorized_keys
-=======
-(.*/)?/authorized_keys
->>>>>>> ab2d-498-regex-secrets-filter
 Deploy/documentation/Internal_Test_Environment_Appendices.md
 bfd/src/test/resources/bb-test-data/(.*/)?
 optout/src/test/resources/test-data/(.*/)?

--- a/trufflehog-excludes.txt
+++ b/trufflehog-excludes.txt
@@ -1,5 +1,5 @@
 .travis.yml
-(.*/)?/authorized_keys
+(.*/)?authorized_keys
 Deploy/documentation/Internal_Test_Environment_Appendices.md
 bfd/src/test/resources/bb-test-data/(.*/)?
 optout/src/test/resources/test-data/(.*/)?


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Fixes regular expression account for literally all authorized_keys files

<!-- A more detailed multi line description of the pr. -->
The original fix included with PR #78 had a regular expression that only tested for directories nested 1 folder deep. This new regex contains no directory constraints and checks for all instances of the authorized keys file.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
Fixes the security regression caused by a bad regex in PR #78, impact is the same as the original PR #78

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->