### PR TITLE
AB2D 832 - Handle efs.mount path without trailing slash

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -555,8 +555,8 @@ public class BulkDataAccessAPIIntegrationTests {
         jobRepository.saveAndFlush(job);
 
         String testFile = "test.ndjson";
-        String destinationStr = tmpJobLocation + job.getJobUuid();
-        Path destination = Paths.get(destinationStr);
+        Path destination = Paths.get(tmpJobLocation, job.getJobUuid());
+        String destinationStr = destination.toString();
         Files.createDirectories(destination);
         InputStream testFileStream = this.getClass().getResourceAsStream("/" + testFile);
         String testFileStr = IOUtils.toString(testFileStream, "UTF-8");

--- a/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
+++ b/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
@@ -1,15 +1,11 @@
 package gov.cms.ab2d.audit.cleanup;
 
 import gov.cms.ab2d.audit.SpringBootApp;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.FileSystemUtils;
 
@@ -27,16 +23,16 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
 public class FileDeletionServiceTest {
 
-    @Rule
-    public TemporaryFolder tmpDirFolder = new TemporaryFolder();
+    @TempDir
+    File tmpDirFolder;
 
     @Autowired
     private FileDeletionService fileDeletionService;
@@ -64,7 +60,7 @@ public class FileDeletionServiceTest {
 
     @Test
     public void checkToEnsureFilesDeleted() throws IOException, URISyntaxException {
-        String efsMount = tmpDirFolder.getRoot().toString();
+        String efsMount = tmpDirFolder.toPath().toString();
 
         // other tests set this value, so set it to the correct one, JUnit ordering annotations don't seem to be respected
         ReflectionTestUtils.setField(fileDeletionService, "efsMount", efsMount);
@@ -115,15 +111,15 @@ public class FileDeletionServiceTest {
 
         fileDeletionService.deleteFiles();
 
-        Assert.assertTrue(Files.notExists(destination));
+        assertTrue(Files.notExists(destination));
 
-        Assert.assertTrue(Files.notExists(nestedFileDestination));
+        assertTrue(Files.notExists(nestedFileDestination));
 
-        Assert.assertTrue(Files.exists(destinationNotDeleted));
+        assertTrue(Files.exists(destinationNotDeleted));
 
-        Assert.assertTrue(Files.exists(noPermissionsFileDestination));
+        assertTrue(Files.exists(noPermissionsFileDestination));
 
-        Assert.assertTrue(Files.exists(regularFileDestination));
+        assertTrue(Files.exists(regularFileDestination));
 
         // Cleanup
         Files.delete(destinationNotDeleted);

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -130,7 +130,7 @@ public class JobServiceImpl implements JobService {
             throw new ResourceNotFoundException("No Job Output with the file name " + fileName + " exists in our records");
         }
 
-        Path file = Paths.get(fileDownloadPath + job.getJobUuid() + File.separator +  fileName);
+        Path file = Paths.get(fileDownloadPath, job.getJobUuid(), fileName);
         Resource resource = new UrlResource(file.toUri());
 
         if (!resource.exists()) {

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -287,8 +287,8 @@ public class JobServiceTest {
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
 
-        String destinationStr = tmpJobLocation + job.getJobUuid();
-        Path destination = Paths.get(destinationStr);
+        Path destination = Paths.get(tmpJobLocation, job.getJobUuid());
+        String destinationStr = destination.toString();
         Files.createDirectories(destination);
 
         createNDJSONFile(testFile, destinationStr);


### PR DESCRIPTION
Fix code so that it is not sensitive to presence/absence of trailing slash in the efs.mount property

### Summary

Fix code so that it is not sensitive to presence/absence of trailing slash in the efs.mount property


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A