### PR TITLE
AB2D 609 handle job cancellation in worker

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.common.repository;
 
 import gov.cms.ab2d.common.model.Job;
+import gov.cms.ab2d.common.model.JobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,10 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     void cancelJobByJobUuid(@Param("jobUuid") String jobUuid);
 
     Job findByJobUuid(String jobUuid);
+
+
+    @Query("SELECT j.status FROM Job j WHERE j.jobUuid = :jobUuid ")
+    JobStatus findJobStatus(String jobUuid);
+
+
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/JobCancelledException.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/JobCancelledException.java
@@ -1,0 +1,8 @@
+package gov.cms.ab2d.worker.service;
+
+public class JobCancelledException extends RuntimeException {
+
+    public JobCancelledException(String message) {
+        super(message);
+    }
+}

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -19,6 +19,7 @@ bfd-client.core.pool.size=5
 bfd-client.max.pool.size=10
 bfd-client.queue.capacity=100
 file.try.lock.timeout=30
+cancellation.check.frequency=10
 
 ## ------------------------------------------------------------------------------------------------  LOGGING LEVEL
 logging.level.root=INFO

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceUnitTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -154,6 +156,8 @@ class JobProcessingServiceUnitTest {
                 Mockito.any()
         )).thenReturn(futureResources);
 
+        ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 2);
+
         var processedJob = cut.processJob("S001");
 
         assertThat(processedJob.getStatus(), is(JobStatus.SUCCESSFUL));
@@ -211,6 +215,61 @@ class JobProcessingServiceUnitTest {
         verify(beneficiaryAdapter).getPatientsByContract(anyString());
         verify(patientClaimsProcessor, never()).process(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
+
+
+    @Test
+    @DisplayName("When a job is cancelled while it is being processed, then attempt to stop the job gracefully without completing it")
+    void whenJobIsCancelledWhileItIsBeingProcessed_ThenAttemptToStopTheJob(@TempDir Path efsMountTmpDir) throws IOException {
+
+        job.setStatus(JobStatus.IN_PROGRESS);
+
+        // create parent sponsor
+        final Sponsor parentSponsor = createSponsor();
+        parentSponsor.setOrgName(parentSponsor.getOrgName() + " - PARENT");
+        parentSponsor.setLegalName(parentSponsor.getLegalName() + " - PARENT");
+
+        // associate the parent to the child
+        final Sponsor childSponsor = user.getSponsor();
+        childSponsor.setParent(parentSponsor);
+        parentSponsor.getChildren().add(childSponsor);
+
+        // switch the user to the parent sponsor
+        user.setSponsor(parentSponsor);
+
+        var contract = createContract(sponsor);
+        when(jobRepository.findByJobUuid(anyString())).thenReturn(job);
+
+        var patientsByContract = createPatientsByContractResponse(contract);
+        Mockito.when(beneficiaryAdapter.getPatientsByContract(anyString())).thenReturn(patientsByContract);
+
+        when(fileService.createDirectory(Mockito.any(Path.class))).thenReturn(efsMountTmpDir);
+        when(fileService.createFile(Mockito.any(Path.class), anyString()))
+                .thenReturn(efsMountTmpDir)
+                .thenReturn(efsMountTmpDir);
+
+        Future<Integer> futureResources = new AsyncResult(0);
+        Mockito.when(patientClaimsProcessor.process(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()
+        )).thenReturn(futureResources);
+
+        ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 2);
+        when(jobRepository.findJobStatus(anyString())).thenReturn(JobStatus.CANCELLED);
+
+        var processedJob = cut.processJob("S001");
+
+        assertThat(processedJob.getStatus(), is(JobStatus.CANCELLED));
+        assertThat(processedJob.getStatusMessage(), is("Job was cancelled while it was being processed"));
+        assertThat(processedJob.getCompletedAt(), nullValue());
+        assertThat(processedJob.getExpiresAt(), notNullValue());
+
+        verify(fileService).createDirectory(Mockito.any());
+        verify(beneficiaryAdapter).getPatientsByContract(anyString());
+        verify(patientClaimsProcessor, atLeast(1)).process(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
 
     private List<OptOut> getOptOutRows(GetPatientsByContractResponse patientsByContract) {
         return patientsByContract.getPatients()

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/JobProcessingServiceUnitTest.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -260,10 +261,8 @@ class JobProcessingServiceUnitTest {
 
         var processedJob = cut.processJob("S001");
 
-        assertThat(processedJob.getStatus(), is(JobStatus.CANCELLED));
-        assertThat(processedJob.getStatusMessage(), is("Job was cancelled while it was being processed"));
+        assertThat(processedJob.getStatus(), is(not(JobStatus.SUCCESSFUL)));
         assertThat(processedJob.getCompletedAt(), nullValue());
-        assertThat(processedJob.getExpiresAt(), notNullValue());
 
         verify(fileService).createDirectory(Mockito.any());
         verify(beneficiaryAdapter).getPatientsByContract(anyString());

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -22,6 +22,7 @@ bfd-client.core.pool.size=3
 bfd-client.max.pool.size=5
 bfd-client.queue.capacity=25
 file.try.lock.timeout=30
+cancellation.check.frequency=2
 
 ## ------------------------------------------------------------------------------------------------  LOGGING LEVEL
 logging.level.root=WARN


### PR DESCRIPTION
Add functionality to the worker module to enable it to stop processing an `IN_PROGRESS` job mid-way if the job gets cancelled

### Summary

While the working is processing a submitted job, if the job gets cancelled, the worker needs to be aware of it and attempt to cancel the  processing of the job, if possible.


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A