### PR TITLE
Added additional environment variables to support Dev/Sandbox roll-out

### DIFF
--- a/common/src/main/resources/application.common.properties
+++ b/common/src/main/resources/application.common.properties
@@ -1,1 +1,1 @@
-efs.mount=${java.io.tmpdir}/jobdownloads/
+efs.mount=${AB2D_EFS_MOUNT:#{systemProperties['java.io.tmpdir']+'/jobdownloads/'}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - AB2D_DB_DATABASE=ab2d
       - AB2D_DB_USER=ab2d
       - AB2D_DB_PASSWORD=ab2d
+      - AB2D_EFS_MOUNT=/tmp/ab2d_efs_mount
     ports:
       - "8080:8080"
     depends_on:
@@ -38,5 +39,6 @@ services:
       - AB2D_DB_DATABASE=ab2d
       - AB2D_DB_USER=ab2d
       - AB2D_DB_PASSWORD=ab2d
+      - AB2D_EFS_MOUNT=/tmp/ab2d_efs_mount
     depends_on:
       - db

--- a/optout/src/main/resources/application.optout.properties
+++ b/optout/src/main/resources/application.optout.properties
@@ -10,5 +10,7 @@ spring.quartz.properties.org.quartz.jobStore.acquireTriggersWithinLock=true
 # Every hour at minute 0, second 0 ------------------------------------------------------------ CRON SCHEDULE
 cron.schedule=0 0 * * * ?
 
-
+s3.region=${AB2D_S3_REGION:us-east-1}
+s3.bucket=${AB2D_S3_OPTOUT_BUCKET:ab2d-optout-data-dev}
+s3.filename=${AB2D_S3_OPTOUT_FILE:T#EFT.ON.ACO.NGD1800.DPRF.D191029.T1135430}
 


### PR DESCRIPTION
Added additional environment variables to support Dev/Sandbox roll-out

### Summary

Added environment variables that will hold EFS mount and opt-out file S3 location information with default fallback to values that would work in Dex or Sandbox. Update Dockerfile to call them out explicitly. 


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and linting pass
- [x] Code checked for PHI/PII exposure

### Security
N/A

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->