### PR TITLE
ab2d 667 shutdown cleanup reset jobs

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -34,5 +34,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     @Query("FROM Job j WHERE j.createdAt < :createdAt AND j.status = 'IN_PROGRESS' AND j.completedAt IS NULL ")
     List<Job> findStuckJobs(OffsetDateTime createdAt);
 
+    @Modifying
+    @Query("UPDATE Job j SET j.status = 'SUBMITTED' WHERE j.jobUuid IN :jobUuids ")
+    void resetJobsToSubmittedStatus(List<String> jobUuids);
 
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/WorkerConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/WorkerConfig.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.worker.config;
 
 import gov.cms.ab2d.bfd.client.BFDClientConfiguration;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -101,17 +100,16 @@ public class WorkerConfig {
 
     @Bean
     public LockRepository lockRepository() {
-        return new DefaultLockRepository(dataSource);
+        final DefaultLockRepository defaultLockRepository = new DefaultLockRepository(dataSource);
+        defaultLockRepository.setTimeToLive(60_000);        // 60 seconds
+        return defaultLockRepository;
     }
 
     /**
      * Using {@link JdbcLockRegistry} is critical to avoid race condition among workers competing for requests.
-     * Locks will auto-expire after one hour.
      */
     @Bean
     public LockRegistry lockRegistry(LockRepository lockRepository) {
-        final JdbcLockRegistry registry = new JdbcLockRegistry(lockRepository);
-        registry.expireUnusedOlderThan(DateUtils.MILLIS_PER_HOUR);
-        return registry;
+        return new JdbcLockRegistry(lockRepository);
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownService.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownService.java
@@ -1,0 +1,9 @@
+package gov.cms.ab2d.worker.service;
+
+import java.util.List;
+
+public interface ShutDownService {
+
+    void resetInProgressJobs(List<String> jobsInProgress);
+
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownServiceImpl.java
@@ -17,10 +17,10 @@ public class ShutDownServiceImpl implements ShutDownService {
 
     @Override
     @Transactional
-    public void resetInProgressJobs(List<String> jobsInProgress) {
-        log.info("Reset jobs : {} to SUBMITTED status", jobsInProgress);
+    public void resetInProgressJobs(List<String> activeJobs) {
+        log.info("Reset jobs : {} to SUBMITTED status", activeJobs);
         try {
-            jobRepository.resetJobsToSubmittedStatus(jobsInProgress);
+            jobRepository.resetJobsToSubmittedStatus(activeJobs);
         } catch (Exception e) {
             log.error("Error while doing house cleaning during shutdown ", e);
             // do nothing

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/ShutDownServiceImpl.java
@@ -1,0 +1,29 @@
+package gov.cms.ab2d.worker.service;
+
+import gov.cms.ab2d.common.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShutDownServiceImpl implements ShutDownService {
+
+    private final JobRepository jobRepository;
+
+    @Override
+    @Transactional
+    public void resetInProgressJobs(List<String> jobsInProgress) {
+        log.info("Reset jobs : {} to SUBMITTED status", jobsInProgress);
+        try {
+            jobRepository.resetJobsToSubmittedStatus(jobsInProgress);
+        } catch (Exception e) {
+            log.error("Error while doing house cleaning during shutdown ", e);
+            // do nothing
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
@@ -23,21 +23,23 @@ public class WorkerServiceImpl implements WorkerService {
     private final JobProcessor jobProcessor;
     private final ShutDownService shutDownService;
 
-    private static List<String> activeJobs = Collections.synchronizedList(new ArrayList<>());
+    private List<String> activeJobs = Collections.synchronizedList(new ArrayList<>());
 
 
     @Override
     public void process(String jobUuid) {
 
         activeJobs.add(jobUuid);
+        try {
+            jobPreprocessor.preprocess(jobUuid);
+            log.info("Job was put in progress");
 
-        jobPreprocessor.preprocess(jobUuid);
-        log.info("Job was put in progress");
+            jobProcessor.process(jobUuid);
+            log.info("Job was processed");
 
-        jobProcessor.process(jobUuid);
-        log.info("Job was processed");
-
-        activeJobs.remove(jobUuid);
+        } finally {
+            activeJobs.remove(jobUuid);
+        }
     }
 
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
@@ -6,6 +6,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * This class is responsible for actually processing the job and preparing bulk downloads for users.
  */
@@ -16,17 +21,37 @@ public class WorkerServiceImpl implements WorkerService {
 
     private final JobPreProcessor jobPreprocessor;
     private final JobProcessor jobProcessor;
+    private final ShutDownService shutDownService;
+
+    private static List<String> jobsInProgres = Collections.synchronizedList(new ArrayList<>());
 
 
     @Override
     public void process(String jobUuid) {
+
+        jobsInProgres.add(jobUuid);
+
         jobPreprocessor.preprocess(jobUuid);
         log.info("Job was put in progress");
 
         jobProcessor.process(jobUuid);
         log.info("Job was processed");
+
+        jobsInProgres.remove(jobUuid);
     }
 
+
+
+    @PreDestroy
+    public void resetInProgressJobs() {
+        log.info("Shutdown in progress ... Do house cleaning ...");
+
+        if (!jobsInProgres.isEmpty()) {
+            shutDownService.resetInProgressJobs(jobsInProgres);
+        }
+
+        log.info("House cleaning done - Shutting down");
+    }
 
 
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
@@ -23,13 +23,13 @@ public class WorkerServiceImpl implements WorkerService {
     private final JobProcessor jobProcessor;
     private final ShutDownService shutDownService;
 
-    private static List<String> jobsInProgres = Collections.synchronizedList(new ArrayList<>());
+    private static List<String> activeJobs = Collections.synchronizedList(new ArrayList<>());
 
 
     @Override
     public void process(String jobUuid) {
 
-        jobsInProgres.add(jobUuid);
+        activeJobs.add(jobUuid);
 
         jobPreprocessor.preprocess(jobUuid);
         log.info("Job was put in progress");
@@ -37,7 +37,7 @@ public class WorkerServiceImpl implements WorkerService {
         jobProcessor.process(jobUuid);
         log.info("Job was processed");
 
-        jobsInProgres.remove(jobUuid);
+        activeJobs.remove(jobUuid);
     }
 
 
@@ -46,8 +46,8 @@ public class WorkerServiceImpl implements WorkerService {
     public void resetInProgressJobs() {
         log.info("Shutdown in progress ... Do house cleaning ...");
 
-        if (!jobsInProgres.isEmpty()) {
-            shutDownService.resetInProgressJobs(jobsInProgres);
+        if (!activeJobs.isEmpty()) {
+            shutDownService.resetInProgressJobs(activeJobs);
         }
 
         log.info("House cleaning done - Shutting down");


### PR DESCRIPTION
When a shutdown command is issued, worker needs to put active jobs into submitted status

### Summary

When a shutdown command is issued, worker needs to put active jobs into submitted status so that the job can be processed by another instance.


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A