### PR TITLE
ab2d 973 introduce failure threshold for the worker

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -370,6 +370,7 @@ public class JobProcessorImpl implements JobProcessor {
             // log exception, but continue processing job as errorCount is below threshold
         } else {
             cancelFuturesInQueue(futureHandles);
+            log.error("{} out of {} records failed. Stopping job", progressTracker.getFailureCount(), progressTracker.getProcessedCount());
             throw new RuntimeException("Too many patient records in the job had failures");
         }
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -364,12 +364,13 @@ public class JobProcessorImpl implements JobProcessor {
     private void analyzeException(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Exception e) {
         progressTracker.incrementFailureCount();
         progressTracker.incrementProcessedCount();
-        if (progressTracker.failJob()) {
-            cancelFuturesInQueue(futureHandles);
-
+        if (progressTracker.isErrorCountBelowThreshold()) {
             final Throwable rootCause = ExceptionUtils.getRootCause(e);
-            log.error("exception while processing patient {}", rootCause.getMessage());
-            throw new RuntimeException(rootCause.getMessage(), rootCause);
+            log.error("exception while processing patient {}", rootCause.getMessage(), rootCause);
+            // log exception, but continue processing job as errorCount is below threshold
+        } else {
+            cancelFuturesInQueue(futureHandles);
+            throw new RuntimeException("Too many patient records in the job had failures");
         }
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -363,6 +363,7 @@ public class JobProcessorImpl implements JobProcessor {
 
     private void analyzeException(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Exception e) {
         progressTracker.incrementFailureCount();
+        progressTracker.incrementProcessedCount();
         if (progressTracker.failJob()) {
             cancelFuturesInQueue(futureHandles);
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -70,7 +70,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
                 //should not happen - original exception will be thrown
                 log.error("error during exception handling to write error record");
             }
-            throw new RuntimeException(e);
+            return AsyncResult.forExecutionException(e);
         }
 
         log.debug("finished writing [{}] resources", resourceCount);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
@@ -65,7 +65,7 @@ public class ProgressTracker {
     }
 
     public boolean isErrorCountBelowThreshold() {
-        return (failureCount * 100) / processedCount < failureThreshold;
+        return (failureCount * 100) / getTotalCount() < failureThreshold;
     }
 
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
@@ -64,8 +64,8 @@ public class ProgressTracker {
         return percentCompleted;
     }
 
-    public boolean failJob() {
-        return (failureCount * 100) / processedCount >= failureThreshold;
+    public boolean isErrorCountBelowThreshold() {
+        return (failureCount * 100) / processedCount < failureThreshold;
     }
 
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
@@ -19,6 +19,9 @@ public class ProgressTracker {
     private int totalCount;
     private int processedCount;
 
+    private final int failureThreshold;
+    private int failureCount;
+
     @Setter
     private int lastDbUpdateCount;
 
@@ -30,6 +33,10 @@ public class ProgressTracker {
 
     public void incrementProcessedCount() {
         ++processedCount;
+    }
+
+    public void incrementFailureCount() {
+        ++failureCount;
     }
 
 
@@ -55,6 +62,10 @@ public class ProgressTracker {
         final int percentCompleted = (processedCount * 100) / getTotalCount();
         lastDbUpdateCount = processedCount;
         return percentCompleted;
+    }
+
+    public boolean failJob() {
+        return (failureCount * 100) / processedCount >= failureThreshold;
     }
 
 

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -19,6 +19,9 @@ cancellation.check.frequency=10
 report.progress.db.frequency=100
 report.progress.log.frequency=10000
 
+## fail the job if >= 10% of the records fail
+failure.threshold=10
+
 ## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
 ## These properties apply to "patientProcessorThreadPool".
 pcp.core.pool.size=${AB2D_PCP_POOL_CORE_SIZE:#{100}}

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -19,8 +19,8 @@ cancellation.check.frequency=10
 report.progress.db.frequency=100
 report.progress.log.frequency=10000
 
-## fail the job if >= 10% of the records fail
-failure.threshold=10
+## fail the job if >= 1% of the records fail
+failure.threshold=1
 
 ## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
 ## These properties apply to "patientProcessorThreadPool".

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -166,8 +166,8 @@ class JobProcessorIntegrationTest {
                 .thenReturn(bundle1, bundles)
                 .thenReturn(bundle1, bundles)
                 .thenReturn(bundle1, bundles)
-                .thenReturn(bundle1)
-                .thenThrow(fail, fail, fail, fail, fail, fail, fail, fail, fail)
+                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1)
+                .thenThrow(fail, fail, fail, fail, fail)
                 ;
 
         var processedJob = cut.process("S0000");
@@ -187,7 +187,7 @@ class JobProcessorIntegrationTest {
         when(mockBfdClient.requestEOBFromServer(anyString()))
                 .thenReturn(bundle1, bundles)
                 .thenReturn(bundle1, bundles)
-                .thenThrow(fail, fail, fail)
+                .thenThrow(fail, fail, fail, fail, fail, fail, fail, fail, fail, fail)
                 .thenReturn(bundle1, bundles)
         ;
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -162,18 +162,22 @@ class JobProcessorIntegrationTest {
 
         ExplanationOfBenefit eob = EobTestDataUtil.createEOB();
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        final Bundle[] bundles = {bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1};
+
+        final RuntimeException fail = new RuntimeException("TEST EXCEPTION");
+        final Throwable[] failures = {fail, fail, fail, fail, fail, fail, fail, fail, fail};
         when(mockBfdClient.requestEOBFromServer(anyString()))
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenThrow(new RuntimeException("TEST EXCEPTION"))
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1)
+                .thenThrow(failures)
                 ;
 
         var processedJob = cut.process("S0000");
@@ -195,19 +199,17 @@ class JobProcessorIntegrationTest {
         createContract(sponsor);
 
         ExplanationOfBenefit eob = EobTestDataUtil.createEOB();
-        Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        final Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        final Bundle[] bundles = {bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1};
+
         final RuntimeException fail = new RuntimeException("TEST EXCEPTION");
+        final Throwable[] failures = {fail, fail, fail};
+
         when(mockBfdClient.requestEOBFromServer(anyString()))
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenReturn(bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1, bundle1)
-                .thenThrow(fail, fail, fail, fail, fail, fail, fail, fail, fail, fail)
+                .thenReturn(bundle1, bundles)
+                .thenReturn(bundle1, bundles)
+                .thenThrow(failures)
+                .thenReturn(bundle1, bundles)
         ;
 
         var processedJob = cut.process("S0000");

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -106,6 +106,7 @@ class JobProcessorIntegrationTest {
                 optOutRepository);
         ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 10);
         ReflectionTestUtils.setField(cut, "efsMount", tmpEfsMountDir.toString());
+        ReflectionTestUtils.setField(cut, "failureThreshold", 10);
     }
 
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -216,9 +216,6 @@ class JobProcessorIntegrationTest {
         assertThat(processedJob.getStatusMessage(), is("Too many patient records in the job had failures"));
         assertThat(processedJob.getExpiresAt(), nullValue());
         assertThat(processedJob.getCompletedAt(), notNullValue());
-
-        final List<JobOutput> jobOutputs = job.getJobOutputs();
-        assertTrue(jobOutputs.isEmpty());
     }
 
     private Sponsor createSponsor() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -227,23 +227,6 @@ class JobProcessorUnitTest {
         verify(patientClaimsProcessor, never()).process(any(), any(), any());
     }
 
-
-    @Test
-    @DisplayName("When patientClaimsProcessor throws an exception, the job status becomes FAILED")
-    void whenPatientClaimsProcessorThrowsException_jobFailsWithErrorMessage() {
-
-        final String errMsg = "error during exception handling to write error record";
-        final RuntimeException runtimeException = new RuntimeException(errMsg);
-        Mockito.doThrow(runtimeException).when(patientClaimsProcessor).process(any(), any(), any());
-
-        var processedJob = cut.process(jobUuid);
-
-        assertThat(processedJob.getStatus(), is(JobStatus.FAILED));
-        assertThat(processedJob.getStatusMessage(), is(errMsg));
-        assertThat(processedJob.getCompletedAt(), notNullValue());
-        doVerify();
-    }
-
     @Test
     @DisplayName("When output directory for the job already exists, delete it and create it afresh")
     void whenOutputDirectoryAlreadyExist_DeleteItAndCreateItAfresh() throws IOException {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
@@ -100,11 +100,11 @@ public class PatientClaimsProcessorUnitTest {
     }
 
     @Test
-    void process_whenBfdClientThrowsException() throws IOException {
+    void process_whenBfdClientThrowsException() {
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
         when(mockBfdClient.requestEOBFromServer(patientId)).thenThrow(new RuntimeException("Test Exception"));
 
-        var exceptionThrown = assertThrows(RuntimeException.class,
+        var exceptionThrown = assertThrows(ExecutionException.class,
                 () -> cut.process(patientDTO, jobDataWriter, earlyAttDate).get());
 
         assertThat(exceptionThrown.getCause().getMessage(), startsWith("Test Exception"));
@@ -114,7 +114,7 @@ public class PatientClaimsProcessorUnitTest {
     }
 
     @Test
-    void process_whenPatientHasNoEOBClaimsData() throws IOException, ExecutionException, InterruptedException {
+    void process_whenPatientHasNoEOBClaimsData() throws ExecutionException, InterruptedException {
         Bundle bundle1 = new Bundle();
         when(mockBfdClient.requestEOBFromServer(patientId)).thenReturn(bundle1);
 

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -22,6 +22,9 @@ cancellation.check.frequency=2
 report.progress.db.frequency=10
 report.progress.log.frequency=10
 
+## fail the job if >= 10% of the records fail
+failure.threshold=10
+
 ## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
 pcp.core.pool.size=3
 pcp.max.pool.size=5


### PR DESCRIPTION
introduce failure threshold for the worker

### Summary

Given a job, the worker processes all the patients in the contract. Introduce a failure threshold so that the batch is not stopped on the first failure. Instead when a failure occurs, check against an externally configurable failure threshold and if the number of errors crosses the threshold, only then stop processing the job.


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A