### PR TITLE
lgtm config to fix java and maven build versions for jdk13

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,3 +2,8 @@ extraction:
   java:
     index:
       java_version: 13
+      maven:
+        version: 3.6.3
+      build_command:
+      - "java -version"
+      - "mvn -version"


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### LGTM config to fix java and maven build versions for jdk13

<!-- A more detailed multi line description of the pr. -->
LGTM config to fix java and maven build versions for jdk13. Our previous builds were failing due to what `appeared` to be a version mismatch on the LGTM service with JDK. It ended up being resolved by specifying the correct maven version that was working when building locally which at the time of this PR should be the latest `3.6.3`.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests and linting pass
- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
This improves the security posture by fixing a breaking build bug that was revealed during our JDK13 upgrade preventing automated SAST. Now SAST will be able to resume as part of the regular SDLC.

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->