### PR TITLE
ab2d 685 delete pre existing job directory

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -109,6 +109,8 @@ public class JobProcessorImpl implements JobProcessor {
                 log.warn("Directory already exists. Delete and create afresh ...");
                 deleteExistingDirectory(outputDirPath);
                 directory = fileService.createDirectory(outputDirPath);
+            } else {
+                throw e;
             }
         }
         return directory;

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/FileServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/FileServiceImpl.java
@@ -20,6 +20,10 @@ public class FileServiceImpl implements FileService {
     public Path createDirectory(Path outputDir) {
         Path outputDirectory = null;
         try {
+            if (Files.exists(outputDir)) {
+                throw new IOException("Directory already exists");
+            }
+
             outputDirectory = Files.createDirectories(outputDir);
         } catch (IOException e) {
             final String errMsg = "Could not create output directory : ";

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -277,7 +277,7 @@ class JobProcessorUnitTest {
 
         var errMsg = "Directory already exists";
         var uncheckedIOE = new UncheckedIOException(errMsg, new IOException(errMsg));
-        Mockito.lenient().when(fileService.createDirectory(any()))
+        Mockito.when(fileService.createDirectory(any()))
                 .thenThrow(uncheckedIOE)
                 .thenReturn(efsMountTmpDir);
 
@@ -307,10 +307,7 @@ class JobProcessorUnitTest {
         var errMsg = "Directory already exists";
         var uncheckedIOE = new UncheckedIOException(errMsg, new IOException(errMsg));
 
-        Mockito.lenient().when(fileService.createDirectory(any()))
-                .thenThrow(uncheckedIOE)
-                .thenReturn(efsMountTmpDir);
-
+        Mockito.when(fileService.createDirectory(any())).thenThrow(uncheckedIOE);
         Mockito.lenient().when(beneficiaryAdapter.getPatientsByContract(anyString())).thenReturn(patientsByContract);
 
         var processedJob = cut.process(jobUuid);

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
@@ -93,6 +93,18 @@ public class FileServiceIntegrationTest {
     }
 
     @Test
+    void testCreateDirectoryWhenDirectoryAlreadyExist_ThrowsException() throws IOException {
+        Files.deleteIfExists(tmpEfsMountDir.toPath());
+        final Path directory = cut.createDirectory(tmpEfsMountDir.toPath());
+        Assertions.assertTrue(directory.toFile().isDirectory());
+
+        var exceptionThrown = assertThrows(RuntimeException.class,
+                () -> cut.createDirectory(tmpEfsMountDir.toPath()));
+
+        assertThat(exceptionThrown.getMessage(), startsWith("Could not create output directory"));
+    }
+
+    @Test
     void testAppendToFile() throws IOException {
         Files.deleteIfExists(tmpEfsMountDir.toPath());
         cut.createDirectory(tmpEfsMountDir.toPath());


### PR DESCRIPTION
When a batch needs to be restarted after a failure, the output directory needs to be re-created afresh

### Summary

When a job is submitted, the batch process creates an output directory based on the job_uuid.
Inside this directory, it will create an ndjson file for each contract for the sponsor who submitted the job.
So normally the output directory would not exist prior to the start of the batch process.
However, when a batch is restarted after a failure, the output directory would already exist (from the failed run) and it needs to be deleted and re-created afresh


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A