### PR TITLE
ab2d-931 - refactor async call to return void return type

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
@@ -1,11 +1,12 @@
 package gov.cms.ab2d.worker.processor;
 
-import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse;
+import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse.PatientDTO;
+
 import java.time.OffsetDateTime;
 import java.util.concurrent.Future;
 
 public interface PatientClaimsProcessor {
 
-    Future<Integer> process(GetPatientsByContractResponse.PatientDTO patientId, JobDataWriter writer, OffsetDateTime attTime);
+    Future<Void> process(PatientDTO patientDTO, JobDataWriter writer, OffsetDateTime attTime);
 
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -102,7 +102,7 @@ class JobProcessorUnitTest {
         final Path outputDir = Files.createDirectories(outputDirPath);
         Mockito.lenient().when(fileService.createDirectory(any(Path.class))).thenReturn(outputDir);
 
-        Future<Integer> futureResources = new AsyncResult(0);
+        Future<Void> futureResources = new AsyncResult(0);
         Mockito.lenient().when(patientClaimsProcessor.process(any(), any(), any())).thenReturn(futureResources);
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -102,7 +102,7 @@ class JobProcessorUnitTest {
         final Path outputDir = Files.createDirectories(outputDirPath);
         Mockito.lenient().when(fileService.createDirectory(any(Path.class))).thenReturn(outputDir);
 
-        Future<Void> futureResources = new AsyncResult(0);
+        Future<Void> futureResources = new AsyncResult<>(null);
         Mockito.lenient().when(patientClaimsProcessor.process(any(), any(), any())).thenReturn(futureResources);
     }
 


### PR DESCRIPTION
refactor async call to return void return type

### Summary

After the design change to enable worker to create multiple output files, the logic no longer needs the errorCount to be returned by the `PatientClaimsProcessor` class. `JobProcessor` is able to use the `dataFiles` & `errorFiles` obtained from the `JobDataWriter` class to create the relevant records in the `JobOutput`  table. This refactor removes the redundant `errorCount` return type from being returned from the async call and the corresponding clean up of the code in `JobProcessor`


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A