### PR TITLE
Ab2d 742 improve swagger docs

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/config/SwaggerConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/config/SwaggerConfig.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.api.config;
 
 import com.fasterxml.classmate.TypeResolver;
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.JsonNode;
 import gov.cms.ab2d.api.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -43,7 +42,6 @@ public class SwaggerConfig {
                 .paths(PathSelectors.ant(API_PREFIX + FHIR_PREFIX + "/**"))
                 .build()
                 .directModelSubstitute(Resource.class, String.class)
-                .directModelSubstitute(JsonNode.class, Void.class)
                 .useDefaultResponseMessages(false)
                 .securitySchemes(auth)
                 .globalResponseMessage(RequestMethod.GET,

--- a/api/src/main/java/gov/cms/ab2d/api/config/SwaggerConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/config/SwaggerConfig.java
@@ -25,6 +25,7 @@ import java.util.*;
 
 import static gov.cms.ab2d.api.util.Constants.API_PREFIX;
 import static gov.cms.ab2d.api.util.Constants.FHIR_PREFIX;
+import static gov.cms.ab2d.api.util.SwaggerConstants.MAIN;
 
 @Configuration
 @EnableSwagger2
@@ -76,13 +77,12 @@ public class SwaggerConfig {
 
     private ApiInfo apiInfo() {
         return new ApiInfo(
-                "AB2D FHIR Bulk Data Access API",
-                "This API Provides Part A (Hospital Insurance) & B (Medical Insurance) claim data to Part " +
-                        "D (Prescription Drug Benefit) sponsors.",
-                "1.0",
-                null,
-                null,
-                null, null, Collections.emptyList());
+               "AB2D FHIR Bulk Data Access API",
+                MAIN,
+               "1.0",
+               null,
+               null,
+               null, null, Collections.emptyList());
     }
 
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
@@ -70,7 +70,7 @@ public class BulkDataAccessAPI {
     @Autowired
     private JobService jobService;
 
-    @ApiOperation(value =BULK_EXPORT,
+    @ApiOperation(value = BULK_EXPORT,
         authorizations = {
             @Authorization(value = "Authorization", scopes = {
                     @AuthorizationScope(description = "Export Patient Information", scope = "Authorization") })

--- a/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
@@ -1,7 +1,5 @@
 package gov.cms.ab2d.api.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import gov.cms.ab2d.api.config.SwaggerConfig;
 import gov.cms.ab2d.api.util.SwaggerConstants;
@@ -163,7 +161,7 @@ public class BulkDataAccessAPI {
     @GetMapping("/Group/{contractNumber}/$export")
     public ResponseEntity<Void> exportPatientsWithContract(@ApiParam(value = "A contract number", required = true)
             @PathVariable @NotBlank String contractNumber,
-            @ApiParam(value = BULK_EXPORT_TYPE, allowableValues = EOB)
+            @ApiParam(value = BULK_EXPORT_TYPE, allowableValues = EOB, defaultValue = EOB)
             @RequestParam(required = false, name = "_type") String resourceTypes,
             @ApiParam(value = BULK_OUTPUT_FORMAT,
                     allowableValues = ALLOWABLE_OUTPUT_FORMATS, defaultValue = "application/fhir" +
@@ -238,7 +236,7 @@ public class BulkDataAccessAPI {
     )
     @GetMapping(value = "/Job/{jobUuid}/$status")
     @ResponseStatus(value = HttpStatus.OK)
-    public ResponseEntity<JsonNode> getJobStatus(
+    public ResponseEntity<JobCompletedResponse> getJobStatus(
             @ApiParam(value = "A job identifier", required = true) @PathVariable @NotBlank String jobUuid) {
         MDC.put(JOB_LOG, jobUuid);
         log.info("Request submitted to get job status");
@@ -272,7 +270,7 @@ public class BulkDataAccessAPI {
 
                 log.info("Job status completed successfully");
 
-                return new ResponseEntity<>(new ObjectMapper().valueToTree(resp), responseHeaders, HttpStatus.OK);
+                return new ResponseEntity<>(resp, responseHeaders, HttpStatus.OK);
             case SUBMITTED:
             case IN_PROGRESS:
                 responseHeaders.add("X-Progress", job.getProgress() + "% complete");
@@ -302,7 +300,7 @@ public class BulkDataAccessAPI {
             })
     @ApiImplicitParams(value = {
             @ApiImplicitParam(name = "Accept", required = false, paramType = "header", value =
-                    "application/fhir+json")}
+                    "application/fhir+json", defaultValue = "application/fhir+json")}
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Returns the requested file as " +

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import static gov.cms.ab2d.api.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.api.util.Constants.ADMIN_PREFIX;
 import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
-import static gov.cms.ab2d.api.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static gov.cms.ab2d.api.util.Constants.API_PREFIX;
 
 

--- a/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
+++ b/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
@@ -14,8 +14,6 @@ public final class Constants {
 
     public static final String ADMIN_PREFIX = "/admin";
 
-    public static final String SPONSOR_ROLE = "SPONSOR";
-
     public static final String ADMIN_ROLE = "ADMIN";
 
     public static final String BASE_SANDBOX_URL = "https://sandbox.ab2d.cms.gov";

--- a/api/src/main/java/gov/cms/ab2d/api/util/SwaggerConstants.java
+++ b/api/src/main/java/gov/cms/ab2d/api/util/SwaggerConstants.java
@@ -1,0 +1,30 @@
+package gov.cms.ab2d.api.util;
+
+public final class SwaggerConstants {
+    public static final String MAIN="This API Provides Part A (Hospital Insurance) & B " +
+            "(Medical Insurance) claim data to Part D (Prescription Drug Benefit) sponsors. Consistent with " +
+            "CMS' Final Rule to implement Section 50354 of the Bipartisan Budget Act of 2018, CMS is providing " +
+            "standalone Medicare Part D plan (PDP) sponsors the opportunity to request access to Medicare claims data. " +
+            "Access to Medicare claims data for their enrollees will help plans promote the appropriate use of " +
+            "medications and improve health outcomes, among other benefits.";
+
+    // Bulk Export API
+    public static final String BULK_MAIN ="API through which an authenticated and authorized " +
+            "PDP sponsor may request a bulk-data export from a server, receive status information regarding " +
+            "progress in the generation of the requested files, and retrieve these files.";
+
+    public static final String BULK_EXPORT_TYPE = "String of comma-delimited FHIR resource objects. Only resources of " +
+            "the specified resource types(s) SHALL be included in the response. Currently, only" +
+            "ExplanationOfBenefit objects are supported";
+
+    public static final String BULK_PREFER ="Value must be respond-async";
+
+    public static final String BULK_ACCEPT ="Value must be application/fhir+json";
+
+    public static final String BULK_OUTPUT_FORMAT ="The format for the " +
+            "requested bulk data files to be generated. Currently, only application/fhir+json is supported.";
+
+    public static final String BULK_CONTRACT_EXPORT ="Initiate Part A & B bulk claim export job for a given contract number";
+    public static final String BULK_CANCEL ="Cancel a pending or in progress export job";
+    public static final String BULK_EXPORT="Initiate Part A & B bulk claim export job";
+}

--- a/api/src/main/java/gov/cms/ab2d/api/util/SwaggerConstants.java
+++ b/api/src/main/java/gov/cms/ab2d/api/util/SwaggerConstants.java
@@ -1,7 +1,7 @@
 package gov.cms.ab2d.api.util;
 
 public final class SwaggerConstants {
-    public static final String MAIN="This API Provides Part A (Hospital Insurance) & B " +
+    public static final String MAIN = "This API Provides Part A (Hospital Insurance) & B " +
             "(Medical Insurance) claim data to Part D (Prescription Drug Benefit) sponsors. Consistent with " +
             "CMS' Final Rule to implement Section 50354 of the Bipartisan Budget Act of 2018, CMS is providing " +
             "standalone Medicare Part D plan (PDP) sponsors the opportunity to request access to Medicare claims data. " +
@@ -9,7 +9,7 @@ public final class SwaggerConstants {
             "medications and improve health outcomes, among other benefits.";
 
     // Bulk Export API
-    public static final String BULK_MAIN ="API through which an authenticated and authorized " +
+    public static final String BULK_MAIN = "API through which an authenticated and authorized " +
             "PDP sponsor may request a bulk-data export from a server, receive status information regarding " +
             "progress in the generation of the requested files, and retrieve these files.";
 
@@ -17,14 +17,14 @@ public final class SwaggerConstants {
             "the specified resource types(s) SHALL be included in the response. Currently, only" +
             "ExplanationOfBenefit objects are supported";
 
-    public static final String BULK_PREFER ="Value must be respond-async";
+    public static final String BULK_PREFER = "Value must be respond-async";
 
-    public static final String BULK_ACCEPT ="Value must be application/fhir+json";
+    public static final String BULK_ACCEPT = "Value must be application/fhir+json";
 
-    public static final String BULK_OUTPUT_FORMAT ="The format for the " +
+    public static final String BULK_OUTPUT_FORMAT = "The format for the " +
             "requested bulk data files to be generated. Currently, only application/fhir+json is supported.";
 
-    public static final String BULK_CONTRACT_EXPORT ="Initiate Part A & B bulk claim export job for a given contract number";
-    public static final String BULK_CANCEL ="Cancel a pending or in progress export job";
-    public static final String BULK_EXPORT="Initiate Part A & B bulk claim export job";
+    public static final String BULK_CONTRACT_EXPORT = "Initiate Part A & B bulk claim export job for a given contract number";
+    public static final String BULK_CANCEL = "Cancel a pending or in progress export job";
+    public static final String BULK_EXPORT = "Initiate Part A & B bulk claim export job";
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
@@ -28,6 +28,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 
 import static gov.cms.ab2d.api.util.Constants.*;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 
 import static gov.cms.ab2d.api.util.Constants.*;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -120,7 +120,7 @@ public class BulkDataAccessAPIIntegrationTests {
         Assert.assertEquals(job.getProgress(), Integer.valueOf(0));
         Assert.assertEquals(job.getRequestUrl(),
                 "http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH);
-        Assert.assertEquals(job.getResourceTypes(), null);
+        Assert.assertEquals(job.getResourceTypes(), EOB);
         Assert.assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
     }
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -44,8 +44,7 @@ import java.util.Optional;
 
 import static gov.cms.ab2d.api.util.Constants.*;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
-import static gov.cms.ab2d.common.util.Constants.OPERATION_OUTCOME;
+import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -199,7 +198,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testPatientExportWithParameters() throws Exception {
         final String typeParams =
-                "?_type=ExplanationOfBenefits&_outputFormat=application/fhir+ndjson&since=20191015";
+                "?_type=ExplanationOfBenefit&_outputFormat=application/fhir+ndjson&since=20191015";
         ResultActions resultActions =
                 this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/" + PATIENT_EXPORT_PATH + typeParams)
                         .header("Authorization", "Bearer " + token)
@@ -217,13 +216,13 @@ public class BulkDataAccessAPIIntegrationTests {
         Assert.assertEquals(job.getProgress(), Integer.valueOf(0));
         Assert.assertEquals(job.getRequestUrl(),
                 "http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + typeParams);
-        Assert.assertEquals(job.getResourceTypes(), "ExplanationOfBenefits");
+        Assert.assertEquals(job.getResourceTypes(), EOB);
         Assert.assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
     }
 
     @Test
     public void testPatientExportWithInvalidType() throws Exception {
-        final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefits";
+        final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefit";
         this.mockMvc.perform(get(API_PREFIX +  FHIR_PREFIX + "/" + PATIENT_EXPORT_PATH + typeParams)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -232,7 +231,7 @@ public class BulkDataAccessAPIIntegrationTests {
                 .andExpect(jsonPath("$.issue[0].severity", Is.is("error")))
                 .andExpect(jsonPath("$.issue[0].code", Is.is("invalid")))
                 .andExpect(jsonPath("$.issue[0].details.text",
-                        Is.is("InvalidUserInputException: _type must be ExplanationOfBenefits")));
+                        Is.is("InvalidUserInputException: _type must be ExplanationOfBenefit")));
     }
 
     @Test
@@ -383,7 +382,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testGetStatusWhileFinished() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .header("Authorization", "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -398,7 +397,7 @@ public class BulkDataAccessAPIIntegrationTests {
         job.setCompletedAt(now);
 
         JobOutput jobOutput = new JobOutput();
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setJob(job);
         jobOutput.setFilePath("file.ndjson");
         job.getJobOutputs().add(jobOutput);
@@ -423,7 +422,7 @@ public class BulkDataAccessAPIIntegrationTests {
                         Is.is(new DateTimeType(now.toString()).toHumanDisplay())))
                 .andExpect(jsonPath("$.request", Is.is(job.getRequestUrl())))
                 .andExpect(jsonPath("$.requiresAccessToken", Is.is(true)))
-                .andExpect(jsonPath("$.output[0].type", Is.is("ExplanationOfBenefits")))
+                .andExpect(jsonPath("$.output[0].type", Is.is(EOB)))
                 .andExpect(jsonPath("$.output[0].url",
                         Is.is("http://localhost" + API_PREFIX + FHIR_PREFIX + "/Job/" + job.getJobUuid() +
                                 "/file/file.ndjson")))
@@ -436,7 +435,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testGetStatusWhileFailed() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -461,7 +460,7 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testGetStatusWithJobNotFound() throws Exception {
-        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -486,7 +485,7 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testGetStatusWithSpaceUrl() throws Exception {
-        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .header("Authorization", "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -511,7 +510,7 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testGetStatusWithBadUrl() throws Exception {
-        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -533,7 +532,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testDownloadFile() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -548,7 +547,7 @@ public class BulkDataAccessAPIIntegrationTests {
         job.setCompletedAt(now);
 
         JobOutput jobOutput = new JobOutput();
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setJob(job);
         jobOutput.setFilePath("test.ndjson");
         job.getJobOutputs().add(jobOutput);
@@ -591,7 +590,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testDownloadMissingFile() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -606,7 +605,7 @@ public class BulkDataAccessAPIIntegrationTests {
         job.setCompletedAt(now);
 
         JobOutput jobOutput = new JobOutput();
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setJob(job);
         jobOutput.setFilePath("testmissing.ndjson");
         job.getJobOutputs().add(jobOutput);
@@ -634,7 +633,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @Test
     public void testDownloadBadParameterFile() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefits")
+                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
@@ -649,7 +648,7 @@ public class BulkDataAccessAPIIntegrationTests {
         job.setCompletedAt(now);
 
         JobOutput jobOutput = new JobOutput();
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setJob(job);
         jobOutput.setFilePath("test.ndjson");
         job.getJobOutputs().add(jobOutput);
@@ -702,7 +701,7 @@ public class BulkDataAccessAPIIntegrationTests {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         final String typeParams =
-                "?_type=ExplanationOfBenefits&_outputFormat=application/fhir+ndjson&since=20191015";
+                "?_type=ExplanationOfBenefit&_outputFormat=application/fhir+ndjson&since=20191015";
         ResultActions resultActions =
                 this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams)
                         .header("Authorization", "Bearer " + token)
@@ -720,7 +719,7 @@ public class BulkDataAccessAPIIntegrationTests {
         Assert.assertEquals(job.getProgress(), Integer.valueOf(0));
         Assert.assertEquals(job.getRequestUrl(),
                 "http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams);
-        Assert.assertEquals(job.getResourceTypes(), "ExplanationOfBenefits");
+        Assert.assertEquals(job.getResourceTypes(), EOB);
         Assert.assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
     }
 
@@ -728,7 +727,7 @@ public class BulkDataAccessAPIIntegrationTests {
     public void testPatientExportWithInvalidTypeWithContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
-        final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefits";
+        final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefit";
         this.mockMvc.perform(get(API_PREFIX +  FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -737,7 +736,7 @@ public class BulkDataAccessAPIIntegrationTests {
                 .andExpect(jsonPath("$.issue[0].severity", Is.is("error")))
                 .andExpect(jsonPath("$.issue[0].code", Is.is("invalid")))
                 .andExpect(jsonPath("$.issue[0].details.text",
-                        Is.is("InvalidUserInputException: _type must be ExplanationOfBenefits")));
+                        Is.is("InvalidUserInputException: _type must be ExplanationOfBenefit")));
     }
 
     @Test

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import static gov.cms.ab2d.api.util.Constants.*;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 
 import static gov.cms.ab2d.api.util.Constants.*;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static gov.cms.ab2d.api.util.Constants.*;
+import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/common/src/main/java/gov/cms/ab2d/common/model/Job.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Job.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static gov.cms.ab2d.common.util.Constants.EOB;
 import static javax.persistence.EnumType.STRING;
 
 @Entity
@@ -58,8 +59,8 @@ public class Job {
     @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private OffsetDateTime expiresAt;
 
-    @Pattern(regexp = "ExplanationOfBenefits", message = "_type should be ExplanationOfBenefits")
-    private String resourceTypes; // for now just limited to ExplanationOfBenefits
+    @Pattern(regexp = EOB, message = "_type should be ExplanationOfBenefit")
+    private String resourceTypes; // for now just limited to ExplanationOfBenefit
 
     @ManyToOne
     @JoinColumn(name = "contract_id")

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -19,4 +19,6 @@ public final class Constants {
     public static final String SPONSOR_ROLE = "SPONSOR";
 
     public static final String ADMIN_ROLE = "ADMIN";
+
+    public static final String EOB = "ExplanationOfBenefit";
 }

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
+import static gov.cms.ab2d.common.util.Constants.EOB;
 import static gov.cms.ab2d.common.util.Constants.OPERATION_OUTCOME;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
@@ -94,13 +95,13 @@ public class JobServiceTest {
 
     @Test
     public void createJob() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
         assertThat(job).isNotNull();
         assertThat(job.getId()).isNotNull();
         assertThat(job.getJobUuid()).isNotNull();
         assertEquals(job.getProgress(), Integer.valueOf(0));
         assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
-        assertEquals(job.getResourceTypes(), "ExplanationOfBenefits");
+        assertEquals(job.getResourceTypes(), EOB);
         assertEquals(job.getRequestUrl(), "http://localhost:8080");
         assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
         assertEquals(job.getStatus(), JobStatus.SUBMITTED);
@@ -118,13 +119,13 @@ public class JobServiceTest {
     public void createJobWithContract() {
         Contract contract = contractRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
 
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080", contract.getContractNumber());
+        Job job = jobService.createJob(EOB, "http://localhost:8080", contract.getContractNumber());
         assertThat(job).isNotNull();
         assertThat(job.getId()).isNotNull();
         assertThat(job.getJobUuid()).isNotNull();
         assertEquals(job.getProgress(), Integer.valueOf(0));
         assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
-        assertEquals(job.getResourceTypes(), "ExplanationOfBenefits");
+        assertEquals(job.getResourceTypes(), EOB);
         assertEquals(job.getRequestUrl(), "http://localhost:8080");
         assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
         assertEquals(job.getStatus(), JobStatus.SUBMITTED);
@@ -142,20 +143,20 @@ public class JobServiceTest {
     @Test
     public void createJobWithBadContract() {
         Assertions.assertThrows(ResourceNotFoundException.class, () -> {
-            jobService.createJob("ExplanationOfBenefits", "http://localhost:8080", "BadContract");
+            jobService.createJob(EOB, "http://localhost:8080", "BadContract");
         });
     }
 
     @Test
     public void failedValidation() {
         Assertions.assertThrows(TransactionSystemException.class, () -> {
-            jobService.createJob("Patient,ExplanationOfBenefits,Coverage", "http://localhost:8080");
+            jobService.createJob("Patient,ExplanationOfBenefit,Coverage", "http://localhost:8080");
         });
     }
 
     @Test
     public void cancelJob() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
 
         jobService.cancelJob(job.getJobUuid());
 
@@ -174,7 +175,7 @@ public class JobServiceTest {
 
     @Test
     public void getJob() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
 
         Job retrievedJob = jobService.getJobByJobUuid(job.getJobUuid());
 
@@ -190,7 +191,7 @@ public class JobServiceTest {
 
     @Test
     public void testJobInSuccessfulState() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
 
         job.setStatus(JobStatus.SUCCESSFUL);
         jobRepository.saveAndFlush(job);
@@ -202,7 +203,7 @@ public class JobServiceTest {
 
     @Test
     public void testJobInCancelledState() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
 
         job.setStatus(JobStatus.CANCELLED);
         jobRepository.saveAndFlush(job);
@@ -215,7 +216,7 @@ public class JobServiceTest {
 
     @Test
     public void testJobInFailedState() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
 
         job.setStatus(JobStatus.FAILED);
         jobRepository.saveAndFlush(job);
@@ -228,7 +229,7 @@ public class JobServiceTest {
 
     @Test
     public void updateJob() {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime localDateTime = OffsetDateTime.now();
         job.setProgress(100);
@@ -237,14 +238,14 @@ public class JobServiceTest {
         job.setCreatedAt(localDateTime);
         job.setCompletedAt(localDateTime);
         job.setJobUuid("abc");
-        job.setResourceTypes("ExplanationOfBenefits");
+        job.setResourceTypes(EOB);
         job.setRequestUrl("http://localhost");
         job.setStatusMessage("Pending");
         job.setExpiresAt(now);
 
         JobOutput jobOutput = new JobOutput();
         jobOutput.setError(false);
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setFilePath("file.ndjson");
         jobOutput.setJob(job);
 
@@ -264,14 +265,14 @@ public class JobServiceTest {
         Assert.assertEquals(localDateTime, updatedJob.getCreatedAt());
         Assert.assertEquals(localDateTime, updatedJob.getCompletedAt());
         Assert.assertEquals("abc", updatedJob.getJobUuid());
-        Assert.assertEquals("ExplanationOfBenefits", updatedJob.getResourceTypes());
+        Assert.assertEquals(EOB, updatedJob.getResourceTypes());
         Assert.assertEquals("http://localhost", updatedJob.getRequestUrl());
         Assert.assertEquals("Pending", updatedJob.getStatusMessage());
         Assert.assertEquals(now, updatedJob.getExpiresAt());
 
         JobOutput updatedOutput = updatedJob.getJobOutputs().get(0);
         Assert.assertEquals(false, updatedOutput.isError());
-        Assert.assertEquals("ExplanationOfBenefits", updatedOutput.getFhirResourceType());
+        Assert.assertEquals(EOB, updatedOutput.getFhirResourceType());
         Assert.assertEquals("file.ndjson", updatedOutput.getFilePath());
 
         JobOutput updatedErrorOutput = updatedJob.getJobOutputs().get(1);
@@ -309,7 +310,7 @@ public class JobServiceTest {
     }
 
     private Job createJobForFileDownloads(String fileName, String errorFileName) {
-        Job job = jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        Job job = jobService.createJob(EOB, "http://localhost:8080");
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime localDateTime = OffsetDateTime.now();
         job.setProgress(100);
@@ -317,14 +318,14 @@ public class JobServiceTest {
         job.setStatus(JobStatus.IN_PROGRESS);
         job.setCreatedAt(localDateTime);
         job.setCompletedAt(localDateTime);
-        job.setResourceTypes("ExplanationOfBenefits");
+        job.setResourceTypes(EOB);
         job.setRequestUrl("http://localhost");
         job.setStatusMessage("Pending");
         job.setExpiresAt(now);
 
         JobOutput jobOutput = new JobOutput();
         jobOutput.setError(false);
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setFilePath(fileName);
         jobOutput.setJob(job);
 
@@ -371,7 +372,7 @@ public class JobServiceTest {
 
     @Test
     public void checkIfUserHasActiveJobTrueTest() {
-        jobService.createJob("ExplanationOfBenefits", "http://localhost:8080");
+        jobService.createJob(EOB, "http://localhost:8080");
 
         boolean result = jobService.checkIfCurrentUserHasActiveJob();
         Assert.assertTrue(result);
@@ -386,7 +387,7 @@ public class JobServiceTest {
 
     @Test
     public void checkIfUserHasActiveJobWithContractTest() {
-        jobService.createJob("ExplanationOfBenefits", "http://localhost:8080", VALID_CONTRACT_NUMBER);
+        jobService.createJob(EOB, "http://localhost:8080", VALID_CONTRACT_NUMBER);
 
         boolean result = jobService.checkIfCurrentUserHasActiveJobForContractNumber(VALID_CONTRACT_NUMBER);
         Assert.assertTrue(result);

--- a/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmer.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmer.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
  * Cleans out data from a copy of an ExplanationOfBenefit object that we don't want
  * to forward to Part D providers
  */
-public class ExplanationOfBenefitsTrimmer {
+public class ExplanationOfBenefitTrimmer {
 
     /**
      * Pass in an ExplanationOfBenefit, return the copy without the data
@@ -82,7 +82,7 @@ public class ExplanationOfBenefitsTrimmer {
         benefit.setHospitalization(null);
         if (benefit.getItem() != null) {
             benefit.setItem(benefit.getItem().stream()
-                    .map(ExplanationOfBenefitsTrimmer::cleanOutItemComponent)
+                    .map(ExplanationOfBenefitTrimmer::cleanOutItemComponent)
                     .collect(Collectors.toList()));
         }
         clearOutList(benefit.getAddItem());

--- a/filter/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
@@ -20,8 +20,8 @@ class EOBLoadUtilitiesTest {
     static FhirContext context = FhirContext.forDstu3();
 
     static {
-        eobCarrier = ExplanationOfBenefitsTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context));
-        eobSNF = ExplanationOfBenefitsTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-SNF-Claims.json", context));
+        eobCarrier = ExplanationOfBenefitTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context));
+        eobSNF = ExplanationOfBenefitTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-SNF-Claims.json", context));
     }
 
     @Test
@@ -177,7 +177,7 @@ class EOBLoadUtilitiesTest {
     void testToJson() {
         var jsonParser = context.newJsonParser();
         ExplanationOfBenefit eob = EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context);
-        ExplanationOfBenefit eobNew = ExplanationOfBenefitsTrimmer.getBenefit(eob);
+        ExplanationOfBenefit eobNew = ExplanationOfBenefitTrimmer.getBenefit(eob);
         String payload = jsonParser.encodeResourceToString(eobNew) + System.lineSeparator();
         assertNotNull(payload);
         System.out.println(payload);

--- a/filter/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerTest.java
@@ -11,29 +11,29 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ExplanationOfBenefitsTrimmerTest {
+class ExplanationOfBenefitTrimmerTest {
     private static ExplanationOfBenefit eobCarrier = null;
     private static FhirContext context = FhirContext.forDstu3();
 
     static {
-        eobCarrier = ExplanationOfBenefitsTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context));
+        eobCarrier = ExplanationOfBenefitTrimmer.getBenefit(EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context));
     }
 
     @Test
     public void testEmptyList() {
-        ExplanationOfBenefitsTrimmer.clearOutList(null);
+        ExplanationOfBenefitTrimmer.clearOutList(null);
         List<Integer> list = new ArrayList<>();
-        ExplanationOfBenefitsTrimmer.clearOutList(list);
+        ExplanationOfBenefitTrimmer.clearOutList(list);
         assertTrue(list.isEmpty());
         list.add(5);
         assertFalse(list.isEmpty());
-        ExplanationOfBenefitsTrimmer.clearOutList(list);
+        ExplanationOfBenefitTrimmer.clearOutList(list);
         assertTrue(list.isEmpty());
     }
 
     @Test
     public void validateEmpty() {
-        assertNull(ExplanationOfBenefitsTrimmer.getBenefit(null));
+        assertNull(ExplanationOfBenefitTrimmer.getBenefit(null));
         // Since getting a patient target creates a new one, make sure the object is empty
         assertTrue(eobCarrier.getPatientTarget().getIdentifier().isEmpty());
         assertNull(eobCarrier.getPatientTarget().getId());
@@ -113,7 +113,7 @@ class ExplanationOfBenefitsTrimmerTest {
     private void printItOut(String file) {
         IParser jsonParser = context.newJsonParser().setPrettyPrint(true);
 
-        ExplanationOfBenefit eCarrier = ExplanationOfBenefitsTrimmer.getBenefit(
+        ExplanationOfBenefit eCarrier = ExplanationOfBenefitTrimmer.getBenefit(
                 EOBLoadUtilities.getEOBFromFileInClassPath(file, context));
 
         String result = jsonParser.encodeResourceToString(eCarrier);
@@ -127,7 +127,7 @@ class ExplanationOfBenefitsTrimmerTest {
 
     @Test
     void isPartD() {
-        ExplanationOfBenefit ePartD = ExplanationOfBenefitsTrimmer.getBenefit(
+        ExplanationOfBenefit ePartD = ExplanationOfBenefitTrimmer.getBenefit(
                 EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Part-D-Claims.json", context));
         assertTrue(EOBLoadUtilities.isPartD(ePartD));
         assertFalse(EOBLoadUtilities.isPartD(eobCarrier));

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorImpl.java
@@ -3,7 +3,7 @@ package gov.cms.ab2d.worker.adapter.bluebutton;
 import ca.uhn.fhir.context.FhirContext;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.util.FHIRUtil;
-import gov.cms.ab2d.filter.ExplanationOfBenefitsTrimmer;
+import gov.cms.ab2d.filter.ExplanationOfBenefitTrimmer;
 import gov.cms.ab2d.worker.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -163,7 +163,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
                 // Get only the explanation of benefits
                 .filter(resource -> resource.getResourceType() == ResourceType.ExplanationOfBenefit)
                 // filter it
-                .map(resource -> ExplanationOfBenefitsTrimmer.getBenefit((ExplanationOfBenefit) resource))
+                .map(resource -> ExplanationOfBenefitTrimmer.getBenefit((ExplanationOfBenefit) resource))
                 // Remove any empty values
                 .filter(Objects::nonNull)
                 // Remove Plan D

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -39,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import static gov.cms.ab2d.common.model.JobStatus.CANCELLED;
 import static gov.cms.ab2d.common.model.JobStatus.SUCCESSFUL;
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
+import static gov.cms.ab2d.common.util.Constants.EOB;
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 @Slf4j
@@ -312,7 +313,7 @@ public class JobProcessorImpl implements JobProcessor {
     private JobOutput createJobOutput(Path outputFile, boolean isError) {
         JobOutput jobOutput = new JobOutput();
         jobOutput.setFilePath(outputFile.getFileName().toString());
-        jobOutput.setFhirResourceType("ExplanationOfBenefits");
+        jobOutput.setFhirResourceType(EOB);
         jobOutput.setError(isError);
         return jobOutput;
     }

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorUnitTest.java
@@ -4,13 +4,12 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import gov.cms.ab2d.bfd.client.BFDClient;
-import gov.cms.ab2d.filter.ExplanationOfBenefitsTrimmer;
+import gov.cms.ab2d.filter.ExplanationOfBenefitTrimmer;
 import gov.cms.ab2d.worker.service.FileService;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.Resource;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -136,7 +134,7 @@ public class PatientClaimsProcessorUnitTest {
         final EncodingEnum respType = EncodingEnum.forContentType(EncodingEnum.JSON_PLAIN_STRING);
         final IParser parser = respType.newParser(FhirContext.forDstu3());
         final ExplanationOfBenefit explanationOfBenefit = parser.parseResource(ExplanationOfBenefit.class, inputStream);
-        eob = ExplanationOfBenefitsTrimmer.getBenefit(explanationOfBenefit);
+        eob = ExplanationOfBenefitTrimmer.getBenefit(explanationOfBenefit);
     }
 
     private void createOutputFiles() throws IOException {

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import static gov.cms.ab2d.common.model.JobStatus.SUCCESSFUL;
+import static gov.cms.ab2d.common.util.Constants.EOB;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -72,15 +73,13 @@ public class WorkerServiceTest {
         checkResult(processedJob2);
     }
 
-
-
     private Job createJob(final User user) {
         Job job = new Job();
         job.setId((long) getIntRandom());
         job.setJobUuid(UUID.randomUUID().toString());
         job.setStatus(JobStatus.SUBMITTED);
         job.setStatusMessage("0%");
-        job.setResourceTypes("ExplanationOfBenefits");
+        job.setResourceTypes(EOB);
         job.setCreatedAt(OffsetDateTime.now());
         job.setUser(user);
         return jobRepository.save(job);


### PR DESCRIPTION
### Summary

Cleaned up the Swagger documentation 

- Added constants for reused values and to remove the 
bulk of the text out of the file. 
- Created defaults for situations where only one value is allowed
- Expanded on some of the text
- Changed ExplanationOfBenefits to ExplanationOfBenefit since that is the name of the object throughout the system and made it a variable to prevent typos.
- Because there was a static variable with the same value SPONSOR in common, used that one instead of the one in api.

### Security
No security implications
