### PR TITLE
ab2d-974 - exclude SAMHSA while requesting EOB data from BFD

### DIFF
--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -80,9 +80,11 @@ public class BFDClientImpl implements BFDClient {
             exclude = { ResourceNotFoundException.class }
     )
     public Bundle requestEOBFromServer(String patientID) {
+        var excludeSAMHSA = new TokenClientParam("excludeSAMHSA").exactly().code("true");
         return client.search()
                 .forResource(ExplanationOfBenefit.class)
                 .where(ExplanationOfBenefit.PATIENT.hasId(patientID))
+                .and(excludeSAMHSA)
                 .count(pageSize)
                 .returnBundle(Bundle.class)
                 .encodedJson()

--- a/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
+++ b/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
@@ -98,7 +98,8 @@ public class BlueButtonClientTest {
                     "/v1/fhir/ExplanationOfBenefit",
                     HttpStatus.OK_200,
                     getRawXML(SAMPLE_EOB_PATH_PREFIX + patientId + ".xml"),
-                    Collections.singletonList(Parameter.param("patient", patientId))
+                    List.of(Parameter.param("patient", patientId),
+                            Parameter.param("excludeSAMHSA", "true"))
             );
 
             createMockServerExpectation(
@@ -128,7 +129,8 @@ public class BlueButtonClientTest {
                 "/v1/fhir/ExplanationOfBenefit",
                 HttpStatus.OK_200,
                 getRawXML(SAMPLE_EOB_PATH_PREFIX + TEST_NO_RECORD_PATIENT_ID + ".xml"),
-                Collections.singletonList(Parameter.param("patient", TEST_NO_RECORD_PATIENT_ID))
+                List.of(Parameter.param("patient", TEST_NO_RECORD_PATIENT_ID),
+                        Parameter.param("excludeSAMHSA", "true"))
         );
 
         // Create mocks for pages of the results
@@ -139,7 +141,8 @@ public class BlueButtonClientTest {
                     getRawXML(SAMPLE_EOB_PATH_PREFIX + TEST_PATIENT_ID + "_" + startIndex + ".xml"),
                     List.of(Parameter.param("patient", TEST_PATIENT_ID),
                             Parameter.param("count", "10"),
-                            Parameter.param("startIndex", startIndex))
+                            Parameter.param("startIndex", startIndex),
+                            Parameter.param("excludeSAMHSA", "true"))
             );
         }
     }

--- a/bfd/src/test/resources/bb-test-data/eob/20010000001115.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20010000001115.xml
@@ -7,11 +7,11 @@
     <total value="32"/>
     <link>
         <relation value="self"/>
-        <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20010000001115&amp;count=10&amp;startIndex=0"/>
+        <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20010000001115&amp;count=10&amp;startIndex=0&amp;excludeSAMHSA=true"/>
     </link>
     <link>
         <relation value="next"/>
-        <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20010000001115&amp;count=10&amp;startIndex=10"/>
+        <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20010000001115&amp;count=10&amp;startIndex=10&amp;excludeSAMHSA=true"/>
     </link>
     <entry>
         <resource>

--- a/bfd/src/test/resources/bb-test-data/eob/20140000008325.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20140000008325.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=0"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=0&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/bfd/src/test/resources/bb-test-data/eob/20140000008325_10.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20140000008325_10.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/bfd/src/test/resources/bb-test-data/eob/20140000008325_20.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20140000008325_20.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/bfd/src/test/resources/bb-test-data/eob/20140000008325_30.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20140000008325_30.xml
@@ -7,7 +7,7 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/bfd/src/test/resources/bb-test-data/eob/20140000009893.xml
+++ b/bfd/src/test/resources/bb-test-data/eob/20140000009893.xml
@@ -7,7 +7,7 @@
    <total value="1"/>
    <link>
       <relation value="self"/>
-      <url value="https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/ExplanationOfBenefit?patient=20140000009893"/>
+      <url value="https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/ExplanationOfBenefit?patient=20140000009893&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>


### PR DESCRIPTION
While requesting EOB data from BFD, exclude substance abuse and mental health claims

### Summary

While requesting EOB data from BFD, pass an additional search criteria to exclude substance abuse and mental health claims.


### Checklist
- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A