### PR TITLE
Setting max concurrent jobs to 3

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>net.rakugakibox.spring.boot</groupId>
             <artifactId>logback-access-spring-boot-starter</artifactId>
-            <version>2.7.0</version>
+            <version>2.7.1</version>
         </dependency>
 
         <dependency>

--- a/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
@@ -99,11 +99,7 @@ public class BulkDataAccessAPI {
             @RequestParam(required = false, name = "_outputFormat") String outputFormat) {
         log.info("Received request to export");
 
-        if (jobService.checkIfCurrentUserHasActiveJob()) {
-            String errorMsg = "User already has an active or submitted job";
-            log.error(errorMsg);
-            throw new TooManyRequestsException(errorMsg);
-        }
+        checkIfCurrentUserCanAddJob();
 
         checkResourceTypesAndOutputFormat(resourceTypes, outputFormat);
 
@@ -112,6 +108,14 @@ public class BulkDataAccessAPI {
         logSuccessfulJobCreation(job);
 
         return returnStatusForJobCreation(job);
+    }
+
+    private void checkIfCurrentUserCanAddJob() {
+        if (!jobService.checkIfCurrentUserCanAddJob()) {
+            String errorMsg = "User already has enough active or submitted jobs for their limit";
+            log.error(errorMsg);
+            throw new TooManyRequestsException(errorMsg);
+        }
     }
 
     private void checkResourceTypesAndOutputFormat(String resourceTypes, String outputFormat) {
@@ -171,10 +175,7 @@ public class BulkDataAccessAPI {
         MDC.put(CONTRACT_LOG, contractNumber);
         log.info("Received request to export by contractNumber");
 
-        if (jobService.checkIfCurrentUserHasActiveJobForContractNumber(contractNumber)) {
-            log.error("User already has an active or submitted job for the contract number {}", contractNumber);
-            throw new TooManyRequestsException("User already has an active or submitted job for the contract number " + contractNumber);
-        }
+        checkIfCurrentUserCanAddJob();
 
         checkResourceTypesAndOutputFormat(resourceTypes, outputFormat);
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/BulkDataAccessAPI.java
@@ -112,7 +112,7 @@ public class BulkDataAccessAPI {
 
     private void checkIfCurrentUserCanAddJob() {
         if (!jobService.checkIfCurrentUserCanAddJob()) {
-            String errorMsg = "User already has enough active or submitted jobs for their limit";
+            String errorMsg = "You already have active export requests in progress. Please wait until they complete before submitting a new one.";
             log.error(errorMsg);
             throw new TooManyRequestsException(errorMsg);
         }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -90,6 +90,8 @@ public class BulkDataAccessAPIIntegrationTests {
 
     private static final String PATIENT_EXPORT_PATH = "/Patient/$export";
 
+    private static final int MAX_JOBS_PER_USER = 3;
+
     @BeforeEach
     public void setup() throws JwtVerificationException {
         contractRepository.deleteAll();
@@ -99,6 +101,15 @@ public class BulkDataAccessAPIIntegrationTests {
         sponsorRepository.deleteAll();
 
         token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+    }
+
+    private void createMaxJobs() throws Exception {
+        for(int i = 0; i < MAX_JOBS_PER_USER; i++) {
+            this.mockMvc.perform(
+                    get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", "Bearer " + token))
+                    .andExpect(status().is(202));
+        }
     }
 
     @Test
@@ -126,9 +137,7 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testPatientExportDuplicateSubmission() throws Exception {
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobs();
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
@@ -140,13 +149,13 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testPatientExportDuplicateSubmissionWithCancelledStatus() throws Exception {
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobs();
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
-        job.setStatus(JobStatus.CANCELLED);
-        jobRepository.saveAndFlush(job);
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for(Job job : jobs) {
+            job.setStatus(JobStatus.CANCELLED);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
@@ -156,13 +165,13 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testPatientExportDuplicateSubmissionWithInProgressStatus() throws Exception {
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobs();
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
-        job.setStatus(JobStatus.IN_PROGRESS);
-        jobRepository.saveAndFlush(job);
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for(Job job : jobs) {
+            job.setStatus(JobStatus.IN_PROGRESS);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
@@ -174,11 +183,9 @@ public class BulkDataAccessAPIIntegrationTests {
 
     @Test
     public void testPatientExportDuplicateSubmissionWithDifferentUser() throws Exception {
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobs();
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
         User user = new User();
         Sponsor sponsor = dataSetup.createSponsor("Parent Spons", 4441, "Child Spons", 1114);
         user.setSponsor(sponsor);
@@ -186,8 +193,11 @@ public class BulkDataAccessAPIIntegrationTests {
         user.setUsername("test");
         user.setEmail("test@test.com");
         userRepository.saveAndFlush(user);
-        job.setUser(user);
-        jobRepository.saveAndFlush(job);
+
+        for(Job job : jobs) {
+            job.setUser(user);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
@@ -770,16 +780,23 @@ public class BulkDataAccessAPIIntegrationTests {
                 .andExpect(jsonPath("$.issue[0].severity", Is.is("error")))
                 .andExpect(jsonPath("$.issue[0].code", Is.is("invalid")))
                 .andExpect(jsonPath("$.issue[0].details.text",
-                        Is.is("ResourceNotFoundException: Contract number badContract was not found")));
+                        Is.is("ResourceNotFoundException: Contract badContract was not found")));
+    }
+
+    private void createMaxJobsWithContract(Contract contract) throws Exception {
+        for(int i = 0; i < MAX_JOBS_PER_USER; i++) {
+            this.mockMvc.perform(
+                    get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", "Bearer " + token))
+                            .andExpect(status().is(202));
+        }
     }
 
     @Test
     public void testPatientExportWithContractDuplicateSubmission() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobsWithContract(contract);
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
@@ -793,13 +810,13 @@ public class BulkDataAccessAPIIntegrationTests {
     public void testPatientExportWithContractDuplicateSubmissionInProgress() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobsWithContract(contract);
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
-        job.setStatus(JobStatus.IN_PROGRESS);
-        jobRepository.saveAndFlush(job);
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for(Job job : jobs) {
+            job.setStatus(JobStatus.IN_PROGRESS);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
@@ -813,13 +830,17 @@ public class BulkDataAccessAPIIntegrationTests {
     public void testPatientExportWithContractDuplicateSubmissionCancelled() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
+        createMaxJobsWithContract(contract);
+
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token));
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
-        job.setStatus(JobStatus.CANCELLED);
-        jobRepository.saveAndFlush(job);
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for(Job job : jobs) {
+            job.setStatus(JobStatus.CANCELLED);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
@@ -831,9 +852,13 @@ public class BulkDataAccessAPIIntegrationTests {
     public void testPatientExportWithContractDuplicateSubmissionDifferentContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+
+        for(int i = 0; i < MAX_JOBS_PER_USER - 1; i++) {
+            this.mockMvc.perform(
+                    get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", "Bearer " + token))
+                    .andExpect(status().is(202));
+        }
 
         Sponsor sponsor = dataSetup.createSponsor("Parent Spons", 4441, "Child Spons", 1114);
         User user = userRepository.findByUsername(TEST_USER);
@@ -851,11 +876,8 @@ public class BulkDataAccessAPIIntegrationTests {
     public void testPatientExportWithContractDuplicateSubmissionDifferentUser() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
-        this.mockMvc.perform(
-                get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token));
+        createMaxJobsWithContract(contract);
 
-        Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         User user = new User();
         Sponsor sponsor = dataSetup.createSponsor("Parent Spons", 4441, "Child Spons", 1114);
         user.setSponsor(sponsor);
@@ -863,8 +885,12 @@ public class BulkDataAccessAPIIntegrationTests {
         user.setUsername("test");
         user.setEmail("test@test.com");
         userRepository.saveAndFlush(user);
-        job.setUser(user);
-        jobRepository.saveAndFlush(job);
+
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for(Job job : jobs) {
+            job.setUser(user);
+            jobRepository.saveAndFlush(job);
+        }
 
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export").contentType(MediaType.APPLICATION_JSON)

--- a/common/src/main/java/gov/cms/ab2d/common/model/User.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/User.java
@@ -56,6 +56,9 @@ public class User implements UserDetails {
         roles.remove(role);
     }
 
+    @NotNull
+    private Integer maxParallelJobs = 1;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<GrantedAuthority> authorities = new ArrayList<>();

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobService.java
@@ -22,7 +22,5 @@ public interface JobService {
 
     void deleteFileForJob(File file);
 
-    boolean checkIfCurrentUserHasActiveJob();
-
-    boolean checkIfCurrentUserHasActiveJobForContractNumber(String contractNumber);
+    boolean checkIfCurrentUserCanAddJob();
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -150,21 +150,9 @@ public class JobServiceImpl implements JobService {
     }
 
     @Override
-    public boolean checkIfCurrentUserHasActiveJob() {
+    public boolean checkIfCurrentUserCanAddJob() {
         User user = userService.getCurrentUser();
         List<Job> jobs = jobRepository.findActiveJobsByUser(user);
-        return jobs.size() > 0;
-    }
-
-    @Override
-    public boolean checkIfCurrentUserHasActiveJobForContractNumber(String contractNumber) {
-        User user = userService.getCurrentUser();
-        Contract contract = contractRepository.findContractByContractNumber(contractNumber)
-            .orElseThrow(() -> {
-                log.error("Contract number {} }was not found", contractNumber);
-                return new ResourceNotFoundException("Contract number " + contractNumber + " was not found");
-            });
-        List<Job> jobs = jobRepository.findActiveJobsByUserAndContract(user, contract);
-        return jobs.size() > 0;
+        return jobs.size() < user.getMaxParallelJobs();
     }
 }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -20,3 +20,5 @@ databaseChangeLog:
       file: db/changelog/v001/add_multicontract_data.sql
   - include:
       file: db/changelog/v001/update_attestation_date.sql
+  - include:
+      file: db/changelog/v001/add_concurrent_job_column.sql

--- a/common/src/main/resources/db/changelog/v001/add_concurrent_job_column.sql
+++ b/common/src/main/resources/db/changelog/v001/add_concurrent_job_column.sql
@@ -5,3 +5,5 @@
 ALTER TABLE user_account ADD COLUMN max_parallel_jobs INT DEFAULT 1 NOT NULL;
 
 UPDATE user_account SET max_parallel_jobs = 3;
+
+UPDATE user_account SET max_parallel_jobs = 30 WHERE username = '0oa2t7wfhvB2qSqPg297';

--- a/common/src/main/resources/db/changelog/v001/add_concurrent_job_column.sql
+++ b/common/src/main/resources/db/changelog/v001/add_concurrent_job_column.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+--changeset adaykin:add_concurrent_job_column failOnError:true
+ALTER TABLE user_account ADD COLUMN max_parallel_jobs INT DEFAULT 1 NOT NULL;
+
+UPDATE user_account SET max_parallel_jobs = 3;

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -365,31 +365,26 @@ public class JobServiceTest {
     }
 
     @Test
-    public void checkIfUserHasActiveJobTest() {
-        boolean result = jobService.checkIfCurrentUserHasActiveJob();
-        Assert.assertFalse(result);
+    public void checkIfUserCanAddJobTest() {
+        boolean result = jobService.checkIfCurrentUserCanAddJob();
+        Assert.assertTrue(result);
     }
 
     @Test
-    public void checkIfUserHasActiveJobTrueTest() {
+    public void checkIfUserCanAddJobTrueTest() {
         jobService.createJob(EOB, "http://localhost:8080");
 
-        boolean result = jobService.checkIfCurrentUserHasActiveJob();
+        boolean result = jobService.checkIfCurrentUserCanAddJob();
         Assert.assertTrue(result);
     }
 
     @Test
-    public void checkIfUserHasActiveJobWithBadContractTest() {
-        var exceptionThrown = assertThrows(ResourceNotFoundException.class,
-                () -> jobService.checkIfCurrentUserHasActiveJobForContractNumber("S001"));
-        Assert.assertThat(exceptionThrown.getMessage(), is("Contract number S001 was not found"));
-    }
+    public void checkIfUserCanAddJobPastLimitTest() {
+        jobService.createJob(EOB, "http://localhost:8080");
+        jobService.createJob(EOB, "http://localhost:8080");
+        jobService.createJob(EOB, "http://localhost:8080");
 
-    @Test
-    public void checkIfUserHasActiveJobWithContractTest() {
-        jobService.createJob(EOB, "http://localhost:8080", VALID_CONTRACT_NUMBER);
-
-        boolean result = jobService.checkIfCurrentUserHasActiveJobForContractNumber(VALID_CONTRACT_NUMBER);
-        Assert.assertTrue(result);
+        boolean result = jobService.checkIfCurrentUserCanAddJob();
+        Assert.assertFalse(result);
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
@@ -102,6 +102,7 @@ public class DataSetup {
         user.setUsername(TEST_USER);
         user.setSponsor(sponsor);
         user.setEnabled(true);
+        user.setMaxParallelJobs(3);
         for(String userRole :  userRoles) {
             Role role = new Role();
             role.setName(userRole);

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -391,6 +391,10 @@ public class TestRunner {
         String fileContent = downloadResponse.body();
 
         verifyJsonFromfileDownload(fileContent);
+
+        // Cleanup
+        HttpResponse<String> deleteResponse = cancelJobRequest(jobUuid);
+        Assert.assertEquals(202, deleteResponse.statusCode());
     }
 
     @Test


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

Setting max concurrent jobs to 3

### Summary

<!-- A more detailed multi line description of the pr. -->

Add a column in the user_account table that will set the maximum concurrent jobs a user can have to 1 by default, and adding a migration that will change it to 3 for all users. The exports will enforce that a user can only have a max number of jobs to whatever their limit is set to.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and linting pass
- [x] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?

NA

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->