### PR TITLE
Feature/ab2d 855 on failure cleanup threads in queue

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/PatientClaimsProcessorImpl.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
@@ -38,8 +37,6 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 @Component
 @RequiredArgsConstructor
 public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
-
-    private static int stopBatchErrorCounter = 0;
 
     private final BFDClient bfdClient;
     private final FhirContext fhirContext;
@@ -61,14 +58,6 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
 
             var byteArrayOutputStream = new ByteArrayOutputStream();
             for (var resource : resources) {
-                ++stopBatchErrorCounter;
-                if (stopBatchErrorCounter % 7 == 0) {
-                    // simulate a random execption to see how the batch behaves.
-                    log.info("###############################################################################");
-                    log.info("STOP BATCH - Counter: [{}]", stopBatchErrorCounter);
-                    log.info("###############################################################################");
-                    throw new UncheckedIOException(new IOException("DOES BATCH STOP RIGHTAWAY?"));
-                }
                 ++resourceCount;
                 try {
                     final String payload = jsonParser.encodeResourceToString(resource) + System.lineSeparator();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -267,8 +267,6 @@ public class JobProcessorImpl implements JobProcessor {
                 }
 
                 errorCount += processHandles(futureHandles, progressTracker);
-
-                sleep();
             }
         }
 
@@ -357,21 +355,14 @@ public class JobProcessorImpl implements JobProcessor {
                     }
                     progressTracker.incrementProcessedCount();
                 } catch (InterruptedException e) {
+                    cancelFuturesInQueue(futureHandles);
                     final String errMsg = "interrupted exception while processing patient ";
                     log.error(errMsg);
                     throw new RuntimeException(errMsg, e);
+
                 } catch (ExecutionException e) {
-                    log.info("###############################################################################");
-                    log.info("AM HERE .... !!!!!   processHandles(List<Future<Integer>> futureHandles)  ==== ");
-                    log.info("###############################################################################");
-
-                    log.error("exception while processing patient ", e);
-
-                    log.info("###############################################################################");
-                    log.info("cancelFuturesInQueue() ....");
-                    log.info("###############################################################################");
-
                     cancelFuturesInQueue(futureHandles);
+                    log.error("exception while processing patient ", e);
 
                     final String errMsg;
                     if (e.getCause() != null) {
@@ -379,8 +370,8 @@ public class JobProcessorImpl implements JobProcessor {
                     } else {
                         errMsg = e.getMessage();
                     }
-
                     throw new RuntimeException(errMsg, e.getCause());
+
                 } catch (CancellationException e) {
                     // This could happen in the rare event that a job was cancelled mid-process.
                     // due to which the futures in the queue (that were not yet in progress) were cancelled.

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -53,7 +53,7 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 public class JobProcessorImpl implements JobProcessor {
     private static final String OUTPUT_FILE_SUFFIX = ".ndjson";
     private static final String ERROR_FILE_SUFFIX = "_error.ndjson";
-    private static final int SLEEP_DURATION = 1_000;                    // 1 second
+    private static final int SLEEP_DURATION = 250;
 
     @Value("${cancellation.check.frequency:10}")
     private int cancellationCheckFrequency;
@@ -267,6 +267,8 @@ public class JobProcessorImpl implements JobProcessor {
                 }
 
                 errorCount += processHandles(futureHandles, progressTracker);
+
+                sleep();
             }
         }
 
@@ -359,8 +361,25 @@ public class JobProcessorImpl implements JobProcessor {
                     log.error(errMsg);
                     throw new RuntimeException(errMsg, e);
                 } catch (ExecutionException e) {
-                    final String errMsg = "exception while processing patient ";
-                    log.error(errMsg, e);
+                    log.info("###############################################################################");
+                    log.info("AM HERE .... !!!!!   processHandles(List<Future<Integer>> futureHandles)  ==== ");
+                    log.info("###############################################################################");
+
+                    log.error("exception while processing patient ", e);
+
+                    log.info("###############################################################################");
+                    log.info("cancelFuturesInQueue() ....");
+                    log.info("###############################################################################");
+
+                    cancelFuturesInQueue(futureHandles);
+
+                    final String errMsg;
+                    if (e.getCause() != null) {
+                        errMsg = e.getCause().getMessage();
+                    } else {
+                        errMsg = e.getMessage();
+                    }
+
                     throw new RuntimeException(errMsg, e.getCause());
                 } catch (CancellationException e) {
                     // This could happen in the rare event that a job was cancelled mid-process.


### PR DESCRIPTION
on failure, cleanup threads in queue so that the job comes to a stop sooner

### Summary

When an exception is thrown in the PatientClaimsProcessorImpl resulting in the job ending in a FAILED status,  ensure that the threads in queue are cleaned up so that the job comes to a stop sooner


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A