### PR TITLE
prevent concurrent execution of quartz job in worker

### DIFF
--- a/audit/src/main/java/gov/cms/ab2d/audit/cleanup/FileDeletionJob.java
+++ b/audit/src/main/java/gov/cms/ab2d/audit/cleanup/FileDeletionJob.java
@@ -2,11 +2,13 @@ package gov.cms.ab2d.audit.cleanup;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
 @Slf4j
 @RequiredArgsConstructor
+@DisallowConcurrentExecution
 public class FileDeletionJob extends QuartzJobBean {
 
     private final FileDeletionService fileDeletionService;

--- a/audit/src/main/resources/application.audit.properties
+++ b/audit/src/main/resources/application.audit.properties
@@ -9,3 +9,4 @@ spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
 spring.quartz.properties.org.quartz.jobStore.tablePrefix=qrtz_
 spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+spring.quartz.properties.org.quartz.jobStore.acquireTriggersWithinLock=true

--- a/optout/src/main/java/gov/cms/ab2d/optout/job/OptoutJob.java
+++ b/optout/src/main/java/gov/cms/ab2d/optout/job/OptoutJob.java
@@ -2,13 +2,13 @@ package gov.cms.ab2d.optout.job;
 
 import gov.cms.ab2d.optout.OptOutProcessor;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
-@Slf4j
 @RequiredArgsConstructor
+@DisallowConcurrentExecution
 public class OptoutJob extends QuartzJobBean {
 
     private final OptOutProcessor processor;

--- a/optout/src/main/resources/application.optout.properties
+++ b/optout/src/main/resources/application.optout.properties
@@ -1,10 +1,11 @@
 #------------------------------------------------------------------------------------ QUARTZ SCHEDULER CONFIG
 spring.quartz.job-store-type=jdbc
 spring.quartz.jdbc.initialize-schema=always
-spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
+spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.org.quartz.jobStore.tablePrefix=qrtz_
 spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+spring.quartz.properties.org.quartz.jobStore.acquireTriggersWithinLock=true
 
 # Every hour at minute 0, second 0 ------------------------------------------------------------ CRON SCHEDULE
 cron.schedule=0 0 * * * ?


### PR DESCRIPTION
prevent concurrent execution of quartz job in worker

### Summary

Occasionally, when the worker is started, it appeared as if the opt-out was being triggered twice concurrently on start-up for the first run. Adding an extra configuration to prevent it.


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A