### PR TITLE
ab2d 746 - do not throw exception when patient has no claims data

### DIFF
--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClient.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClient.java
@@ -1,16 +1,15 @@
 package gov.cms.ab2d.bfd.client;
 
 
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.hl7.fhir.dstu3.model.Bundle;
 
 
 public interface BFDClient {
 
 
-    Bundle requestEOBFromServer(String patientID) throws ResourceNotFoundException;
+    Bundle requestEOBFromServer(String patientID);
 
-    Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException;
+    Bundle requestNextBundleFromServer(Bundle bundle);
 
 
 }

--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -74,7 +74,7 @@ public class BFDClientImpl implements BFDClient {
             backoff = @Backoff(delayExpression = "${bfd.retry.backoffDelay:250}", multiplier = 2),
             exclude = { ResourceNotFoundException.class }
     )
-    public Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException {
+    public Bundle requestNextBundleFromServer(Bundle bundle) {
         return client
                 .loadPage()
                 .next(bundle)
@@ -92,20 +92,13 @@ public class BFDClientImpl implements BFDClient {
      */
     private <T extends IBaseResource> Bundle fetchBundle(Class<T> resourceClass,
                                                          ICriterion<ReferenceClientParam> criterion) {
-        final Bundle bundle = client.search()
+        return client.search()
                 .forResource(resourceClass)
                 .where(criterion)
                 .count(pageSize)
                 .returnBundle(Bundle.class)
                 .execute();
 
-        // Case where patientID does not have any records
-        if (!bundle.hasEntry()) {
-            String message = "Patient does not have any records";
-            log.error(message);
-            throw new ResourceNotFoundException(message);
-        }
-        return bundle;
     }
 
 }

--- a/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
+++ b/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
@@ -161,9 +161,8 @@ public class BlueButtonClientTest {
 
     @Test
     public void shouldGetEOBPatientNoRecords() {
-        thrown.expect(ResourceNotFoundException.class);
-        thrown.expectMessage("Patient does not have any records");
-        bbc.requestEOBFromServer(TEST_NO_RECORD_PATIENT_ID);
+        Bundle response = bbc.requestEOBFromServer(TEST_NO_RECORD_PATIENT_ID);
+        assertFalse(response.hasEntry());
     }
 
     @Test


### PR DESCRIPTION
Do not throw exception when patient has no claims data

### Summary

Do not throw exception when patient has no claims data. 


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A
