### PR TITLE
add new parameter to set sslmode to connect to db

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE}
+spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE:allow}
 spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}
+spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE}
 spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - AB2D_DB_HOST=db
       - AB2D_DB_PORT=5432
       - AB2D_DB_DATABASE=ab2d
+      - AB2D_DB_SSL_MODE=allow
       - AB2D_DB_USER=ab2d
       - AB2D_DB_PASSWORD=ab2d
       - AB2D_EFS_MOUNT=/tmp/ab2d_efs_mount
@@ -39,6 +40,7 @@ services:
       - AB2D_DB_HOST=db
       - AB2D_DB_PORT=5432
       - AB2D_DB_DATABASE=ab2d
+      - AB2D_DB_SSL_MODE=allow
       - AB2D_DB_USER=ab2d
       - AB2D_DB_PASSWORD=ab2d
       - AB2D_EFS_MOUNT=/tmp/ab2d_efs_mount

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ## -------------------------------------------------------------------------------------------  DATA-SOURCE CONFIG
-spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}
+spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE}
 spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ## -------------------------------------------------------------------------------------------  DATA-SOURCE CONFIG
-spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE}
+spring.datasource.url=jdbc:postgresql://${AB2D_DB_HOST}:${AB2D_DB_PORT}/${AB2D_DB_DATABASE}?sslmode=${AB2D_DB_SSL_MODE:allow}
 spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Add a new parameter `sslmode` in the db connection URL to allow ssl connection to be turned on in specific environments

### Summary

Add a new parameter `sslmode` in the db connection URL to allow ssl connection to be turned on in specific environments
Set the default value to `allow` which will **not** require ssl connection for dev and other non-prod environments. 
To turn on ssl in prod(and any other environments) , the value could be set to `verify-full` by setting the environment variable `AB2D_DB_SSL_MODE`




### Checklist

- [x] Tests and linting pass


### Security


### Additional JIRA Tickets (optional)
