### PR TITLE
Feature ab2d 1070 Add ability to cache contract-to-bene data

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -46,11 +46,4 @@ public class Contract {
     private Set<Coverage> coverages = new HashSet<>();
 
 
-    public void addBeneficiary(Beneficiary beneficiary) {
-        Coverage coverage = new Coverage();
-        coverage.setContract(this);
-        coverage.setBeneficiary(beneficiary);
-        coverages.add(coverage);
-        beneficiary.getCoverages().add(coverage);
-    }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/BeneficiaryRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/BeneficiaryRepository.java
@@ -1,0 +1,15 @@
+package gov.cms.ab2d.common.repository;
+
+import gov.cms.ab2d.common.model.Beneficiary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BeneficiaryRepository extends JpaRepository<Beneficiary, Long> {
+
+
+    Optional<Beneficiary> findByPatientId(String patientId);
+
+}

--- a/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CoverageRepository extends JpaRepository<Coverage, Long> {
@@ -19,6 +20,6 @@ public interface CoverageRepository extends JpaRepository<Coverage, Long> {
             "   AND c.partDMonth = :month ")
     List<String> findActivePatientIds(Long contractId, int month);
 
-    List<Coverage> findByContractAndBeneficiaryAndPartDMonth(Contract contract, Beneficiary bene, int month);
+    Optional<Coverage> findByContractAndBeneficiaryAndPartDMonth(Contract contract, Beneficiary bene, int month);
 
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.common.repository;
 
+import gov.cms.ab2d.common.model.Beneficiary;
+import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.Coverage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +18,7 @@ public interface CoverageRepository extends JpaRepository<Coverage, Long> {
             " WHERE c.contract.id = :contractId " +
             "   AND c.partDMonth = :month ")
     List<String> findActivePatientIds(Long contractId, int month);
+
+    List<Coverage> findByContractAndBeneficiaryAndPartDMonth(Contract contract, Beneficiary bene, int month);
+
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/CoverageRepository.java
@@ -1,0 +1,19 @@
+package gov.cms.ab2d.common.repository;
+
+import gov.cms.ab2d.common.model.Coverage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CoverageRepository extends JpaRepository<Coverage, Long> {
+
+
+    @Query(" SELECT c.beneficiary.patientId " +
+            "  FROM Coverage c " +
+            " WHERE c.contract.id = :contractId " +
+            "   AND c.partDMonth = :month ")
+    List<String> findActivePatientIds(Long contractId, int month);
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -14,6 +14,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
@@ -33,6 +34,8 @@ public class ContractAdapterImpl implements ContractAdapter {
 
     private static final String BENEFICIARY_ID = "https://bluebutton.cms.gov/resources/variables/bene_id";
 
+    @Value("${contract2bene.local.storage.threshold:1000}")
+    private int localStorageThreshold;
 
     private final BFDClient bfdClient;
     private final ContractRepository contractRepo;
@@ -55,7 +58,10 @@ public class ContractAdapterImpl implements ContractAdapter {
                 // call BFD to fetch the data
 
                 bfdPatientsIds = getPatientIdsForMonth(contractNumber, month);
-                if (!bfdPatientsIds.isEmpty()) {
+
+                //if number of benes for this month exceeds localStorageThreshold, store it locally
+                var beneficiaryCount = bfdPatientsIds.size();
+                if (beneficiaryCount > localStorageThreshold) {
                     beneficiaryService.storeBeneficiaries(contract.getId(), bfdPatientsIds, month);
                 }
             }

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -56,7 +56,9 @@ public class ContractAdapterImpl implements ContractAdapter {
                 // call BFD to fetch the data
 
                 bfdPatientsIds = getPatientIdsForMonth(contractNumber, month);
-                beneficiaryService.storeBeneficiaries(contract.getId(), bfdPatientsIds,  month);
+                if (!bfdPatientsIds.isEmpty()) {
+                    beneficiaryService.storeBeneficiaries(contract.getId(), bfdPatientsIds, month);
+                }
             }
 
             var monthDateRange = toDateRange(month);

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -34,8 +34,8 @@ public class ContractAdapterImpl implements ContractAdapter {
 
     private static final String BENEFICIARY_ID = "https://bluebutton.cms.gov/resources/variables/bene_id";
 
-    @Value("${contract2bene.local.storage.threshold:1000}")
-    private int localStorageThreshold;
+    @Value("${contract2bene.caching.threshold:1000}")
+    private int cachingThreshold;
 
     private final BFDClient bfdClient;
     private final ContractRepository contractRepo;
@@ -59,9 +59,9 @@ public class ContractAdapterImpl implements ContractAdapter {
 
                 bfdPatientsIds = getPatientIdsForMonth(contractNumber, month);
 
-                //if number of benes for this month exceeds localStorageThreshold, store it locally
+                //if number of benes for this month exceeds cachingThreshold, cache it
                 var beneficiaryCount = bfdPatientsIds.size();
-                if (beneficiaryCount > localStorageThreshold) {
+                if (beneficiaryCount > cachingThreshold) {
                     beneficiaryService.storeBeneficiaries(contract.getId(), bfdPatientsIds, month);
                 }
             }

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -14,7 +14,6 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.ResourceType;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
@@ -27,7 +26,7 @@ import java.util.stream.Collectors;
 
 
 @Slf4j
-@Primary // - once the BFD API starts returning data, change this to primary bean so spring injects this instead of the stub.
+//@Primary // - once the BFD API starts returning data, change this to primary bean so spring injects this instead of the stub.
 @Component
 @RequiredArgsConstructor
 public class ContractAdapterImpl implements ContractAdapter {

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStub.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStub.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.worker.adapter.bluebutton;
 import gov.cms.ab2d.filter.FilterOutByDate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
@@ -21,7 +22,7 @@ import static org.apache.commons.lang3.StringUtils.contains;
  * The rightmost 3 characters of the contractNumber being passed in must be numeric.
  */
 @Slf4j
-//@Primary    //Till the BFD api starts returning data, use this as the primary instance.
+@Primary    //Till the BFD api starts returning data, use this as the primary instance.
 @Component
 public class ContractAdapterStub implements ContractAdapter {
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStub.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStub.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.worker.adapter.bluebutton;
 import gov.cms.ab2d.filter.FilterOutByDate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
@@ -22,7 +21,7 @@ import static org.apache.commons.lang3.StringUtils.contains;
  * The rightmost 3 characters of the contractNumber being passed in must be numeric.
  */
 @Slf4j
-@Primary    //Till the BFD api starts returning data, use this as the primary instance.
+//@Primary    //Till the BFD api starts returning data, use this as the primary instance.
 @Component
 public class ContractAdapterStub implements ContractAdapter {
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryService.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryService.java
@@ -1,0 +1,11 @@
+package gov.cms.ab2d.worker.service;
+
+import java.util.Set;
+
+public interface BeneficiaryService {
+
+    Set<String> findPatientIdsInDb(Long contractId, int month);
+
+
+    void storeBeneficiaries(Long contractId, Set<String> bfdPatientsIds, int month);
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,7 +37,7 @@ public class BeneficiaryServiceImpl implements BeneficiaryService {
     @Override
     public Set<String> findPatientIdsInDb(Long contractId, int month) {
         var patientIds = coverageRepo.findActivePatientIds(contractId, month);
-        return new HashSet<>(patientIds);
+        return new LinkedHashSet<>(patientIds);
     }
 
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
@@ -1,0 +1,86 @@
+package gov.cms.ab2d.worker.service;
+
+import gov.cms.ab2d.common.model.Beneficiary;
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.Coverage;
+import gov.cms.ab2d.common.repository.BeneficiaryRepository;
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.repository.CoverageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BeneficiaryServiceImpl implements BeneficiaryService {
+
+    private final BeneficiaryRepository beneRepo;
+    private final ContractRepository contractRepo;
+    private final CoverageRepository coverageRepo;
+
+
+    /**
+     * Given a contractId and a month,
+     * search for bene information in the local db first.
+     *
+     * @param contractId
+     * @param month
+     * @return
+     */
+    @Override
+    public Set<String> findPatientIdsInDb(Long contractId, int month) {
+        final List<String> patientIds = coverageRepo.findActivePatientIds(contractId, month);
+        return new HashSet<>(patientIds);
+    }
+
+
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void storeBeneficiaries(Long contractId, Set<String> patientIds, int month) {
+        final Contract contract = contractRepo.findById(contractId).get();
+        patientIds.forEach(patientId -> storeBeneficiaryCoverage(contract, patientId, month));
+    }
+
+
+    private void storeBeneficiaryCoverage(Contract contract, String patientId, int month) {
+        final Beneficiary beneficiary = getBeneficiary(patientId);
+        final Coverage coverage = createCoverage(contract, beneficiary, month);
+        contract.getCoverages().add(coverage);
+        beneficiary.getCoverages().add(coverage);
+    }
+
+
+    private Beneficiary getBeneficiary(String patientId) {
+        final Optional<Beneficiary> optPatient = beneRepo.findByPatientId(patientId);
+        if (optPatient.isPresent()) {
+            return optPatient.get();
+        } else {
+            return createBeneficiary(patientId);
+        }
+
+    }
+    private Beneficiary createBeneficiary(String patientId) {
+        Beneficiary beneficiary = new Beneficiary();
+        beneficiary.setPatientId(patientId);
+        return beneRepo.save(beneficiary);
+    }
+
+    private Coverage createCoverage(Contract contract, Beneficiary beneficiary, int month) {
+        Coverage coverage = new Coverage();
+        coverage.setContract(contract);
+        coverage.setBeneficiary(beneficiary);
+        coverage.setPartDMonth(month);
+        return coverageRepo.save(coverage);
+    }
+
+
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/BeneficiaryServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,7 +28,7 @@ public class BeneficiaryServiceImpl implements BeneficiaryService {
 
     /**
      * Given a contractId and a month,
-     * search for bene information in the local db first.
+     * search for bene information in the local db
      *
      * @param contractId
      * @param month
@@ -37,7 +36,7 @@ public class BeneficiaryServiceImpl implements BeneficiaryService {
      */
     @Override
     public Set<String> findPatientIdsInDb(Long contractId, int month) {
-        final List<String> patientIds = coverageRepo.findActivePatientIds(contractId, month);
+        var patientIds = coverageRepo.findActivePatientIds(contractId, month);
         return new HashSet<>(patientIds);
     }
 

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -20,7 +20,7 @@ report.progress.log.frequency=10000
 ## fail the job if >= 1% of the records fail
 failure.threshold=1
 
-contract2bene.local.storage.threshold=1000
+contract2bene.caching.threshold=1000
 
 ## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG
 ## These properties apply to "patientProcessorThreadPool".

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -20,6 +20,8 @@ report.progress.log.frequency=10000
 ## fail the job if >= 1% of the records fail
 failure.threshold=1
 
+contract2bene.local.storage.threshold=1000
+
 ## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG
 ## These properties apply to "patientProcessorThreadPool".
 pcp.queue.capacity=${AB2D_PCP_QUEUE_CAPACITY:#{150}}

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -301,8 +301,8 @@ class ContractAdapterTest {
 
 
     @Test
-    @DisplayName("given patient count > localStorageThreshold, should store beneficiary data")
-    void GivenPatientCountGreaterThanLocalStorageThreshold_ShouldStoreBeneficiaryData() {
+    @DisplayName("given patient count > cachingThreshold, should store beneficiary data")
+    void GivenPatientCountGreaterThanCachingThreshold_ShouldStoreBeneficiaryData() {
         var entries = bundle.getEntry();
         entries.add(createBundleEntry("ccw_patient_001"));
         entries.add(createBundleEntry("ccw_patient_002"));
@@ -310,7 +310,7 @@ class ContractAdapterTest {
         entries.add(createBundleEntry("ccw_patient_004"));
         entries.add(createBundleEntry("ccw_patient_005"));
 
-        ReflectionTestUtils.setField(cut, "localStorageThreshold", 2);
+        ReflectionTestUtils.setField(cut, "cachingThreshold", 2);
         cut.getPatients(contractNumber, Month.JANUARY.getValue());
 
         verify(client).requestPartDEnrolleesFromServer(anyString(), anyInt());

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -17,10 +17,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.time.Month;
 import java.util.Calendar;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
@@ -28,11 +31,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -53,10 +54,12 @@ class ContractAdapterTest {
     @BeforeEach
     void setUp() {
         cut = new ContractAdapterImpl(client, contractRepository, beneficiaryService);
+
         bundle = createBundle();
-        when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);
+        lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);
 
         Contract contract = new Contract();
+        contract.setId(Long.valueOf(Instant.now().getNano()));
         contract.setContractNumber(contractNumber);
         when(contractRepository.findContractByContractNumber(anyString())).thenReturn(Optional.of(contract));
     }
@@ -283,6 +286,35 @@ class ContractAdapterTest {
 
         verify(client, times(1)).requestPartDEnrolleesFromServer(anyString(), anyInt());
         verify(client, never()).requestNextBundleFromServer(Mockito.any(Bundle.class));
+    }
+
+
+    @Test
+    @DisplayName("given patientid rows in db for a specific contract & month, should not call BFD contract-2-bene api")
+    void GivenPatientInLocalDb_ShouldNotCallBfdContractToBeneAPI() {
+        when(beneficiaryService.findPatientIdsInDb(anyLong(), anyInt())).thenReturn(Set.of("ccw_patient_005"));
+        cut.getPatients(contractNumber, Month.JANUARY.getValue());
+
+        verify(client, never()).requestPartDEnrolleesFromServer(anyString(), anyInt());
+        verify(beneficiaryService, never()).storeBeneficiaries(anyLong(), anySet(), anyInt());
+    }
+
+
+    @Test
+    @DisplayName("given patient count > localStorageThreshold, should store beneficiary data")
+    void GivenPatientCountGreaterThanLocalStorageThreshold_ShouldStoreBeneficiaryData() {
+        var entries = bundle.getEntry();
+        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_002"));
+        entries.add(createBundleEntry("ccw_patient_003"));
+        entries.add(createBundleEntry("ccw_patient_004"));
+        entries.add(createBundleEntry("ccw_patient_005"));
+
+        ReflectionTestUtils.setField(cut, "localStorageThreshold", 2);
+        cut.getPatients(contractNumber, Month.JANUARY.getValue());
+
+        verify(client).requestPartDEnrolleesFromServer(anyString(), anyInt());
+        verify(beneficiaryService).storeBeneficiaries(anyLong(), anySet(), anyInt());
     }
 
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -301,8 +301,8 @@ class ContractAdapterTest {
 
 
     @Test
-    @DisplayName("given patient count > cachingThreshold, should store beneficiary data")
-    void GivenPatientCountGreaterThanCachingThreshold_ShouldStoreBeneficiaryData() {
+    @DisplayName("given patient count > cachingThreshold, should cache beneficiary data")
+    void GivenPatientCountGreaterThanCachingThreshold_ShouldCacheBeneficiaryData() {
         var entries = bundle.getEntry();
         entries.add(createBundleEntry("ccw_patient_001"));
         entries.add(createBundleEntry("ccw_patient_002"));
@@ -315,6 +315,23 @@ class ContractAdapterTest {
 
         verify(client).requestPartDEnrolleesFromServer(anyString(), anyInt());
         verify(beneficiaryService).storeBeneficiaries(anyLong(), anySet(), anyInt());
+    }
+
+    @Test
+    @DisplayName("given patient count < cachingThreshold, should not cache beneficiary data")
+    void GivenPatientCountLessThanCachingThreshold_ShouldNotCacheBeneficiaryData() {
+        var entries = bundle.getEntry();
+        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_002"));
+        entries.add(createBundleEntry("ccw_patient_003"));
+        entries.add(createBundleEntry("ccw_patient_004"));
+        entries.add(createBundleEntry("ccw_patient_005"));
+
+        ReflectionTestUtils.setField(cut, "cachingThreshold", 10);
+        cut.getPatients(contractNumber, Month.JANUARY.getValue());
+
+        verify(client).requestPartDEnrolleesFromServer(anyString(), anyInt());
+        verify(beneficiaryService, never()).storeBeneficiaries(anyLong(), anySet(), anyInt());
     }
 
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -2,6 +2,9 @@ package gov.cms.ab2d.worker.adapter.bluebutton;
 
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import gov.cms.ab2d.bfd.client.BFDClient;
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.worker.service.BeneficiaryService;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.dstu3.model.Bundle.BundleLinkComponent;
@@ -17,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Month;
 import java.util.Calendar;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
@@ -36,8 +40,9 @@ class ContractAdapterTest {
 
     private static final String BENEFICIARY_ID = "https://bluebutton.cms.gov/resources/variables/bene_id";
 
-    @Mock
-    private BFDClient client;
+    @Mock BFDClient client;
+    @Mock ContractRepository contractRepository;
+    @Mock BeneficiaryService beneficiaryService;
 
     private ContractAdapter cut;
     private String contractNumber = "S0000";
@@ -47,9 +52,13 @@ class ContractAdapterTest {
 
     @BeforeEach
     void setUp() {
-        cut = new ContractAdapterImpl(client);
+        cut = new ContractAdapterImpl(client, contractRepository, beneficiaryService);
         bundle = createBundle();
         when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);
+
+        Contract contract = new Contract();
+        contract.setContractNumber(contractNumber);
+        when(contractRepository.findContractByContractNumber(anyString())).thenReturn(Optional.of(contract));
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.integration.test.context.SpringIntegrationTest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -70,6 +71,7 @@ class JobProcessorIntegrationTest {
     @Autowired
     private JobOutputRepository jobOutputRepository;
     @Autowired
+    @Qualifier("contractAdapterStub")
     private ContractAdapter contractAdapterStub;
     @Autowired
     private OptOutRepository optOutRepository;

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
@@ -4,14 +4,11 @@ import gov.cms.ab2d.common.model.Beneficiary;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.Coverage;
 import gov.cms.ab2d.common.model.Sponsor;
-import gov.cms.ab2d.common.model.User;
 import gov.cms.ab2d.common.repository.BeneficiaryRepository;
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.repository.CoverageRepository;
 import gov.cms.ab2d.common.repository.SponsorRepository;
-import gov.cms.ab2d.common.repository.UserRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,18 +20,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.lang.Boolean.TRUE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Slf4j
 @SpringBootTest
 @Testcontainers
 class BeneficiaryServiceIntegrationTest {
@@ -102,17 +96,7 @@ class BeneficiaryServiceIntegrationTest {
     void storeBeneficiaries_WhenTheBenesAlreadyExist() {
 
         cut.storeBeneficiaries(contract.getId(), patientIds, 1);
-
-        beneficiaries.stream().forEach( beneficiary -> {
-            final List<Coverage> coveragesSaved = coverageRepo.findByContractAndBeneficiaryAndPartDMonth(contract, beneficiary, 1);
-            assertThat(coveragesSaved.size(), is(1));
-
-            final Coverage coverageSaved = coveragesSaved.get(0);
-            assertThat(coverageSaved.getBeneficiary().getPatientId(), is(beneficiary.getPatientId()));
-            assertThat(coverageSaved.getContract().getContractNumber(), is(contract.getContractNumber()));
-            assertThat(coverageSaved.getContract().getContractName(), is(contract.getContractName()));
-            assertThat(coverageSaved.getPartDMonth(), is(1));
-        });
+        verifyStoredBenes();
     }
 
     @Test
@@ -120,16 +104,17 @@ class BeneficiaryServiceIntegrationTest {
 
         patientIds.add(Instant.now().toString() + random.nextInt(100));
         cut.storeBeneficiaries(contract.getId(), patientIds, 1);
+        verifyStoredBenes();
+    }
 
-        beneficiaries.stream().forEach( beneficiary -> {
-            final List<Coverage> coveragesSaved = coverageRepo.findByContractAndBeneficiaryAndPartDMonth(contract, beneficiary, 1);
-            assertThat(coveragesSaved.size(), is(1));
+    private void verifyStoredBenes() {
+        beneficiaries.stream().forEach(beneficiary -> {
+            var coverage = coverageRepo.findByContractAndBeneficiaryAndPartDMonth(contract, beneficiary, 1).get();
 
-            final Coverage coverageSaved = coveragesSaved.get(0);
-            assertThat(coverageSaved.getBeneficiary().getPatientId(), is(beneficiary.getPatientId()));
-            assertThat(coverageSaved.getContract().getContractNumber(), is(contract.getContractNumber()));
-            assertThat(coverageSaved.getContract().getContractName(), is(contract.getContractName()));
-            assertThat(coverageSaved.getPartDMonth(), is(1));
+            assertThat(coverage.getBeneficiary().getPatientId(), is(beneficiary.getPatientId()));
+            assertThat(coverage.getContract().getContractNumber(), is(contract.getContractNumber()));
+            assertThat(coverage.getContract().getContractName(), is(contract.getContractName()));
+            assertThat(coverage.getPartDMonth(), is(1));
         });
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
@@ -1,0 +1,140 @@
+package gov.cms.ab2d.worker.service;
+
+import gov.cms.ab2d.common.model.Beneficiary;
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.Coverage;
+import gov.cms.ab2d.common.repository.BeneficiaryRepository;
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.repository.CoverageRepository;
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+@Testcontainers
+class BeneficiaryServiceIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
+
+    @Autowired BeneficiaryService cut;
+    @Autowired BeneficiaryRepository beneRepo;
+    @Autowired ContractRepository contractRepo;
+    @Autowired CoverageRepository coverageRepo;
+
+//    @BeforeEach
+//    void setUp() {
+//    }
+
+//    @AfterEach
+//    void tearDown() {
+//    }
+
+    @Test
+    void findPatientIdsInDb() {
+    }
+
+    @Test
+    @Transactional
+    void storeBeneficiaries() {
+
+//        final Optional<Contract> s0000 = contracts.stream().filter(c -> c.getContractNumber().equalsIgnoreCase("S0000")).findAny();
+//        final Contract contractS0000 = s0000.get();
+
+//        contracts.forEach(c -> {
+//            log.info("Contract:: id:[{}]-number:[{}]-name:[{}]-attestedOn:[{}]",
+//                    c.getId(), c.getContractNumber(), c.getContractName(), c.getAttestedOn());
+//            Contract contract = c;
+//            Beneficiary beneficiary = new Beneficiary();
+//            beneficiary.setPatientId("patientId");
+//            contract.addBeneficiary(beneficiary);
+//            contractRepo.save(contract);
+//        });
+
+        final Contract contractS0000 = new Contract();
+        contractS0000.setContractNumber("S0000");
+        contractS0000.setContractName("S0000");
+        contractS0000.setAttestedOn(OffsetDateTime.now().minusDays(2));
+            log.info("Contract:: id:[{}] - number:[{}] - name:[{}] - attestedOn:[{}]",
+                    contractS0000.getId(),
+                    contractS0000.getContractNumber(),
+                    contractS0000.getContractName(),
+                    contractS0000.getAttestedOn());
+
+            Contract contract = contractS0000;
+        final Beneficiary beneficiary = createBeneficiary();
+        if (beneficiary == null) {
+            log.info("Beneficiary is NULL");
+        }
+
+        final Coverage coverage = createCoverage(contract, beneficiary, 1);
+        //TODO: Need to come up with an alternative for this.
+//        contract.addBeneficiary(beneficiary);
+        final Contract savedContract = contractRepo.save(contract);
+
+
+//        final Optional<Contract> optContract = contractRepo.findContractByContractNumber(contractS0000.getContractNumber());
+//        final Contract contract2 = optContract.get();
+//        contract2.getCoverages().stream().map(cov -> {
+//        contract2.getCoverages().forEach(cov -> {
+
+        final Set<Coverage> coverages = savedContract.getCoverages();
+        if (coverages == null) {
+            log.info("Coverages is NULL ... ");
+        } else if (coverages.isEmpty()) {
+            log.info("Coverages is empty() ... ");
+        } else {
+            final int coverageSize = coverages.size();
+            log.info("There are [{}] coverages for contract [{}]", coverages.size(), savedContract);
+            coverages.forEach(cov -> {
+                final Beneficiary beneficiary1 = cov.getBeneficiary();
+                if (beneficiary1 == null) {
+                    log.info("beneficiary1 is NULL");
+                } else {
+                    final Long id = beneficiary1.getId();
+                    if (id == null) {
+                        log.info("id is NULL");
+                    }
+                    final String patientId = beneficiary1.getPatientId();
+                    if (patientId == null) {
+                        log.info("patientId is NULL");
+                    }
+                    log.info(" Beneficiary :: id:[{}] -  patientId:[{}]", id, patientId);
+                }
+            });
+        }
+//        cut.storeBeneficiaries();
+
+    }
+
+    private Beneficiary createBeneficiary() {
+        Beneficiary beneficiary = new Beneficiary();
+        beneficiary.setPatientId("patientId");
+        return beneRepo.save(beneficiary);
+    }
+
+    private Coverage createCoverage(Contract contract, Beneficiary bene, int partDMonth) {
+        Coverage coverage = new Coverage();
+        coverage.setBeneficiary(bene);
+        coverage.setContract(contract);
+        coverage.setPartDMonth(partDMonth);
+        return coverageRepo.save(coverage);
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/BeneficiaryServiceIntegrationTest.java
@@ -47,7 +47,6 @@ class BeneficiaryServiceIntegrationTest {
     @Autowired ContractRepository contractRepo;
     @Autowired CoverageRepository coverageRepo;
     @Autowired SponsorRepository sponsorRepo;
-    @Autowired UserRepository userRepo;
 
     private Random random = new Random();
     private Contract contract;
@@ -56,14 +55,11 @@ class BeneficiaryServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        userRepo.deleteAll();
         coverageRepo.deleteAll();
-        sponsorRepo.deleteAll();
         contractRepo.deleteAll();
         beneRepo.deleteAll();
 
         var sponsor = createSponsor();
-        createUser(sponsor);
         contract = createContract(sponsor);
 
         beneficiaries.add( createBeneficiary());
@@ -152,9 +148,6 @@ class BeneficiaryServiceIntegrationTest {
     }
 
 
-
-
-
     private Sponsor createSponsor() {
         Sponsor parent = new Sponsor();
         parent.setOrgName("Parent");
@@ -171,38 +164,18 @@ class BeneficiaryServiceIntegrationTest {
         return sponsorRepo.save(sponsor);
     }
 
-    private User createUser(Sponsor sponsor) {
-        User user = new User();
-        user.setUsername("Harry_Potter");
-        user.setFirstName("Harry");
-        user.setLastName("Potter");
-        user.setEmail("harry_potter@hogwarts.edu");
-        user.setEnabled(TRUE);
-        user.setSponsor(sponsor);
-        return userRepo.save(user);
-    }
 
     private Contract createContract(Sponsor sponsor) {
         Contract contract = new Contract();
-        contract.setContractName("CONTRACT_0000");
-        contract.setContractNumber("CONTRACT_0000");
+        final Instant thisInstant = Instant.now();
+        contract.setContractName("CONTRACT_" + thisInstant + "0000");
+        contract.setContractNumber("CONTRACT_" + thisInstant + "0000");
         contract.setAttestedOn(OffsetDateTime.now().minusDays(10));
         contract.setSponsor(sponsor);
 
         sponsor.getContracts().add(contract);
         return contractRepo.save(contract);
     }
-
-//    private Job createJob(User user) {
-//        Job job = new Job();
-//        job.setJobUuid("S0000");
-//        job.setStatus(JobStatus.SUBMITTED);
-//        job.setStatusMessage("0%");
-//        job.setUser(user);
-//        job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
-//        job.setCreatedAt(OffsetDateTime.now());
-//        return jobRepository.save(job);
-//    }
 
 
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobStatus;
 import gov.cms.ab2d.common.model.Sponsor;
 import gov.cms.ab2d.common.model.User;
+import gov.cms.ab2d.common.repository.CoverageRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.common.repository.SponsorRepository;
 import gov.cms.ab2d.common.repository.UserRepository;
@@ -38,6 +39,7 @@ public class WorkerServiceTest {
 
     @Autowired private JobRepository jobRepository;
     @Autowired private SponsorRepository sponsorRepository;
+    @Autowired private CoverageRepository coverageRepository;
     @Autowired private UserRepository userRepository;
 
     @Container
@@ -47,6 +49,7 @@ public class WorkerServiceTest {
     public void init() {
         jobRepository.deleteAll();
         userRepository.deleteAll();
+        coverageRepository.deleteAll();
         sponsorRepository.deleteAll();
     }
 

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -25,7 +25,7 @@ report.progress.log.frequency=10
 ## fail the job if >= 10% of the records fail
 failure.threshold=10
 
-contract2bene.local.storage.threshold=10
+contract2bene.caching.threshold=10
 
 ## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
 # Changing these WILL break AutoScalingServiceTest!

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -25,6 +25,8 @@ report.progress.log.frequency=10
 ## fail the job if >= 10% of the records fail
 failure.threshold=10
 
+contract2bene.local.storage.threshold=10
+
 ## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
 # Changing these WILL break AutoScalingServiceTest!
 pcp.core.pool.size=3


### PR DESCRIPTION
Add ability to cache contract-to-bene data

### Summary

Add the ability to worker to be able to cache the patientId and months active in a contract when the call the BDF contract-to-bene API returns a large amount of data. When processing a job, the `ContractAdapterImpl` will look at the cache first to see if we have the data, before attempting to call the remote api. A property named `contract2bene.caching.threshold` is used to configure this.


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A