### PR TITLE
AB2D 1190 refactor JobProcessor - extract ContractProcessor

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
@@ -1,0 +1,15 @@
+package gov.cms.ab2d.worker.processor;
+
+import gov.cms.ab2d.common.model.JobOutput;
+import gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.util.List;
+
+public interface ContractProcessor {
+
+    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType contractType)
+            throws FileNotFoundException;
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface ContractProcessor {
 
-    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType contractType);
+    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType outputType);
 
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
@@ -4,12 +4,11 @@ import gov.cms.ab2d.common.model.JobOutput;
 import gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.List;
 
 public interface ContractProcessor {
 
-    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType contractType)
-            throws FileNotFoundException;
+    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType contractType);
+
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -42,6 +42,7 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.TooManyStaticImports")
 public class ContractProcessorImpl implements ContractProcessor {
     private static final int SLEEP_DURATION = 250;
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -103,7 +103,7 @@ public class ContractProcessorImpl implements ContractProcessor {
                     continue;
                 }
 
-                futureHandles.add(processPatient(contractData, helper, patient));
+                futureHandles.add(processPatient(patient, contractData, helper));
 
                 // Periodically check if cancelled
                 if (recordsProcessedCount % cancellationCheckFrequency == 0) {
@@ -119,7 +119,7 @@ public class ContractProcessorImpl implements ContractProcessor {
                     processHandles(futureHandles, progressTracker);
                 }
             }
-            awaitTermination(progressTracker, futureHandles);
+            awaitTermination(futureHandles, progressTracker);
 
         } finally {
             close(helper);
@@ -145,10 +145,10 @@ public class ContractProcessorImpl implements ContractProcessor {
 
     /**
      * While there are still patient records in progress, sleep for a bit and check progress
-     * @param progressTracker
      * @param futureHandles
+     * @param progressTracker
      */
-    private void awaitTermination(ProgressTracker progressTracker, ArrayList<Future<Void>> futureHandles) {
+    private void awaitTermination(ArrayList<Future<Void>> futureHandles, ProgressTracker progressTracker) {
         while (!futureHandles.isEmpty()) {
             sleep();
             processHandles(futureHandles, progressTracker);
@@ -179,12 +179,12 @@ public class ContractProcessorImpl implements ContractProcessor {
      * On using new-relic tokens with async calls
      * See https://docs.newrelic.com/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
      *
+     * @param patient
      * @param contractData
      * @param helper
-     * @param patient
      * @return a Future<Void>
      */
-    private Future<Void> processPatient(ContractData contractData, StreamHelper helper, PatientDTO patient) {
+    private Future<Void> processPatient(PatientDTO patient, ContractData contractData, StreamHelper helper) {
         final Token token = NewRelic.getAgent().getTransaction().getToken();
 
         // Using a ThreadLocal to communicate contract number to RoundRobinBlockingQueue

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -1,0 +1,392 @@
+package gov.cms.ab2d.worker.processor;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Token;
+import gov.cms.ab2d.common.model.JobOutput;
+import gov.cms.ab2d.common.model.JobStatus;
+import gov.cms.ab2d.common.model.OptOut;
+import gov.cms.ab2d.common.repository.JobRepository;
+import gov.cms.ab2d.common.repository.OptOutRepository;
+import gov.cms.ab2d.common.util.Constants;
+import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse;
+import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse.PatientDTO;
+import gov.cms.ab2d.worker.config.RoundRobinBlockingQueue;
+import gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
+import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
+import gov.cms.ab2d.worker.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static gov.cms.ab2d.common.model.JobStatus.CANCELLED;
+import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
+import static gov.cms.ab2d.common.util.Constants.EOB;
+import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.ZIP;
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContractProcessorImpl implements ContractProcessor {
+    private static final int SLEEP_DURATION = 250;
+
+    @Value("${job.file.rollover.ndjson:200}")
+    private long ndjsonRollOver;
+
+    @Value("${job.file.rollover.zip:200}")
+    private long zipRollOver;
+
+    @Value("${cancellation.check.frequency:10}")
+    private int cancellationCheckFrequency;
+
+    @Value("${report.progress.db.frequency:100}")
+    private int reportProgressDbFrequency;
+
+    @Value("${report.progress.log.frequency:100}")
+    private int reportProgressLogFrequency;
+
+    @Value("${file.try.lock.timeout}")
+    private int tryLockTimeout;
+
+
+    private final FileService fileService;
+    private final JobRepository jobRepository;
+    private final PatientClaimsProcessor patientClaimsProcessor;
+    private final OptOutRepository optOutRepository;
+
+
+    /**
+     * Process the contract - retrieve all the patients for the contract and create a thread in the
+     * patientProcessorThreadPool to handle searching for EOBs for each patient. Periodically check to
+     * see if the job is cancelled and cancel the threads if necessary, otherwise, wait until all threads
+     * have processed.
+     *
+     * @param contractData - the contract data (contract, progress tracker, attested time, writer)
+     * @return - the job output records containing the file information
+     */
+    public List<JobOutput> process(Path outputDirPath, ContractData contractData,
+                                            FileOutputType contractType) throws FileNotFoundException {
+        var contract = contractData.getContract();
+        log.info("Beginning to process contract {}", keyValue(CONTRACT_LOG, contract.getContractName()));
+
+        var contractNumber = contract.getContractNumber();
+
+        var progressTracker = contractData.getProgressTracker();
+
+        var patientsByContract = getPatientsByContract(contractNumber, progressTracker);
+        var patients = patientsByContract.getPatients();
+        int patientCount = patients.size();
+        log.info("Contract [{}] has [{}] Patients", contractNumber, patientCount);
+
+        boolean isCancelled = false;
+
+        StreamHelper helper = null;
+        try {
+            if (contractType == ZIP) {
+                helper = new ZipStreamHelperImpl(outputDirPath, contractNumber, getZipRolloverThreshold(), getRollOverThreshold(), tryLockTimeout);
+            } else {
+                helper = new TextStreamHelperImpl(outputDirPath, contractNumber, getRollOverThreshold(), tryLockTimeout);
+            }
+            int recordsProcessedCount = 0;
+            var futureHandles = new ArrayList<Future<Void>>();
+            for (PatientDTO patient : patients) {
+                ++recordsProcessedCount;
+
+                final String patientId = patient.getPatientId();
+
+                if (isOptOutPatient(patientId)) {
+                    // this patient has opted out. skip patient record.
+                    continue;
+                }
+
+                // Add the thread to process the patient and start the thread
+
+                // See https://docs.newrelic.com/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
+                // for more detail on tokens with async calls
+                final Token token = NewRelic.getAgent().getTransaction().getToken();
+
+                // Using a ThreadLocal to communicate contract number to RoundRobinBlockingQueue
+                // could be viewed as a hack by many; but on the other hand it saves us from writing
+                // tons of extra code.
+                RoundRobinBlockingQueue.CATEGORY_HOLDER.set(progressTracker.getJobUuid());
+                try {
+                    futureHandles.add(patientClaimsProcessor
+                            .process(patient, helper, contract.getAttestedOn(), contractData.getSinceTime(), token));
+                } finally {
+                    RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();
+                }
+
+                // Periodically check if cancelled
+                if (recordsProcessedCount % cancellationCheckFrequency == 0) {
+
+                    var jobUuid = contractData.getProgressTracker().getJobUuid();
+                    isCancelled = hasJobBeenCancelled(jobUuid);
+                    if (isCancelled) {
+                        log.warn("Job [{}] has been cancelled. Attempting to stop processing the job shortly ... ", jobUuid);
+                        cancelFuturesInQueue(futureHandles);
+                        break;
+                    }
+
+                    processHandles(futureHandles, progressTracker);
+                }
+            }
+
+            // While there are still patients not being processed, sleep for a bit and check progress
+            while (!futureHandles.isEmpty()) {
+                sleep();
+                processHandles(futureHandles, progressTracker);
+            }
+
+            if (isCancelled) {
+                final String errMsg = "Job was cancelled while it was being processed";
+                log.warn("{}", errMsg);
+                throw new JobCancelledException(errMsg);
+            }
+        } finally {
+            if (helper != null) {
+                try {
+                    helper.close();
+                } catch (Exception ex) {
+                    log.error("Unable to close the helper", ex);
+                }
+            }
+        }
+        // All jobs are done, return the job output records
+        return createJobOutputs(helper.getDataFiles(), helper.getErrorFiles());
+    }
+
+    /**
+     * Retrieve the patients by contract
+     *
+     * @param contractNumber - the contract number
+     * @param progressTracker - the progress tracker for all contracts and patients for the job
+     * @return the contract's patients
+     */
+    private GetPatientsByContractResponse getPatientsByContract(String contractNumber, ProgressTracker progressTracker) {
+        return progressTracker.getPatientsByContracts()
+                .stream()
+                .filter(byContract -> byContract.getContractNumber().equals(contractNumber))
+                .findFirst()
+                .orElse(null);
+    }
+
+
+    /**
+     * Return the number of bytes when to rollover given the number of megabytes in a zip file if used
+     *
+     * @return the number of bytes
+     */
+    private long getZipRolloverThreshold() {
+        return zipRollOver * Constants.ONE_MEGA_BYTE;
+    }
+
+    /**
+     * Return the number of bytes when to rollover given the number of megabytes
+     *
+     * @return the number of bytes
+     */
+    private long getRollOverThreshold() {
+        return ndjsonRollOver * Constants.ONE_MEGA_BYTE;
+    }
+
+    /**
+     * Check the opt out repository to see if a patient has opted out of data services
+     *
+     * @param patientId - the patient id
+     * @return true if the patient has opted out
+     */
+    private boolean isOptOutPatient(String patientId) {
+
+        final List<OptOut> optOuts = optOutRepository.findByCcwId(patientId);
+        if (optOuts.isEmpty()) {
+            // No opt-out record found for this patient - Opt-In by default.
+            return false;
+        }
+
+        // opt-out record has an effective date.
+        // if any of the opt-out records for a patient is effective as of today or earlier, the patient has opted-out
+        final LocalDate tomorrow = LocalDate.now().plusDays(1);
+        return optOuts.stream()
+                .anyMatch(optOut -> optOut.getEffectiveDate().isBefore(tomorrow));
+    }
+
+    /**
+     * Cancel threads
+     *
+     * @param futureHandles - the running threads
+     */
+    private void cancelFuturesInQueue(List<Future<Void>> futureHandles) {
+
+        // cancel any futures that have not started processing and are waiting in the queue.
+        futureHandles.parallelStream().forEach(future -> future.cancel(false));
+
+        //At this point, there may be a few futures that are already in progress.
+        //But all the futures that are not yet in progress would be cancelled.
+    }
+
+    /**
+     * A Job could run for a long time, perhaps hours. An in process job can be cancelled. Here
+     * we search for the job and determine if the status has been changed to cancel. This is checked
+     * periodically while processing the job.
+     *
+     * @param jobUuid - the job id
+     * @return true if the job is cancelled
+     */
+    private boolean hasJobBeenCancelled(String jobUuid) {
+        final JobStatus jobStatus = jobRepository.findJobStatus(jobUuid);
+        return CANCELLED.equals(jobStatus);
+    }
+
+
+    /**
+     * For each future, check to see if it's done. If it is, remove it from the list of future handles
+     * and increment the number processed
+     *
+     * @param futureHandles - the thread futures
+     * @param progressTracker - the tracker with updated tracker information
+     */
+    private void processHandles(List<Future<Void>> futureHandles, ProgressTracker progressTracker) {
+        var iterator = futureHandles.iterator();
+        while (iterator.hasNext()) {
+            var future = iterator.next();
+            if (future.isDone()) {
+                processFuture(futureHandles, progressTracker, future);
+                iterator.remove();
+            }
+        }
+
+        // update the progress in the DB & logs periodically
+        trackProgress(progressTracker);
+    }
+
+    /**
+     * process the future that is marked as done.
+     * On doing a get(), if an exception is thrown, analyze it to decide whether to stop the batch or not.
+     * @param futureHandles - List of Futures
+     * @param progressTracker - progress tracker instance
+     * @param future - a specific future
+     */
+    private void processFuture(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Future<Void> future) {
+        progressTracker.incrementProcessedCount();
+        try {
+            future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            analyzeException(futureHandles, progressTracker, e);
+
+        } catch (CancellationException e) {
+            // This could happen in the rare event that a job was cancelled mid-process.
+            // due to which the futures in the queue (that were not yet in progress) were cancelled.
+            // Nothing to be done here
+            log.warn("CancellationException while calling Future.get() - Job may have been cancelled");
+        }
+    }
+
+    private void analyzeException(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Exception e) {
+        progressTracker.incrementFailureCount();
+
+        if (progressTracker.isErrorCountBelowThreshold()) {
+            final Throwable rootCause = ExceptionUtils.getRootCause(e);
+            log.error("exception while processing patient {}", rootCause.getMessage(), rootCause);
+            // log exception, but continue processing job as errorCount is below threshold
+        } else {
+            cancelFuturesInQueue(futureHandles);
+            log.error("{} out of {} records failed. Stopping job", progressTracker.getFailureCount(), progressTracker.getTotalCount());
+            throw new RuntimeException("Too many patient records in the job had failures");
+        }
+    }
+
+    /**
+     * Update the database or log with the % complete on the job periodically
+     *
+     * @param progressTracker - the progress tracker
+     */
+
+    private void trackProgress(ProgressTracker progressTracker) {
+        if (progressTracker.isTimeToUpdateDatabase(reportProgressDbFrequency)) {
+            final int percentageCompleted = progressTracker.getPercentageCompleted();
+
+            if (percentageCompleted > progressTracker.getLastUpdatedPercentage()) {
+                jobRepository.updatePercentageCompleted(progressTracker.getJobUuid(), percentageCompleted);
+                progressTracker.setLastUpdatedPercentage(percentageCompleted);
+            }
+        }
+
+        var processedCount = progressTracker.getProcessedCount();
+        if (progressTracker.isTimeToLog(reportProgressLogFrequency)) {
+            progressTracker.setLastLogUpdateCount(processedCount);
+
+            var totalCount = progressTracker.getTotalCount();
+            var percentageCompleted = progressTracker.getPercentageCompleted();
+            log.info("[{}/{}] records processed = [{}% completed]", processedCount, totalCount, percentageCompleted);
+        }
+    }
+
+    /**
+     * Once the job writer is finished, create a list of job output objects with
+     * the data files and the error files
+     *
+     * @param dataFiles - the results of writing the contract
+     * @param errorFiles - any errors that arose due to writing the contract
+     * @return the list of job output objects
+     */
+    private List<JobOutput> createJobOutputs(List<Path> dataFiles, List<Path> errorFiles) {
+
+        // create Job Output records for data files from the job writer
+        final List<JobOutput> jobOutputs = dataFiles.stream()
+                .map(dataFile -> createJobOutput(dataFile, false)).collect(Collectors.toList());
+
+        // create Job Output record for error file
+        final List<JobOutput> errorJobOutputs = errorFiles.stream()
+                .map(errorFile -> createJobOutput(errorFile, true))
+                .collect(Collectors.toList());
+        jobOutputs.addAll(errorJobOutputs);
+
+        if (jobOutputs.isEmpty()) {
+            var errMsg = "The export process has produced no results";
+            throw new RuntimeException(errMsg);
+        }
+
+        return jobOutputs;
+    }
+
+    /**
+     * From a file, return the JobOutput object
+     *
+     * @param outputFile - the output file from the job
+     * @param isError - if there was an error
+     * @return - the joub output object
+     */
+    private JobOutput createJobOutput(Path outputFile, boolean isError) {
+        JobOutput jobOutput = new JobOutput();
+        jobOutput.setFilePath(outputFile.getFileName().toString());
+        jobOutput.setFhirResourceType(EOB);
+        jobOutput.setError(isError);
+        jobOutput.setChecksum(fileService.generateChecksum(outputFile.toFile()));
+        jobOutput.setFileLength(outputFile.toFile().length());
+        return jobOutput;
+    }
+
+    /**
+     * Tell the thread to sleep
+     */
+    private void sleep() {
+        try {
+            Thread.sleep(SLEEP_DURATION);
+        } catch (InterruptedException e) {
+            log.warn("interrupted exception in thread.sleep(). Ignoring");
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -107,11 +107,9 @@ public class ContractProcessorImpl implements ContractProcessor {
 
                 // Periodically check if cancelled
                 if (recordsProcessedCount % cancellationCheckFrequency == 0) {
-
-                    var jobUuid = contractData.getProgressTracker().getJobUuid();
-                    isCancelled = hasJobBeenCancelled(jobUuid);
+                    isCancelled = hasJobBeenCancelled(progressTracker.getJobUuid());
                     if (isCancelled) {
-                        log.warn("Job [{}] has been cancelled. Attempting to stop processing the job shortly ... ", jobUuid);
+                        log.warn("Job [{}] has been cancelled. Attempting to stop processing the job shortly ... ", progressTracker.getJobUuid());
                         cancelFuturesInQueue(futureHandles);
                         break;
                     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -2,29 +2,21 @@ package gov.cms.ab2d.worker.processor;
 
 import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.Segment;
-import com.newrelic.api.agent.Token;
 import com.newrelic.api.agent.Trace;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.Job;
-import gov.cms.ab2d.common.model.JobOutput;
 import gov.cms.ab2d.common.model.JobStatus;
-import gov.cms.ab2d.common.model.OptOut;
 import gov.cms.ab2d.common.model.Sponsor;
 import gov.cms.ab2d.common.repository.JobOutputRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
-import gov.cms.ab2d.common.repository.OptOutRepository;
-import gov.cms.ab2d.common.util.Constants;
 import gov.cms.ab2d.worker.adapter.bluebutton.ContractAdapter;
 import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse;
-import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse.PatientDTO;
-import gov.cms.ab2d.worker.config.RoundRobinBlockingQueue;
 import gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
 import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
 import gov.cms.ab2d.worker.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -40,51 +32,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import static gov.cms.ab2d.common.model.JobStatus.CANCELLED;
 import static gov.cms.ab2d.common.model.JobStatus.SUCCESSFUL;
 import static gov.cms.ab2d.common.service.JobServiceImpl.ZIPFORMAT;
-import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
-import static gov.cms.ab2d.common.util.Constants.EOB;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.ZIP;
-import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@SuppressWarnings("PMD.TooManyStaticImports")
 public class JobProcessorImpl implements JobProcessor {
-    private static final int SLEEP_DURATION = 250;
-
-    @Value("${job.file.rollover.ndjson:200}")
-    private long ndjsonRollOver;
-
-    @Value("${job.file.rollover.zip:200}")
-    private long zipRollOver;
-
-    @Value("${cancellation.check.frequency:10}")
-    private int cancellationCheckFrequency;
-
-    @Value("${report.progress.db.frequency:100}")
-    private int reportProgressDbFrequency;
-
-    @Value("${report.progress.log.frequency:100}")
-    private int reportProgressLogFrequency;
-
-    @Value("${file.try.lock.timeout}")
-    private int tryLockTimeout;
-
-    /** Failure threshold an integer expressed as a percentage of failure tolerated in a batch **/
-    @Value("${failure.threshold}")
-    private int failureThreshold;
 
     @Value("${efs.mount}")
     private String efsMount;
@@ -92,12 +52,15 @@ public class JobProcessorImpl implements JobProcessor {
     @Value("${audit.files.ttl.hours}")
     private int auditFilesTTLHours;
 
+    /** Failure threshold an integer expressed as a percentage of failure tolerated in a batch **/
+    @Value("${failure.threshold}")
+    private int failureThreshold;
+
     private final FileService fileService;
     private final JobRepository jobRepository;
     private final JobOutputRepository jobOutputRepository;
     private final ContractAdapter contractAdapter;
-    private final PatientClaimsProcessor patientClaimsProcessor;
-    private final OptOutRepository optOutRepository;
+    private final ContractProcessor contractProcessor;
 
     /**
      * Load the job and process it
@@ -145,8 +108,8 @@ public class JobProcessorImpl implements JobProcessor {
      * @param outputDirPath - the output directory to put all the files
      */
     private void processJob(Job job, Path outputDirPath) throws FileNotFoundException {
-        // Get the output directory
-        var outputDir = createOutputDirectory(outputDirPath);
+        // Create the output directory
+        createOutputDirectory(outputDirPath);
 
         // Get all attested contracts for that job (or the one specified in the job)
         var attestedContracts = getAttestedContracts(job);
@@ -167,13 +130,13 @@ public class JobProcessorImpl implements JobProcessor {
             // Create a holder for the contract, writer, progress tracker and attested date
             var contractData = new ContractData(contract, progressTracker, contract.getAttestedOn(), job.getSince());
 
-            /*** process contract ***/
             final Segment contractSegment = NewRelic.getAgent().getTransaction().startSegment("Patient processing of contract " + contract.getContractNumber());
-            var jobOutputs = processContract(outputDirPath, contractData, outputType);
+
+            var jobOutputs = contractProcessor.process(outputDirPath, contractData, outputType);
             contractSegment.end();
 
             // For each job output, add to the job and save the result
-            jobOutputs.forEach(jobOutput -> job.addJobOutput(jobOutput));
+            jobOutputs.forEach(job::addJobOutput);
             jobOutputRepository.saveAll(jobOutputs);
         }
 
@@ -286,7 +249,6 @@ public class JobProcessorImpl implements JobProcessor {
         return attestedContracts;
     }
 
-
     /**
      * Creates a ProgressTracker for the list of all patients in all contracts
      *
@@ -317,316 +279,6 @@ public class JobProcessorImpl implements JobProcessor {
     }
 
     /**
-     * Return the number of bytes when to rollover given the number of megabytes in a zip file if used
-     *
-     * @return the number of bytes
-     */
-    private long getZipRolloverThreshold() {
-        return zipRollOver * Constants.ONE_MEGA_BYTE;
-    }
-
-    /**
-     * Return the number of bytes when to rollover given the number of megabytes
-     *
-     * @return the number of bytes
-     */
-    private long getRollOverThreshold() {
-        return ndjsonRollOver * Constants.ONE_MEGA_BYTE;
-    }
-
-
-    /**
-     * Process the contract - retrieve all the patients for the contract and create a thread in the
-     * patientProcessorThreadPool to handle searching for EOBs for each patient. Periodically check to
-     * see if the job is cancelled and cancel the threads if necessary, otherwise, wait until all threads
-     * have processed.
-     *
-     * @param contractData - the contract data (contract, progress tracker, attested time, writer)
-     * @return - the job output records containing the file information
-     */
-    private List<JobOutput> processContract(Path outputDirPath, ContractData contractData,
-                                            FileOutputType contractType) throws FileNotFoundException {
-        var contract = contractData.getContract();
-        log.info("Beginning to process contract {}", keyValue(CONTRACT_LOG, contract.getContractName()));
-
-        var contractNumber = contract.getContractNumber();
-
-        var progressTracker = contractData.getProgressTracker();
-
-        var patientsByContract = getPatientsByContract(contractNumber, progressTracker);
-        var patients = patientsByContract.getPatients();
-        int patientCount = patients.size();
-        log.info("Contract [{}] has [{}] Patients", contractNumber, patientCount);
-
-        boolean isCancelled = false;
-
-        StreamHelper helper = null;
-        try {
-            if (contractType == ZIP) {
-                helper = new ZipStreamHelperImpl(outputDirPath, contractNumber, getZipRolloverThreshold(), getRollOverThreshold(), tryLockTimeout);
-            } else {
-                helper = new TextStreamHelperImpl(outputDirPath, contractNumber, getRollOverThreshold(), tryLockTimeout);
-            }
-            int recordsProcessedCount = 0;
-            var futureHandles = new ArrayList<Future<Void>>();
-            for (PatientDTO patient : patients) {
-                ++recordsProcessedCount;
-
-                final String patientId = patient.getPatientId();
-
-                if (isOptOutPatient(patientId)) {
-                    // this patient has opted out. skip patient record.
-                    continue;
-                }
-
-                // Add the thread to process the patient and start the thread
-
-                // See https://docs.newrelic.com/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
-                // for more detail on tokens with async calls
-                final Token token = NewRelic.getAgent().getTransaction().getToken();
-
-                // Using a ThreadLocal to communicate contract number to RoundRobinBlockingQueue
-                // could be viewed as a hack by many; but on the other hand it saves us from writing
-                // tons of extra code.
-                RoundRobinBlockingQueue.CATEGORY_HOLDER.set(progressTracker.getJobUuid());
-                try {
-                    futureHandles.add(patientClaimsProcessor
-                            .process(patient, helper, contract.getAttestedOn(), contractData.getSinceTime(), token));
-                } finally {
-                    RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();
-                }
-
-                // Periodically check if cancelled
-                if (recordsProcessedCount % cancellationCheckFrequency == 0) {
-
-                    var jobUuid = contractData.getProgressTracker().getJobUuid();
-                    isCancelled = hasJobBeenCancelled(jobUuid);
-                    if (isCancelled) {
-                        log.warn("Job [{}] has been cancelled. Attempting to stop processing the job shortly ... ", jobUuid);
-                        cancelFuturesInQueue(futureHandles);
-                        break;
-                    }
-
-                    processHandles(futureHandles, progressTracker);
-                }
-            }
-
-            // While there are still patients not being processed, sleep for a bit and check progress
-            while (!futureHandles.isEmpty()) {
-                sleep();
-                processHandles(futureHandles, progressTracker);
-            }
-
-            if (isCancelled) {
-                final String errMsg = "Job was cancelled while it was being processed";
-                log.warn("{}", errMsg);
-                throw new JobCancelledException(errMsg);
-            }
-        } finally {
-            if (helper != null) {
-                try {
-                    helper.close();
-                } catch (Exception ex) {
-                    log.error("Unable to close the helper", ex);
-                }
-            }
-        }
-        // All jobs are done, return the job output records
-        return createJobOutputs(helper.getDataFiles(), helper.getErrorFiles());
-    }
-
-    /**
-     * Retrieve the patients by contract
-     *
-     * @param contractNumber - the contract number
-     * @param progressTracker - the progress tracker for all contracts and patients for the job
-     * @return the contract's patients
-     */
-    private GetPatientsByContractResponse getPatientsByContract(String contractNumber, ProgressTracker progressTracker) {
-        return progressTracker.getPatientsByContracts()
-                .stream()
-                .filter(byContract -> byContract.getContractNumber().equals(contractNumber))
-                .findFirst()
-                .orElse(null);
-    }
-
-    /**
-     * Cancel threads
-     *
-     * @param futureHandles - the running threads
-     */
-    private void cancelFuturesInQueue(List<Future<Void>> futureHandles) {
-
-        // cancel any futures that have not started processing and are waiting in the queue.
-        futureHandles.parallelStream().forEach(future -> future.cancel(false));
-
-        //At this point, there may be a few futures that are already in progress.
-        //But all the futures that are not yet in progress would be cancelled.
-    }
-
-    /**
-     * A Job could run for a long time, perhaps hours. An in process job can be cancelled. Here
-     * we search for the job and determine if the status has been changed to cancel. This is checked
-     * periodically while processing the job.
-     *
-     * @param jobUuid - the job id
-     * @return true if the job is cancelled
-     */
-    private boolean hasJobBeenCancelled(String jobUuid) {
-        final JobStatus jobStatus = jobRepository.findJobStatus(jobUuid);
-        return CANCELLED.equals(jobStatus);
-    }
-
-    /**
-     * Check the opt out repository to see if a patient has opted out of data services
-     *
-     * @param patientId - the patient id
-     * @return true if the patient has opted out
-     */
-    private boolean isOptOutPatient(String patientId) {
-
-        final List<OptOut> optOuts = optOutRepository.findByCcwId(patientId);
-        if (optOuts.isEmpty()) {
-            // No opt-out record found for this patient - Opt-In by default.
-            return false;
-        }
-
-        // opt-out record has an effective date.
-        // if any of the opt-out records for a patient is effective as of today or earlier, the patient has opted-out
-        final LocalDate tomorrow = LocalDate.now().plusDays(1);
-        return optOuts.stream()
-                .anyMatch(optOut -> optOut.getEffectiveDate().isBefore(tomorrow));
-    }
-
-    /**
-     * For each future, check to see if it's done. If it is, remove it from the list of future handles
-     * and increment the number processed
-     *
-     * @param futureHandles - the thread futures
-     * @param progressTracker - the tracker with updated tracker information
-     */
-    private void processHandles(List<Future<Void>> futureHandles, ProgressTracker progressTracker) {
-        var iterator = futureHandles.iterator();
-        while (iterator.hasNext()) {
-            var future = iterator.next();
-            if (future.isDone()) {
-                processFuture(futureHandles, progressTracker, future);
-                iterator.remove();
-            }
-        }
-
-        // update the progress in the DB & logs periodically
-        trackProgress(progressTracker);
-    }
-
-    /**
-     * process the future that is marked as done.
-     * On doing a get(), if an exception is thrown, analyze it to decide whether to stop the batch or not.
-     * @param futureHandles
-     * @param progressTracker
-     * @param future
-     */
-    private void processFuture(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Future<Void> future) {
-        progressTracker.incrementProcessedCount();
-        try {
-            future.get();
-        } catch (InterruptedException | ExecutionException e) {
-            analyzeException(futureHandles, progressTracker, e);
-
-        } catch (CancellationException e) {
-            // This could happen in the rare event that a job was cancelled mid-process.
-            // due to which the futures in the queue (that were not yet in progress) were cancelled.
-            // Nothing to be done here
-            log.warn("CancellationException while calling Future.get() - Job may have been cancelled");
-        }
-    }
-
-    private void analyzeException(List<Future<Void>> futureHandles, ProgressTracker progressTracker, Exception e) {
-        progressTracker.incrementFailureCount();
-
-        if (progressTracker.isErrorCountBelowThreshold()) {
-            final Throwable rootCause = ExceptionUtils.getRootCause(e);
-            log.error("exception while processing patient {}", rootCause.getMessage(), rootCause);
-            // log exception, but continue processing job as errorCount is below threshold
-        } else {
-            cancelFuturesInQueue(futureHandles);
-            log.error("{} out of {} records failed. Stopping job", progressTracker.getFailureCount(), progressTracker.getTotalCount());
-            throw new RuntimeException("Too many patient records in the job had failures");
-        }
-    }
-
-    /**
-     * Update the database or log with the % complete on the job periodically
-     *
-     * @param progressTracker - the progress tracker
-     */
-
-    private void trackProgress(ProgressTracker progressTracker) {
-        if (progressTracker.isTimeToUpdateDatabase(reportProgressDbFrequency)) {
-            final int percentageCompleted = progressTracker.getPercentageCompleted();
-
-            if (percentageCompleted > progressTracker.getLastUpdatedPercentage()) {
-                jobRepository.updatePercentageCompleted(progressTracker.getJobUuid(), percentageCompleted);
-                progressTracker.setLastUpdatedPercentage(percentageCompleted);
-            }
-        }
-
-        var processedCount = progressTracker.getProcessedCount();
-        if (progressTracker.isTimeToLog(reportProgressLogFrequency)) {
-            progressTracker.setLastLogUpdateCount(processedCount);
-
-            var totalCount = progressTracker.getTotalCount();
-            var percentageCompleted = progressTracker.getPercentageCompleted();
-            log.info("[{}/{}] records processed = [{}% completed]", processedCount, totalCount, percentageCompleted);
-        }
-    }
-
-    /**
-     * Once the job writer is finished, create a list of job output objects with
-     * the data files and the error files
-     *
-     * @param dataFiles - the results of writing the contract
-     * @param errorFiles - any errors that arose due to writing the contract
-     * @return the list of job output objects
-     */
-    private List<JobOutput> createJobOutputs(List<Path> dataFiles, List<Path> errorFiles) {
-
-        // create Job Output records for data files from the job writer
-        final List<JobOutput> jobOutputs = dataFiles.stream()
-                .map(dataFile -> createJobOutput(dataFile, false)).collect(Collectors.toList());
-
-        // create Job Output record for error file
-        final List<JobOutput> errorJobOutputs = errorFiles.stream()
-                .map(errorFile -> createJobOutput(errorFile, true))
-                .collect(Collectors.toList());
-        jobOutputs.addAll(errorJobOutputs);
-
-        if (jobOutputs.isEmpty()) {
-            var errMsg = "The export process has produced no results";
-            throw new RuntimeException(errMsg);
-        }
-
-        return jobOutputs;
-    }
-
-    /**
-     * From a file, return the JobOutput object
-     *
-     * @param outputFile - the output file from the job
-     * @param isError - if there was an error
-     * @return - the joub output object
-     */
-    private JobOutput createJobOutput(Path outputFile, boolean isError) {
-        JobOutput jobOutput = new JobOutput();
-        jobOutput.setFilePath(outputFile.getFileName().toString());
-        jobOutput.setFhirResourceType(EOB);
-        jobOutput.setError(isError);
-        jobOutput.setChecksum(fileService.generateChecksum(outputFile.toFile()));
-        jobOutput.setFileLength(outputFile.toFile().length());
-        return jobOutput;
-    }
-
-    /**
      * Set the job as complete in the database
      *
      * @param job - The job to set as complete
@@ -642,14 +294,5 @@ public class JobProcessorImpl implements JobProcessor {
         log.info("Job: [{}] is DONE", job.getJobUuid());
     }
 
-    /**
-     * Tell the thread to sleep
-     */
-    private void sleep() {
-        try {
-            Thread.sleep(SLEEP_DURATION);
-        } catch (InterruptedException e) {
-            log.warn("interrupted exception in thread.sleep(). Ignoring");
-        }
-    }
+
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -107,7 +106,7 @@ public class JobProcessorImpl implements JobProcessor {
      * @param job - the job to process
      * @param outputDirPath - the output directory to put all the files
      */
-    private void processJob(Job job, Path outputDirPath) throws FileNotFoundException {
+    private void processJob(Job job, Path outputDirPath) {
         // Create the output directory
         createOutputDirectory(outputDirPath);
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStubTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractAdapterStubTest.java
@@ -38,13 +38,6 @@ class ContractAdapterStubTest {
         assertThat(patients.size(), is(0));
     }
 
-    @Test
-    @DisplayName("when contractNumber is 9999, returns 9_999_000 patient records")
-    void when_S9999_returns_9999000() {
-        var patients = cut.getPatients("S9999", currentMonth).getPatients();
-        assertThat(patients.size(), is(9999000));
-    }
-
 
     @DisplayName("Given ContractNumber, returns varying number of patient records")
     @ParameterizedTest(name = "Given ContractNumber \"{0}\" returns {1} patient records")
@@ -54,10 +47,7 @@ class ContractAdapterStubTest {
             "S0010, 10000",
             "S0030, 30000",
             "S0100, 100000",
-            "S0110, 110000",
-            "S1000, 1000000",
-            "S2000, 2000000",
-            "S5000, 5000000",
+            "S0110, 110000"
     })
     void when_contractNumber_returns_PatientCount(String contractNumber, int patientCount) {
         var patients = cut.getPatients(contractNumber, currentMonth).getPatients();

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -1,0 +1,256 @@
+package gov.cms.ab2d.worker.processor;
+
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.Job;
+import gov.cms.ab2d.common.model.JobStatus;
+import gov.cms.ab2d.common.model.OptOut;
+import gov.cms.ab2d.common.model.Sponsor;
+import gov.cms.ab2d.common.model.User;
+import gov.cms.ab2d.common.repository.JobRepository;
+import gov.cms.ab2d.common.repository.OptOutRepository;
+import gov.cms.ab2d.filter.FilterOutByDate;
+import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse;
+import gov.cms.ab2d.worker.adapter.bluebutton.GetPatientsByContractResponse.PatientDTO;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
+import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
+import gov.cms.ab2d.worker.processor.stub.PatientClaimsProcessorStub;
+import gov.cms.ab2d.worker.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
+import static java.lang.Boolean.TRUE;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContractProcessorUnitTest {
+    // class under test
+    private ContractProcessor cut;
+
+    private String jobUuid = "6d08bf08-f926-4e19-8d89-ad67ef89f17e";
+
+    private Random random = new Random();
+
+    @TempDir Path efsMountTmpDir;
+
+    @Mock private FileService fileService;
+    @Mock private JobRepository jobRepository;
+    @Mock private OptOutRepository optOutRepository;
+    private PatientClaimsProcessor patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
+
+    private GetPatientsByContractResponse patientsByContract;
+    private Path outputDir;
+    private ContractData contractData;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cut = new ContractProcessorImpl(
+                fileService,
+                jobRepository,
+                patientClaimsProcessor,
+                optOutRepository
+        );
+
+        ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 2);
+        ReflectionTestUtils.setField(cut, "reportProgressDbFrequency", 2);
+        ReflectionTestUtils.setField(cut, "reportProgressLogFrequency", 3);
+        ReflectionTestUtils.setField(cut, "tryLockTimeout", 30);
+
+        var parentSponsor = createParentSponsor();
+        var childSponsor = createChildSponsor(parentSponsor);
+        var user = createUser(childSponsor);
+        var job = createJob(user);
+        var contract = createContract(childSponsor);
+
+        patientsByContract = createPatientsByContractResponse(contract);
+
+        var outputDirPath = Paths.get(efsMountTmpDir.toString(), jobUuid);
+        outputDir = Files.createDirectories(outputDirPath);
+
+        var progressTracker = ProgressTracker.builder()
+                .jobUuid(jobUuid)
+                .patientsByContract(patientsByContract)
+                .failureThreshold(10)
+                .build();
+        contractData = new ContractData(contract, progressTracker, contract.getAttestedOn(), job.getSince());
+    }
+
+
+    @Test
+    @DisplayName("When a job is cancelled while it is being processed, then attempt to stop the job gracefully without completing it")
+    void whenJobIsCancelledWhileItIsBeingProcessed_ThenAttemptToStopTheJob() throws Exception {
+
+        when(jobRepository.findJobStatus(anyString())).thenReturn(JobStatus.CANCELLED);
+
+        var exceptionThrown = assertThrows(JobCancelledException.class,
+                () -> cut.process(outputDir, contractData, NDJSON));
+
+        assertThat(exceptionThrown.getMessage(), startsWith("Job was cancelled while it was being processed"));
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any(), any(), any(), any());
+        verify(jobRepository, atLeastOnce()).updatePercentageCompleted(anyString(), anyInt());
+    }
+
+
+    @Test
+    @DisplayName("When patient has opted out, their record will be skipped.")
+    void processJob_whenSomePatientHasOptedOut_ShouldSkipThatPatientRecord() throws Exception {
+
+        final List<OptOut> optOuts = getOptOutRows(patientsByContract);
+        when(optOutRepository.findByCcwId(anyString()))
+                .thenReturn(new ArrayList<>())
+                .thenReturn(Arrays.asList(optOuts.get(1)))
+                .thenReturn(Arrays.asList(optOuts.get(2)));
+
+        var jobOutputs = cut.process(outputDir, contractData, NDJSON);
+
+        assertFalse(jobOutputs.isEmpty());
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("When all patients have opted out, should throw exception as no jobOutput rows were created")
+    void processJob_whenAllPatientsHaveOptedOut_ShouldThrowException() throws Exception {
+
+        final List<OptOut> optOuts = getOptOutRows(patientsByContract);
+        when(optOutRepository.findByCcwId(anyString()))
+                .thenReturn(Arrays.asList(optOuts.get(0)))
+                .thenReturn(Arrays.asList(optOuts.get(1)))
+                .thenReturn(Arrays.asList(optOuts.get(2)));
+
+        // Test data has 3 patientIds each of whom has opted out.
+        // So the patientsClaimsProcessor should never be called.
+        var exceptionThrown = assertThrows(RuntimeException.class,
+                () -> cut.process(outputDir, contractData, NDJSON));
+
+        assertThat(exceptionThrown.getMessage(), startsWith("The export process has produced no results"));
+        verify(patientClaimsProcessor, never()).process(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("When many patientId are present, 'PercentageCompleted' should be updated many times")
+    void whenManyPatientIdsAreProcessed_shouldUpdatePercentageCompletedMultipleTimes() throws Exception {
+
+        var contract = contractData.getContract();
+        var patients = createPatientsByContractResponse(contract).getPatients();
+        var manyPatientIds = new ArrayList<PatientDTO>();
+        manyPatientIds.addAll(patients);
+        manyPatientIds.addAll(patients);
+        manyPatientIds.addAll(patients);
+        manyPatientIds.addAll(patients);
+        manyPatientIds.addAll(patients);
+        manyPatientIds.addAll(patients);
+        patientsByContract.setPatients(manyPatientIds);
+        var jobOutputs = cut.process(outputDir, contractData, NDJSON);
+
+        assertFalse(jobOutputs.isEmpty());
+        verify(jobRepository, times(9)).updatePercentageCompleted(anyString(), anyInt());
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any(), any(), any(), any());
+    }
+
+    private List<OptOut> getOptOutRows(GetPatientsByContractResponse patientsByContract) {
+        return patientsByContract.getPatients()
+                .stream().map(PatientDTO::getPatientId)
+                .map(this::createOptOut)
+                .collect(Collectors.toList());
+    }
+
+    private OptOut createOptOut(String patientId) {
+        OptOut optOut = new OptOut();
+        optOut.setHicn(patientId);
+        optOut.setEffectiveDate(LocalDate.now().minusDays(10));
+        return optOut;
+    }
+
+    private Sponsor createParentSponsor() {
+        Sponsor parentSponsor = new Sponsor();
+        parentSponsor.setOrgName("PARENT");
+        parentSponsor.setLegalName("LEGAL PARENT");
+        return parentSponsor;
+    }
+
+    private Sponsor createChildSponsor(Sponsor parentSponsor) {
+        Sponsor childSponsor = new Sponsor();
+        childSponsor.setOrgName("Hogwarts School of Wizardry");
+        childSponsor.setLegalName("Hogwarts School of Wizardry LLC");
+
+        childSponsor.setParent(parentSponsor);
+        parentSponsor.getChildren().add(childSponsor);
+
+        return childSponsor;
+    }
+
+    private User createUser(Sponsor sponsor) {
+        User user = new User();
+        user.setUsername("Harry_Potter");
+        user.setFirstName("Harry");
+        user.setLastName("Potter");
+        user.setEmail("harry_potter@hogwarts.edu");
+        user.setEnabled(TRUE);
+        user.setSponsor(sponsor);
+        return user;
+    }
+
+    private Contract createContract(Sponsor sponsor) {
+        Contract contract = new Contract();
+        contract.setContractName("CONTRACT_NM_00000");
+        contract.setContractNumber("CONTRACT_00000");
+        contract.setAttestedOn(OffsetDateTime.now().minusDays(10));
+        contract.setSponsor(sponsor);
+
+        sponsor.getContracts().add(contract);
+        return contract;
+    }
+
+    private Job createJob(User user) {
+        Job job = new Job();
+        job.setJobUuid("S0000");
+        job.setStatusMessage("0%");
+        job.setStatus(JobStatus.IN_PROGRESS);
+        job.setUser(user);
+        return job;
+    }
+
+    private GetPatientsByContractResponse createPatientsByContractResponse(Contract contract) throws ParseException {
+        return GetPatientsByContractResponse.builder()
+                .contractNumber(contract.getContractNumber())
+                .patient(toPatientDTO())
+                .patient(toPatientDTO())
+                .patient(toPatientDTO())
+                .build();
+    }
+
+    private PatientDTO toPatientDTO() throws ParseException {
+        int anInt = random.nextInt(11);
+        var dateRange = new FilterOutByDate.DateRange(new Date(0), new Date());
+        return PatientDTO.builder()
+                .patientId("patient_" + anInt)
+                .dateRangesUnderContract(Arrays.asList(dateRange))
+                .build();
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -117,16 +117,23 @@ class JobProcessorIntegrationTest {
 
         FhirContext fhirContext = FhirContext.forDstu3();
         PatientClaimsProcessor patientClaimsProcessor = new PatientClaimsProcessorImpl(mockBfdClient, fhirContext);
+        ContractProcessor contractProcessor = new ContractProcessorImpl(
+                fileService,
+                jobRepository,
+                patientClaimsProcessor,
+                optOutRepository
+        );
+
+        ReflectionTestUtils.setField(contractProcessor, "cancellationCheckFrequency", 10);
 
         cut = new JobProcessorImpl(
                 fileService,
                 jobRepository,
                 jobOutputRepository,
                 contractAdapterStub,
-                patientClaimsProcessor,
-                optOutRepository
+                contractProcessor
         );
-        ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 10);
+
         ReflectionTestUtils.setField(cut, "efsMount", tmpEfsMountDir.toString());
         ReflectionTestUtils.setField(cut, "failureThreshold", 10);
     }


### PR DESCRIPTION
refactor JobProcessor - extract ContractProcessor

### Summary

Code-climate recommendation is to refactor JobProcessorImpl to simplify it.
JobProcessor has accumulated lot of logic and become large and complicated over time.  
Extracting ContractProcessor that encapsulates all the logic related to processing a contract, thereby simplifying JobProcessorImpl and help make the class smaller


### Checklist

- [x] Tests and linting pass


### Security
N/A

### Additional JIRA Tickets (optional)

N/A