### PR TITLE
rename QuartzJob to OptOutQuartzJob to fix duplicate bean name

### DIFF
--- a/optout/src/main/java/gov/cms/ab2d/optout/setup/OptOutQuartzSetup.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/setup/OptOutQuartzSetup.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource("classpath:application.optout.properties")
-public class QuartzSetup {
+public class OptOutQuartzSetup {
 
     @Value("${cron.schedule}")
     private String schedule;

--- a/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
@@ -1,6 +1,6 @@
 package gov.cms.ab2d.worker;
 
-import gov.cms.ab2d.optout.setup.QuartzSetup;
+import gov.cms.ab2d.optout.setup.OptOutQuartzSetup;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -19,7 +19,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model"})
 @EnableJpaRepositories("gov.cms.ab2d.common.repository")
 @PropertySource("classpath:application.common.properties")
-@Import({QuartzSetup.class})
+@Import({OptOutQuartzSetup.class})
 public class SpringBootApp {
 
     public static void main(String[] args) {


### PR DESCRIPTION
rename QuartzJob to OptOutQuartzJob to fix duplicate bean name

### Summary

rename QuartzJob to OptOutQuartzJob to fix duplicate bean name


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A