### PR TITLE
AB2D 675 - retry failed bfd calls

### DIFF
--- a/bfd/pom.xml
+++ b/bfd/pom.xml
@@ -50,5 +50,11 @@
             <artifactId>mockserver-client-java</artifactId>
             <version>${mockserver.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -10,6 +10,8 @@ import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,6 +56,11 @@ public class BFDClientImpl implements BFDClient {
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
     @Override
+    @Retryable(
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100L, multiplier = 2),
+            exclude = { ResourceNotFoundException.class }
+    )
     public Bundle requestEOBFromServer(String patientID) {
         return
                 fetchBundle(ExplanationOfBenefit.class,
@@ -62,6 +69,11 @@ public class BFDClientImpl implements BFDClient {
 
 
     @Override
+    @Retryable(
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100L, multiplier = 2),
+            exclude = { ResourceNotFoundException.class }
+    )
     public Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException {
         return client
                 .loadPage()

--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -57,8 +57,8 @@ public class BFDClientImpl implements BFDClient {
      */
     @Override
     @Retryable(
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 100L, multiplier = 2),
+            maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",
+            backoff = @Backoff(delayExpression = "${bfd.retry.backoffDelay:250}", multiplier = 2),
             exclude = { ResourceNotFoundException.class }
     )
     public Bundle requestEOBFromServer(String patientID) {
@@ -70,8 +70,8 @@ public class BFDClientImpl implements BFDClient {
 
     @Override
     @Retryable(
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 100L, multiplier = 2),
+            maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",
+            backoff = @Backoff(delayExpression = "${bfd.retry.backoffDelay:250}", multiplier = 2),
             exclude = { ResourceNotFoundException.class }
     )
     public Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException {

--- a/bfd/src/main/resources/application.bfd.properties
+++ b/bfd/src/main/resources/application.bfd.properties
@@ -5,3 +5,7 @@ bfd.connectionTimeout=5000
 bfd.socketTimeout=5000
 bfd.requestTimeout=5000
 bfd.pagesize=100
+
+#--- retry
+bfd.retry.maxAttempts=3
+bfd.retry.backoffDelay=100

--- a/bfd/src/test/resources/application.bfd.properties
+++ b/bfd/src/test/resources/application.bfd.properties
@@ -5,3 +5,7 @@ bfd.connectionTimeout=5000
 bfd.socketTimeout=5000
 bfd.requestTimeout=5000
 bfd.pagesize=10
+
+#--- retry
+bfd.retry.maxAttempts=3
+bfd.retry.backoffDelay=100

--- a/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.retry.annotation.EnableRetry;
 
 
 @SpringBootApplication(scanBasePackages = {
@@ -19,6 +20,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 })
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model"})
 @EnableJpaRepositories("gov.cms.ab2d.common.repository")
+@EnableRetry
 @PropertySource("classpath:application.common.properties")
 @Import({OptOutQuartzSetup.class, StuckJobQuartzSetup.class})
 public class SpringBootApp {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -293,7 +293,7 @@ public class JobProcessorImpl implements JobProcessor {
                     throw new RuntimeException(errMsg, e);
                 } catch (ExecutionException e) {
                     final String errMsg = "exception while processing patient ";
-                    log.error(errMsg);
+                    log.error(errMsg, e);
                     throw new RuntimeException(errMsg, e.getCause());
                 } catch (CancellationException e) {
                     // This could happen in the rare event that a job was cancelled mid-process.


### PR DESCRIPTION
Retry failed bfd calls

### Summary

When worker makes a call to BFD, since it is a remote call, it could fail due to intermittent errors.
In these cases, a retry should be attempted for failed calls. The configuration for retry should be externalized in a property file. Spring-retry module was used to accomplish the retry


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A