### PR TITLE
AB2D-660 Upgrade lgtm config to build with Java 13

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,4 +1,4 @@
 extraction:
   java:
     index:
-      java_version: 12
+      java_version: 13


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Upgrade lgtm config to build with Java 13

The AB2D project is upgrading to Java 13, and as such the LGTM config needs to be reconfigured to use Java 13 instead of Java 12. This PR updates the lgtm config to build with Java 13.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
This helps maintain our current security posture by insuring LGTM is configured correctly so it can continue to build the project and perform SAST scans.
