### PR TITLE
ab2d 1105 add contract2bene cache toggle switch

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -83,6 +83,7 @@ public class AdminAPIPropertiesTests {
             put(PCP_MAX_POOL_SIZE, 150);
             put(PCP_SCALE_TO_MAX_TIME, 900);
             put(MAINTENANCE_MODE, "false");
+            put(CONTRACT_2_BENE_CACHING_ON, "false");
         }};
 
         MvcResult mvcResult = this.mockMvc.perform(
@@ -97,7 +98,7 @@ public class AdminAPIPropertiesTests {
         ObjectMapper mapper = new ObjectMapper();
         List<PropertiesDTO> propertiesDTOs = mapper.readValue(result, new TypeReference<List<PropertiesDTO>>() { } );
 
-        Assert.assertEquals(4, propertiesDTOs.size());
+        Assert.assertEquals(5, propertiesDTOs.size());
         for(PropertiesDTO propertiesDTO : propertiesDTOs) {
             Object value = propertyMap.get(propertiesDTO.getKey());
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/PropertiesService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PropertiesService.java
@@ -14,4 +14,6 @@ public interface PropertiesService {
     Properties getPropertiesByKey(String key);
 
     List<PropertiesDTO> updateProperties(List<PropertiesDTO> propertiesDTOs);
+
+    boolean isToggleOn(String toggleName);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
@@ -89,6 +89,12 @@ public class PropertiesServiceImpl implements PropertiesService {
                 }
 
                 addUpdatedPropertiesToList(propertiesDTOsReturn, propertiesDTO);
+            } else if (propertiesDTO.getKey().equals(CONTRACT_2_BENE_CACHING_ON)) {
+                if (!propertiesDTO.getValue().equals("true") && !propertiesDTO.getValue().equals("false")) {
+                    logErrorAndThrowException(CONTRACT_2_BENE_CACHING_ON, propertiesDTO.getValue());
+                }
+
+                addUpdatedPropertiesToList(propertiesDTOsReturn, propertiesDTO);
             }
         }
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.model.Properties;
 import gov.cms.ab2d.common.repository.PropertiesRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static gov.cms.ab2d.common.util.Constants.*;
+import static java.lang.Boolean.FALSE;
 
 @Service
 @Transactional
@@ -100,5 +102,15 @@ public class PropertiesServiceImpl implements PropertiesService {
     private void logErrorAndThrowException(String propertyKey, Object propertyValue) {
         log.error("Incorrect value for {} of {}", propertyKey, propertyValue);
         throw new InvalidPropertiesException("Incorrect value for " + propertyKey + " of " + propertyValue);
+    }
+
+
+    public boolean isToggleOn(final String toggleName) {
+        return propertiesRepository.findByKey(toggleName)
+                .map(Properties::getValue)
+                .map(StringUtils::trim)
+                .map(Boolean::valueOf)
+                .orElse(FALSE)
+                .booleanValue();
     }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -41,6 +41,8 @@ public final class Constants {
 
     public static final String MAINTENANCE_MODE = "maintenance.mode";
 
+    public static final String CONTRACT_2_BENE_CACHING_ON = "ContractToBeneCachingOn";
+
     public static final Set<String> ALLOWED_PROPERTY_NAMES = Set.of(PCP_CORE_POOL_SIZE, PCP_MAX_POOL_SIZE,
-            PCP_SCALE_TO_MAX_TIME, MAINTENANCE_MODE);
+            PCP_SCALE_TO_MAX_TIME, MAINTENANCE_MODE, CONTRACT_2_BENE_CACHING_ON);
 }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -34,3 +34,5 @@ databaseChangeLog:
       file: db/changelog/v001/modify_hpms_ids.sql
   - include:
       file: db/changelog/v001/add_maintenance_mode_property.sql
+  - include:
+      file: db/changelog/v001/add_contract2beneCache_toggle_property.sql

--- a/common/src/main/resources/db/changelog/v001/add_contract2beneCache_toggle_property.sql
+++ b/common/src/main/resources/db/changelog/v001/add_contract2beneCache_toggle_property.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+
+--changeset spathiyil:add_contract2benecache_toggle_in_property_table failOnError:true
+INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'ContractToBeneCachingOn', 'false');
+
+
+--rollback DELETE FROM properties WHERE key = 'ContractToBeneCachingOn';
+

--- a/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
@@ -92,9 +92,14 @@ public class PropertiesServiceTest {
         propertiesDTOMaintenanceMode.setValue("true");
         propertiesDTOs.add(propertiesDTOMaintenanceMode);
 
+        PropertiesDTO propertiesDTOContract2BeneCachineOn = new PropertiesDTO();
+        propertiesDTOContract2BeneCachineOn.setKey(CONTRACT_2_BENE_CACHING_ON);
+        propertiesDTOContract2BeneCachineOn.setValue("true");
+        propertiesDTOs.add(propertiesDTOContract2BeneCachineOn);
+
         List<PropertiesDTO> updatedPropertiesDTOs = propertiesService.updateProperties(propertiesDTOs);
 
-        Assert.assertEquals(4, updatedPropertiesDTOs.size());
+        Assert.assertEquals(5, updatedPropertiesDTOs.size());
 
         for(PropertiesDTO propertiesDTO : updatedPropertiesDTOs) {
             if(propertiesDTO.getKey().equals(PCP_CORE_POOL_SIZE)) {
@@ -104,6 +109,8 @@ public class PropertiesServiceTest {
             } else if (propertiesDTO.getKey().equals(PCP_SCALE_TO_MAX_TIME)) {
                 Assert.assertEquals("400", propertiesDTO.getValue());
             } else if (propertiesDTO.getKey().equals(MAINTENANCE_MODE)) {
+                Assert.assertEquals("true", propertiesDTO.getValue());
+            } else if (propertiesDTO.getKey().equals(CONTRACT_2_BENE_CACHING_ON)) {
                 Assert.assertEquals("true", propertiesDTO.getValue());
             } else {
                 Assert.fail("Received unknown key");

--- a/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
@@ -46,8 +46,11 @@ public class PropertiesServiceTest {
             put(PCP_MAX_POOL_SIZE, 150);
             put(PCP_SCALE_TO_MAX_TIME, 900);
             put(MAINTENANCE_MODE, "false");
+            put(CONTRACT_2_BENE_CACHING_ON, "false");
         }};
 
+        List<Properties> propertyListBeforeInsert = propertiesService.getAllProperties();
+        int beforeCount = propertyListBeforeInsert.size();
         Properties properties = new Properties();
         properties.setKey("abc");
         properties.setValue("val");
@@ -56,7 +59,7 @@ public class PropertiesServiceTest {
 
         List<Properties> propertiesList = propertiesService.getAllProperties();
 
-        Assert.assertEquals(propertiesList.size(), 5);
+        Assert.assertEquals(propertiesList.size(), beforeCount + 1);
 
         for(Properties propertiesToCheck : propertiesList) {
             Object propertyValue = propertyMap.get(propertiesToCheck.getKey());

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static gov.cms.ab2d.common.util.Constants.CONTRACT_2_BENE_CACHING_ON;
+
 
 @Slf4j
 //@Primary // - once the BFD API starts returning data, change this to primary bean so spring injects this instead of the stub.
@@ -68,7 +70,7 @@ public class ContractAdapterImpl implements ContractAdapter {
     }
 
     private boolean isContractToBeneCachingOn() {
-        return propertiesService.isToggleOn("ContractToBeneCachingOn");
+        return propertiesService.isToggleOn(CONTRACT_2_BENE_CACHING_ON);
     }
 
     private Set<String> getPatientsForMonth(String contractNumber, Contract contract, int month, boolean cachingOn) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -2,9 +2,8 @@ package gov.cms.ab2d.worker.adapter.bluebutton;
 
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
-import gov.cms.ab2d.common.model.Properties;
 import gov.cms.ab2d.common.repository.ContractRepository;
-import gov.cms.ab2d.common.repository.PropertiesRepository;
+import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.filter.FilterOutByDate;
 import gov.cms.ab2d.filter.FilterOutByDate.DateRange;
 import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse.PatientDTO;
@@ -43,7 +42,7 @@ public class ContractAdapterImpl implements ContractAdapter {
     private final BFDClient bfdClient;
     private final ContractRepository contractRepo;
     private final BeneficiaryService beneficiaryService;
-    private final PropertiesRepository propertiesRepo;
+    private final PropertiesService propertiesService;
 
 
     @Override
@@ -51,7 +50,7 @@ public class ContractAdapterImpl implements ContractAdapter {
 
         var patientDTOs = new ArrayList<PatientDTO>();
 
-        final boolean cachingOn = getCachingToggle();
+        final boolean cachingOn = isContractToBeneCachingOn();
 
         var contract = contractRepo.findContractByContractNumber(contractNumber).get();
 
@@ -68,13 +67,8 @@ public class ContractAdapterImpl implements ContractAdapter {
         return toGetPatientsByContractResponse(contractNumber, patientDTOs);
     }
 
-    private boolean getCachingToggle() {
-        return propertiesRepo.findByKey("ContractToBeneCachingOn")
-                .map(Properties::getValue)
-                .map(StringUtils::trim)
-                .map(Boolean::valueOf)
-                .orElse(Boolean.FALSE)
-                .booleanValue();
+    private boolean isContractToBeneCachingOn() {
+        return propertiesService.isToggleOn("ContractToBeneCachingOn");
     }
 
     private Set<String> getPatientsForMonth(String contractNumber, Contract contract, int month, boolean cachingOn) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterImpl.java
@@ -71,6 +71,7 @@ public class ContractAdapterImpl implements ContractAdapter {
     private boolean getCachingToggle() {
         return propertiesRepo.findByKey("ContractToBeneCachingOn")
                 .map(Properties::getValue)
+                .map(StringUtils::trim)
                 .map(Boolean::valueOf)
                 .orElse(Boolean.FALSE)
                 .booleanValue();

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -22,7 +22,6 @@ failure.threshold=1
 
 
 ## ---------------------------------------------------------------------------- CONTRACT-2-BENE CONFIG
-contract2bene.caching.on=true
 contract2bene.caching.threshold=1000
 
 ## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -20,13 +20,16 @@ report.progress.log.frequency=10000
 ## fail the job if >= 1% of the records fail
 failure.threshold=1
 
+
+## ---------------------------------------------------------------------------- CONTRACT-2-BENE CONFIG
+contract2bene.caching.on=true
 contract2bene.caching.threshold=1000
 
 ## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG
 ## These properties apply to "patientProcessorThreadPool".
 pcp.queue.capacity=${AB2D_PCP_QUEUE_CAPACITY:#{150}}
 
-## ---------------------------------------------------------------------------- MAIN JOB PROCESSOR THREAD-POOL CONFIG
+## ---------------------------------------------------------------------------- JOB PROCESSOR THREAD-POOL CONFIG
 ## These properties apply to "mainJobProcessingPool".
 job.core.pool.size=${AB2D_JOB_POOL_CORE_SIZE:#{5}}
 job.max.pool.size=${AB2D_JOB_POOL_MAX_SIZE:#{10}}

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.repository.PropertiesRepository;
 import gov.cms.ab2d.worker.service.BeneficiaryService;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
@@ -44,6 +45,7 @@ class ContractAdapterTest {
     @Mock BFDClient client;
     @Mock ContractRepository contractRepository;
     @Mock BeneficiaryService beneficiaryService;
+    @Mock PropertiesRepository propertiesRepository;
 
     private ContractAdapter cut;
     private String contractNumber = "S0000";
@@ -53,7 +55,12 @@ class ContractAdapterTest {
 
     @BeforeEach
     void setUp() {
-        cut = new ContractAdapterImpl(client, contractRepository, beneficiaryService);
+        cut = new ContractAdapterImpl(
+                client,
+                contractRepository,
+                beneficiaryService,
+                propertiesRepository
+        );
 
         bundle = createBundle();
         lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterTest.java
@@ -292,6 +292,7 @@ class ContractAdapterTest {
     @Test
     @DisplayName("given patientid rows in db for a specific contract & month, should not call BFD contract-2-bene api")
     void GivenPatientInLocalDb_ShouldNotCallBfdContractToBeneAPI() {
+        ReflectionTestUtils.setField(cut, "cachingOn", true);
         when(beneficiaryService.findPatientIdsInDb(anyLong(), anyInt())).thenReturn(Set.of("ccw_patient_005"));
         cut.getPatients(contractNumber, Month.JANUARY.getValue());
 
@@ -310,6 +311,7 @@ class ContractAdapterTest {
         entries.add(createBundleEntry("ccw_patient_004"));
         entries.add(createBundleEntry("ccw_patient_005"));
 
+        ReflectionTestUtils.setField(cut, "cachingOn", true);
         ReflectionTestUtils.setField(cut, "cachingThreshold", 2);
         cut.getPatients(contractNumber, Month.JANUARY.getValue());
 

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -26,7 +26,6 @@ report.progress.log.frequency=10
 failure.threshold=10
 
 ## ---------------------------------------------------------------------------- CONTRACT-2-BENE CONFIG
-contract2bene.caching.on=true
 contract2bene.caching.threshold=10
 
 ## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -1,20 +1,20 @@
-## -------------------------------------------------------------------------------------------  DATA-SOURCE CONFIG
+## ----------------------------------------------------------------------------  DATA-SOURCE CONFIG
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-## ---------------------------------------------------------------------------------------------------  JPA CONFIG
+## ----------------------------------------------------------------------------  JPA CONFIG
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 
-## ------------------------------------------------------------------------------------  SPRING INTEGRATION CONFIG
+## ----------------------------------------------------------------------------  SPRING INTEGRATION CONFIG
 spring.integration.jdbc.initialize-schema=always
 
 spring.liquibase.enabled=true
 
-## --------------------------------------------------------------------------------------------------  MISC CONFIG
+## ----------------------------------------------------------------------------  MISC CONFIG
 efs.mount=${java.io.tmpdir}/jobdownloads/
 
 file.try.lock.timeout=30
@@ -25,24 +25,26 @@ report.progress.log.frequency=10
 ## fail the job if >= 10% of the records fail
 failure.threshold=10
 
+## ---------------------------------------------------------------------------- CONTRACT-2-BENE CONFIG
+contract2bene.caching.on=true
 contract2bene.caching.threshold=10
 
-## ---------------------------------------------------------------------------------------  PCP THREAD-POOL CONFIG
+## ---------------------------------------------------------------------------- PCP THREAD-POOL CONFIG
 # Changing these WILL break AutoScalingServiceTest!
 pcp.queue.capacity=25
 
-## ----------------------------------------------------------------------------- MAIN JOB PROCESSOR THREAD-POOL CONFIG
+## ----------------------------------------------------------------------------- JOB PROCESSOR THREAD-POOL CONFIG
 ## These properties apply to "mainJobProcessingPool".
 job.core.pool.size=5
 job.max.pool.size=10
 job.queue.capacity=0
 
-## ---------------------------------------------------------------------------------------------------   STUCK JOB
+## ----------------------------------------------------------------------------- STUCK JOB
 ## -- run every 2 hours
 stuck.job.cron.schedule=0 0 0/2 * * ?
 stuck.job.cancel.threshold=6
 
-## ------------------------------------------------------------------------------------------------  LOGGING LEVEL
+## ----------------------------------------------------------------------------- LOGGING LEVEL
 logging.level.root=WARN
 logging.level.gov.cms.ab2d=INFO
 logging.level.org.springframework=WARN


### PR DESCRIPTION
ab2d 1105 add contract2bene  cache toggle switch

### Summary

Add contract2bene cache toggle switch to turn caching on or off. 
It looks for a toggle named `ContractToBeneCachingOn` in the properties table with the value `true`


### Checklist

- [x] Tests and linting pass

### Security
N/A

### Additional JIRA Tickets (optional)

N/A