### PR TITLE
Bug/ab2d 953 simple date format not thread safe

### DIFF
--- a/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
@@ -17,8 +17,8 @@ import java.util.stream.Collectors;
  * and to minimize time zone issues, we kept everything as Date objects.
  */
 public final class FilterOutByDate {
-    private static SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
-    private static SimpleDateFormat fullDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+    private static String SHORT_DATE_FORMAT_STRING = "MM/dd/yyyy";
+    private static String FULL_DATE_FORMAT_STRING = "MM/dd/yyyy HH:mm:ss";
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.
@@ -39,13 +39,15 @@ public final class FilterOutByDate {
          * @throws ParseException if there was an error constructing the Date objects
          */
         public DateRange(Date start, Date end) throws ParseException {
+            SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL_DATE_FORMAT_STRING);
+            SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT_DATE_FORMAT_STRING);
             if (start != null) {
                 // we're only dealing with dates, not times, so 0 out time
-                this.start = sdf.parse(sdf.format(start));
+                this.start = shortDateFormat.parse(shortDateFormat.format(start));
             }
             if (end != null) {
                 // we're only dealing with dates, not times, so max out time
-                this.end = fullDateFormat.parse(sdf.format(end) + " 23:59:59");
+                this.end = fullDateFormat.parse(shortDateFormat.format(end) + " 23:59:59");
             }
         }
 
@@ -246,16 +248,15 @@ public final class FilterOutByDate {
      * @throws ParseException - if there is an issue parsing the dates
      */
     static boolean afterAttestation(Date attestation, ExplanationOfBenefit ben) throws ParseException {
+        SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL_DATE_FORMAT_STRING);
+        SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT_DATE_FORMAT_STRING);
         if (ben == null || ben.getBillablePeriod() == null || attestation == null) {
             return false;
         }
-        Date attToUse = fullDateFormat.parse(sdf.format(attestation) + " 00:00:00");
+        Date attToUse = fullDateFormat.parse(shortDateFormat.format(attestation) + " 00:00:00");
         Period p = ben.getBillablePeriod();
         Date end = p.getEnd();
-        if (end != null && end.getTime() >= attToUse.getTime()) {
-            return true;
-        }
-        return false;
+        return end != null && end.getTime() >= attToUse.getTime();
     }
 
     /**

--- a/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
@@ -17,8 +17,8 @@ import java.util.stream.Collectors;
  * and to minimize time zone issues, we kept everything as Date objects.
  */
 public final class FilterOutByDate {
-    private static String SHORT_DATE_FORMAT_STRING = "MM/dd/yyyy";
-    private static String FULL_DATE_FORMAT_STRING = "MM/dd/yyyy HH:mm:ss";
+    private static final String SHORT = "MM/dd/yyyy";
+    private static final String FULL = "MM/dd/yyyy HH:mm:ss";
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.
@@ -39,8 +39,8 @@ public final class FilterOutByDate {
          * @throws ParseException if there was an error constructing the Date objects
          */
         public DateRange(Date start, Date end) throws ParseException {
-            SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL_DATE_FORMAT_STRING);
-            SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT_DATE_FORMAT_STRING);
+            SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL);
+            SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT);
             if (start != null) {
                 // we're only dealing with dates, not times, so 0 out time
                 this.start = shortDateFormat.parse(shortDateFormat.format(start));
@@ -248,8 +248,8 @@ public final class FilterOutByDate {
      * @throws ParseException - if there is an issue parsing the dates
      */
     static boolean afterAttestation(Date attestation, ExplanationOfBenefit ben) throws ParseException {
-        SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL_DATE_FORMAT_STRING);
-        SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT_DATE_FORMAT_STRING);
+        SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL);
+        SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT);
         if (ben == null || ben.getBillablePeriod() == null || attestation == null) {
             return false;
         }


### PR DESCRIPTION
### Summary
The FilterOutByDate class had a SimpleDateFormat private attribute. SimpleDateFormat is not thread safe and the this class is used by the worker which is multi-threaded. There are three alternatives to to this:

1. Update the date formatting to a new version - The problem with that is the the FHIR library uses the Date object and I didn't want to introduce errors by converting back and forth given unknown time zone information.
2. Make the method that uses it synchronized - seems like overkill and potentially blocking
3. Take the SimpleDateFormat and put it in the methods that uses it, creating an instance each time you need it - I decided this was the simplest way and since it isn't a terrible expensive object, the best.

### Checklist

- [ ] Tests and linting pass
- [ ] Code checked for PHI/PII exposure
