### PR TITLE
Feature/correct git secrets readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ## Configure local repo with "git-secrets" protection
 
+*This must be done each time you clone a new copy of the repo*
+
 1. Install git-secrets (on MacOS with brew simply run: `brew install git-secrets`)
     - See the README.md for "git-secrets" for more info or to install on other platforms:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 ## Configure local repo with "git-secrets" protection
 
+1. Install git-secrets (on MacOS with brew simply run: `brew install git-secrets`)
+    - See the README.md for "git-secrets" for more info or to install on other platforms:
+
+       > https://github.com/awslabs/git-secrets
+
+
 1. Change to the repo directory
 
    *Format:*
@@ -32,7 +38,7 @@
 1. Install "git-secrets" for the repo
 
    ```ShellSession
-   $ git secrets --install
+   $ git-secrets --install
    ```
 
 1. Note the output
@@ -46,12 +52,8 @@
 1. Register AWS
 
    ```ShellSession
-   $ git secrets --register-aws
+   $ git-secrets --register-aws
    ```
-
-1. See the README.md for "git-secrets" for more info
-
-   > https://github.com/awslabs/git-secrets
 
 ## Running in Docker
 


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Corrects the typo installation instructions and adds more clarity over all

The current git-secrets instructions contain a typo that made it a bit confusing for developers who were unfamiliar with the tool. Each relevant instruction was simply missing the hyphen between the `git` and `secrets`. This commit simply fixes that typo, and adds some clarity around how to install the tool that was previously missing and moves the reference to the git-secrets README to the top for more information.
 
<!-- A more detailed multi line description of the pr. -->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?
This does not impact anything outside of this repo's README.md. It should improve our security posture by making the git-secrets instructions a bit easier to follow.

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->