### PR TITLE
Ab2d 1048 add zip download tests to e2e

### DIFF
--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/APIClient.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/APIClient.java
@@ -91,7 +91,6 @@ public class APIClient {
         }
         HttpRequest exportRequest = HttpRequest.newBuilder()
                 .uri(URI.create(ab2dApiUrl + PATIENT_EXPORT_PATH + paramString))
-
                 .timeout(Duration.ofSeconds(defaultTimeout))
                 .header("Content-Type", "application/json")
                 .header("Authorization", "Bearer " + jwtStr)
@@ -101,19 +100,25 @@ public class APIClient {
         return httpClient.send(exportRequest, HttpResponse.BodyHandlers.ofString());
     }
 
-    public HttpResponse<String> exportRequest() throws IOException, InterruptedException {
-        return exportRequest(Collections.emptyMap());
+    public HttpResponse<String> exportRequest(String exportType) throws IOException, InterruptedException {
+        return exportRequest(new HashMap<>() {{ put("_outputFormat", exportType); }});
     }
 
-    public HttpResponse<String> exportByContractRequest(String contractNumber) throws IOException, InterruptedException {
-        HttpRequest exportRequest = buildExportByContractRequest(contractNumber);
-
+    public HttpResponse<String> exportByContractRequest(String contractNumber, String exportType) throws IOException, InterruptedException {
+        HttpRequest exportRequest = buildExportByContractRequest(contractNumber, exportType);
         return httpClient.send(exportRequest, HttpResponse.BodyHandlers.ofString());
     }
 
-    public HttpRequest buildExportByContractRequest(String contractNumber) {
+    public HttpRequest buildExportByContractRequest(String contractNumber, String exportType) {
+        var jwtRequestParms = new HashMap<>() {{
+            put("_outputFormat", exportType);
+        }};
+        String paramString = buildParameterString(jwtRequestParms);
+        if(!paramString.equals("")) {
+            paramString = "?" + paramString;
+        }
         return HttpRequest.newBuilder()
-                .uri(URI.create(ab2dApiUrl + "Group/" + contractNumber + "/$export"))
+                .uri(URI.create(ab2dApiUrl + "Group/" + contractNumber + "/$export" + paramString))
                 .timeout(Duration.ofSeconds(defaultTimeout))
                 .header("Content-Type", "application/json")
                 .header("Authorization", "Bearer " + jwtStr)

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.matchesPattern;
 @ExtendWith(TestRunnerParameterResolver.class)
 @Slf4j
 public class TestRunner {
-    private static String FHIR_TYPE = "application/fhir+ndjson";
+    private static final String FHIR_TYPE = "application/fhir+ndjson";
 
     private static APIClient apiClient;
 
@@ -74,24 +74,24 @@ public class TestRunner {
     }
 
     public void init() throws IOException, InterruptedException, JSONException {
-        if(environment.isUsesDockerCompose()) {
-            DockerComposeContainer container = new DockerComposeContainer(
-                    new File("../docker-compose.yml"))
-                    .withEnv(System.getenv())
-                    .withScaledService("worker", 2)
-                    .withExposedService("db", 5432)
-                    .withExposedService("api", 8080, new HostPortWaitStrategy()
-                        .withStartupTimeout(Duration.of(150, SECONDS)));
-                    //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-                    //.withLogConsumer("api", new Slf4jLogConsumer(log));
-            container.start();
-        }
+//        if(environment.isUsesDockerCompose()) {
+//            DockerComposeContainer container = new DockerComposeContainer(
+//                    new File("../docker-compose.yml"))
+//                    .withEnv(System.getenv())
+//                    .withScaledService("worker", 2)
+//                    .withExposedService("db", 5432)
+//                    .withExposedService("api", 8080, new HostPortWaitStrategy()
+//                        .withStartupTimeout(Duration.of(150, SECONDS)));
+//                    //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+//                    //.withLogConsumer("api", new Slf4jLogConsumer(log));
+//            container.start();
+//        }
 
         Yaml yaml = new Yaml();
         InputStream inputStream = getClass().getResourceAsStream("/" + environment.getConfigName());
         yamlMap = yaml.load(inputStream);
-        String oktaUrl = yamlMap.get("okta-url");
-        String baseUrl = yamlMap.get("base-url");
+        String oktaUrl = "https://test.idp.idm.cms.gov/oauth2/aus2r7y3gdaFMKBol297/v1/token";
+        String baseUrl = "http://localhost:8080";
         AB2D_API_URL = APIClient.buildAB2DAPIUrl(baseUrl);
 
         String oktaClientId = System.getenv("OKTA_CLIENT_ID");

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -74,24 +74,24 @@ public class TestRunner {
     }
 
     public void init() throws IOException, InterruptedException, JSONException {
-//        if(environment.isUsesDockerCompose()) {
-//            DockerComposeContainer container = new DockerComposeContainer(
-//                    new File("../docker-compose.yml"))
-//                    .withEnv(System.getenv())
-//                    .withScaledService("worker", 2)
-//                    .withExposedService("db", 5432)
-//                    .withExposedService("api", 8080, new HostPortWaitStrategy()
-//                        .withStartupTimeout(Duration.of(150, SECONDS)));
-//                    //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-//                    //.withLogConsumer("api", new Slf4jLogConsumer(log));
-//            container.start();
-//        }
+        if(environment.isUsesDockerCompose()) {
+            DockerComposeContainer container = new DockerComposeContainer(
+                    new File("../docker-compose.yml"))
+                    .withEnv(System.getenv())
+                    .withScaledService("worker", 2)
+                    .withExposedService("db", 5432)
+                    .withExposedService("api", 8080, new HostPortWaitStrategy()
+                        .withStartupTimeout(Duration.of(150, SECONDS)));
+                    //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+                    //.withLogConsumer("api", new Slf4jLogConsumer(log));
+            container.start();
+        }
 
         Yaml yaml = new Yaml();
         InputStream inputStream = getClass().getResourceAsStream("/" + environment.getConfigName());
         yamlMap = yaml.load(inputStream);
-        String oktaUrl = "https://test.idp.idm.cms.gov/oauth2/aus2r7y3gdaFMKBol297/v1/token";
-        String baseUrl = "http://localhost:8080";
+        String oktaUrl = yamlMap.get("okta-url");
+        String baseUrl = yamlMap.get("base-url");
         AB2D_API_URL = APIClient.buildAB2DAPIUrl(baseUrl);
 
         String oktaClientId = System.getenv("OKTA_CLIENT_ID");

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -31,7 +31,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
+import static gov.cms.ab2d.common.service.JobService.ZIPFORMAT;
 import static gov.cms.ab2d.e2etest.APIClient.PATIENT_EXPORT_PATH;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -43,6 +46,7 @@ import static org.hamcrest.Matchers.matchesPattern;
 @ExtendWith(TestRunnerParameterResolver.class)
 @Slf4j
 public class TestRunner {
+    private static String FHIR_TYPE = "application/fhir+ndjson";
 
     private static APIClient apiClient;
 
@@ -169,15 +173,16 @@ public class TestRunner {
         Boolean requiresAccessToken = json.getBoolean("requiresAccessToken");
         Assert.assertEquals(true, requiresAccessToken);
         String request = json.getString("request");
-        Assert.assertEquals(request, AB2D_API_URL + (contractNumber == null ? "Patient/$export" : "Group/" + contractNumber +
-                "/$export"));
+        String stem = AB2D_API_URL + (contractNumber == null ? "Patient/" : "Group/" + contractNumber + "/") + "$export?_outputFormat=";
+        Assert.assertTrue(request.startsWith(stem));
         JSONArray errors = json.getJSONArray("error");
         Assert.assertEquals(0, errors.length());
 
         JSONArray output = json.getJSONArray("output");
         JSONObject outputObject = output.getJSONObject(0);
         String url = outputObject.getString("url");
-        Assert.assertEquals(url, AB2D_API_URL + "Job/" + jobUuid + "/file/S0000_0001.ndjson");
+        String filestem = AB2D_API_URL + "Job/" + jobUuid + "/file/S0000_0001.";
+        Assert.assertTrue(url.equals(filestem + "ndjson") || (url.equals(filestem + "zip")));
         String type = outputObject.getString("type");
         Assert.assertEquals(type, "ExplanationOfBenefit");
 
@@ -225,6 +230,29 @@ public class TestRunner {
         verifyJsonFromfileDownload(downloadString);
     }
 
+    private void downloadZipFile(String url) throws IOException, InterruptedException, JSONException {
+        HttpResponse<InputStream> downloadResponse = apiClient.fileDownloadRequest(url);
+        ZipInputStream zipIn = new ZipInputStream(downloadResponse.body());
+        ZipEntry entry = zipIn.getNextEntry();
+        StringBuilder downloadString = new StringBuilder();
+        while(entry != null) {
+            downloadString.append(extractZipFileData(entry, zipIn));
+            zipIn.closeEntry();
+            entry = zipIn.getNextEntry();
+        }
+        verifyJsonFromfileDownload(downloadString.toString());
+    }
+
+    public static String extractZipFileData(ZipEntry entry, ZipInputStream zipIn) throws IOException {
+        StringBuilder result = new StringBuilder();
+        int read;
+        while ((read = zipIn.read()) != -1) {
+            result.append((char) read);
+        }
+        System.out.println("    Entry " + entry.getName() + " - size: " + result.length());
+        return result.toString();
+    }
+
     private String performStatusRequests(List<String> contentLocationList, boolean isContract,
                                                          String contractNumber) throws JSONException, IOException, InterruptedException {
         HttpResponse<String> statusResponse = apiClient.statusRequest(contentLocationList.iterator().next());
@@ -252,7 +280,7 @@ public class TestRunner {
 
     @Test
     public void runSystemWideExport() throws IOException, InterruptedException, JSONException {
-        HttpResponse<String> exportResponse = apiClient.exportRequest();
+        HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE);
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
@@ -261,9 +289,19 @@ public class TestRunner {
     }
 
     @Test
+    public void runSystemWideZipExport() throws IOException, InterruptedException, JSONException {
+        HttpResponse<String> exportResponse = apiClient.exportRequest(ZIPFORMAT);
+        Assert.assertEquals(202, exportResponse.statusCode());
+        List<String> contentLocationList = exportResponse.headers().map().get("content-location");
+
+        String downloadUrl = performStatusRequests(contentLocationList, false, "S0000");
+        downloadZipFile(downloadUrl);
+    }
+
+    @Test
     public void runContractNumberExport() throws IOException, InterruptedException, JSONException {
         String contractNumber = "S0000";
-        HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber);
+        HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber, FHIR_TYPE);
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
@@ -272,8 +310,19 @@ public class TestRunner {
     }
 
     @Test
+    void runContractNumberZipExport() throws IOException, InterruptedException, JSONException {
+        String contractNumber = "S0000";
+        HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber, ZIPFORMAT);
+        Assert.assertEquals(202, exportResponse.statusCode());
+        List<String> contentLocationList = exportResponse.headers().map().get("content-location");
+
+        String downloadUrl = performStatusRequests(contentLocationList, true, contractNumber);
+        downloadZipFile(downloadUrl);
+    }
+
+    @Test
     public void testDelete() throws IOException, InterruptedException {
-        HttpResponse<String> exportResponse = apiClient.exportRequest();
+        HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE);
 
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
@@ -287,7 +336,7 @@ public class TestRunner {
     @Test
     public void testUserCannotDownloadOtherUsersJob() throws IOException, InterruptedException, JSONException {
         String contractNumber = "S0000";
-        HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber);
+        HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber, FHIR_TYPE);
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
@@ -301,7 +350,7 @@ public class TestRunner {
 
     @Test
     public void testUserCannotDeleteOtherUsersJob() throws IOException, InterruptedException, JSONException {
-        HttpResponse<String> exportResponse = apiClient.exportRequest();
+        HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE);
 
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
@@ -320,7 +369,7 @@ public class TestRunner {
 
     @Test
     public void testUserCannotCheckStatusOtherUsersJob() throws IOException, InterruptedException, JSONException {
-        HttpResponse<String> exportResponse = apiClient.exportRequest();
+        HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE);
 
         Assert.assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");

--- a/load-test/src/main/java/gov/cms/ab2d/loadtest/TestRunner.java
+++ b/load-test/src/main/java/gov/cms/ab2d/loadtest/TestRunner.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CountDownLatch;
 
 @Slf4j
 public class TestRunner extends AbstractJavaSamplerClient {
+    private static String FHIR_TYPE = "application/fhir+ndjson";
 
     private String[] contractArr;
 
@@ -111,7 +112,7 @@ public class TestRunner extends AbstractJavaSamplerClient {
             exportResult.sampleStart();
 
             try {
-                HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber);
+                HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contractNumber, FHIR_TYPE);
 
                 exportResult.sampleEnd();
                 exportResult.setResponseCode(String.valueOf(exportResponse.statusCode()));

--- a/load-test/src/main/java/gov/cms/ab2d/loadtest/TestRunner.java
+++ b/load-test/src/main/java/gov/cms/ab2d/loadtest/TestRunner.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CountDownLatch;
 
 @Slf4j
 public class TestRunner extends AbstractJavaSamplerClient {
-    private static String FHIR_TYPE = "application/fhir+ndjson";
+    private static final String FHIR_TYPE = "application/fhir+ndjson";
 
     private String[] contractArr;
 

--- a/website/hidden/sandbox/windows-tutorial.md
+++ b/website/hidden/sandbox/windows-tutorial.md
@@ -10,7 +10,7 @@ sections:
   - Overview
   - Setup Windows Linux Subsystem
   - Authentication and Authorization
-  - User the API
+  - Use the API
 ctas:
 
 ---


### PR DESCRIPTION
### Summary
Required an output type to be passed to the export endpoints where it could be ndjson or zip. The zip test makes sure a zip file is created and when downloaded, the contents look exactly like the contents of the ndjson.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and linting pass
- [ ] Code checked for PHI/PII exposure
