### PR TITLE
Remove newline character that was breaking links in alerts

### DIFF
--- a/.github/workflows/gitleaks_github_actions.yml
+++ b/.github/workflows/gitleaks_github_actions.yml
@@ -25,4 +25,4 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       uses: Ilshidur/action-slack@master
       with:
-        args: 'Potential Secrets found in: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}\n Link to build with full gitleaks output: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}/checks'
+        args: 'Potential Secrets found in: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }} Link to build with full gitleaks output: https://github.com/{{ GITHUB_REPOSITORY }}/commit/{{ GITHUB_SHA }}/checks'


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Summary

This PR Removes a newline character that was breaking links in security alerts.

<!-- A more detailed multi line description of the pr. -->
When originally developing the gitleaks automation a manual newline character was inserted to separate the links of an alert. This no longer has any effect on the formatting in the alerts and just breaks the first link. This PR removes the unnecessary character to fix the link.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests and linting pass


### Security
What secure items does this touch, how does this PR affect our security posture, etc?

This impacts security alerting in a minor way by improving the alerting syntax to allow links to be easier to follow

### Additional JIRA Tickets (optional)

Primary ticket not applicable, this is conducted as minor side effort in relation to AB2D-1304