### PR TITLE
Ab2d 1488 turn off logging for build env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - AB2D_EFS_MOUNT=/opt/ab2d
       - NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}"
       - NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME}"
+      - AB2D_EXECUTION_ENV=${AB2D_EXECUTION_ENV}
     ports:
       - "8443:8443"
     depends_on:
@@ -61,6 +62,7 @@ services:
       - AB2D_KEYSTORE_LOCATION=${AB2D_KEYSTORE_LOCATION}
       - AB2D_KEYSTORE_PASSWORD=${AB2D_KEYSTORE_PASSWORD}
       - AB2D_KEY_ALIAS=${AB2D_KEY_ALIAS}
+      - AB2D_EXECUTION_ENV=${AB2D_EXECUTION_ENV}
     depends_on:
       - db
     volumes:

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
@@ -16,9 +16,9 @@ import java.util.concurrent.TimeoutException;
 @Service
 @Slf4j
 public class KinesisEventLogger implements EventLogger {
-    @Value("${execution.env:dev}")
+    @Value("${execution.env:local}")
     private String appEnv;
-    @Value("${eventlogger.kinesis.stream.prefix:bfd-insights-ab2d-}")
+    @Value("${eventlogger.kinesis.stream.prefix:}")
     private String streamId;
 
     private final KinesisConfig config;
@@ -36,6 +36,9 @@ public class KinesisEventLogger implements EventLogger {
 
     public void log(LoggableEvent event, boolean block) {
         event.setEnvironment(appEnv);
+        if (appEnv.equalsIgnoreCase("local")) {
+            return;
+        }
         ThreadPoolTaskExecutor ex = config.kinesisLogProcessingPool();
         KinesisEventProcessor processor = new KinesisEventProcessor(event, client, streamId);
         Future<Void> future = ex.submit(processor);

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventProcessor.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventProcessor.java
@@ -5,26 +5,28 @@ import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
 import com.amazonaws.services.kinesisfirehose.model.PutRecordRequest;
 import com.amazonaws.services.kinesisfirehose.model.PutRecordResult;
 import com.amazonaws.services.kinesisfirehose.model.Record;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.codehaus.jettison.json.JSONObject;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class KinesisEventProcessor implements Callable<Void> {
     private AmazonKinesisFirehose client;
     private String streamId;
     private LoggableEvent event;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .registerModule(new ParameterNamesModule())
-            .registerModule(new Jdk8Module())
-            .registerModule(new JavaTimeModule());
 
     public KinesisEventProcessor(LoggableEvent event, AmazonKinesisFirehose client, String streamPrefix) {
         this.client = client;
@@ -32,8 +34,48 @@ public class KinesisEventProcessor implements Callable<Void> {
         this.event = event;
     }
 
-    static String getJsonString(LoggableEvent event) throws JsonProcessingException {
-        return OBJECT_MAPPER.writeValueAsString(event);
+    /**
+     * Convert an event to a JSON string doing the following:
+     *     1. Convert camelcase attribute names to underscores. For example thisFieldName = this_field_name
+     *     2. Convert any date/time to UTC
+     *
+     * @param event - the event we are serializing
+     * @return the JSON string
+     */
+    public static String getJsonString(LoggableEvent event) {
+        // Get all the methods, including ones from LoggableEvent
+        Method[] methods = event.getClass().getDeclaredMethods();
+        Method[] superMethods = event.getClass().getSuperclass().getDeclaredMethods();
+        List<Method> methodList = List.of(methods);
+        List<Method> superMethodList = List.of(superMethods);
+        List<Method> allMethods = new ArrayList<>(methodList);
+        allMethods.addAll(superMethodList);
+
+        // Retrieve any get methods, these are our public attributes
+        List<Method> getMethods = allMethods.stream().filter(m -> m.getName().startsWith("get")).collect(Collectors.toList());
+
+        // From these methods, create a hash map for fields and their values
+        Map<String, Object> vals = new HashMap<>();
+        for (Method m : getMethods) {
+            try {
+                // Retrieve the value of the field
+                Object attValue = m.invoke(event);
+                // If we are an OffsetDateTime, convert to UTC, then make it a string in the correct format
+                if (attValue != null && attValue.getClass() == OffsetDateTime.class) {
+                    OffsetDateTime timeValue = (OffsetDateTime) attValue;
+                    attValue = timeValue.atZoneSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME);
+                }
+                // Convert the method name to the camelcase name and remove 'get'. For example, getJobId = job_id
+                String newAttName = camelCaseToUnderscore(m.getName().replace("get", ""));
+                vals.put(newAttName, attValue);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                log.info("Unable to call " + m.getName() + " on " + event.getClass().getSimpleName());
+            }
+        }
+        // Create a JSON object from the map
+        JSONObject jsonObject = new JSONObject(vals);
+        // Convert to string
+        return jsonObject.toString();
     }
 
     @Override
@@ -45,7 +87,7 @@ public class KinesisEventProcessor implements Callable<Void> {
                     .withData(ByteBuffer.wrap(json.getBytes()));
 
             PutRecordRequest putRecordRequest = new PutRecordRequest();
-            String className = event.getClass().getSimpleName().toLowerCase();
+            String className = camelCaseToUnderscore(event.getClass().getSimpleName());
             putRecordRequest.setDeliveryStreamName(streamId + className);
             putRecordRequest.setRecord(record);
 
@@ -56,5 +98,9 @@ public class KinesisEventProcessor implements Callable<Void> {
             log.error("Error in pushing event to Kinesis " + json + " - " + ex.getMessage());
         }
         return null;
+    }
+
+    static String camelCaseToUnderscore(String val) {
+        return val.replaceAll("(.)(\\p{Upper})", "$1_$2").toLowerCase();
     }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Slf4j
 public class SqlEventLogger implements EventLogger {
-    @Value("${execution.env:dev}")
+    @Value("${execution.env:local}")
     private String appEnv;
 
     private final SqlMapperConfig mapperConfig;

--- a/eventlogger/src/main/resources/application.properties
+++ b/eventlogger/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+execution.env=${AB2D_EXECUTION_ENV:#{'local'}}

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
@@ -4,29 +4,30 @@ import com.amazonaws.ResponseMetadata;
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
 import com.amazonaws.services.kinesisfirehose.model.PutRecordResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import gov.cms.ab2d.eventlogger.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.eventlogger.SpringBootApp;
-import gov.cms.ab2d.eventlogger.events.BeneficiarySearchEvent;
-import gov.cms.ab2d.eventlogger.events.ErrorEvent;
+import gov.cms.ab2d.eventlogger.events.*;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventProcessor.camelCaseToUnderscore;
+import static gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventProcessor.getJsonString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -48,6 +49,7 @@ class KinesisEventLoggerTest {
     @BeforeEach
     void init() {
         logger = new KinesisEventLogger(config, firehose);
+        ReflectionTestUtils.setField(logger, "appEnv", "dev");
         doReturn(generateRandomResult()).when(firehose).putRecord(any());
     }
 
@@ -85,19 +87,6 @@ class KinesisEventLoggerTest {
         assertEquals("contract1", se.getContractNum());
         assertEquals(now, se.getTimeOfEvent());
         assertEquals(now2, se.getResponseDate());
-        String json = KinesisEventProcessor.getJsonString(se);
-        System.out.println(json);
-        ObjectMapper mapper = new ObjectMapper()
-                .registerModule(new ParameterNamesModule())
-                .registerModule(new Jdk8Module())
-                .registerModule(new JavaTimeModule());
-        BeneficiarySearchEvent resultBene = mapper.readValue(json, BeneficiarySearchEvent.class);
-        assertEquals("bene1", resultBene.getBeneId());
-        assertEquals("SUCCESS", resultBene.getResponse());
-        assertEquals("job1", resultBene.getJobId());
-        assertEquals("contract1", resultBene.getContractNum());
-        assertEquals(now.getNano(), resultBene.getTimeOfEvent().getNano());
-        assertEquals(now2.getNano(), resultBene.getResponseDate().getNano());
     }
 
     @Test
@@ -116,5 +105,75 @@ class KinesisEventLoggerTest {
             Thread.sleep(1000);
         }
         assertNotNull(e.getAwsId());
+    }
+
+    @Test
+    public void testLocal() {
+        ReflectionTestUtils.setField(logger, "appEnv", "local");
+        ErrorEvent e = new ErrorEvent();
+        e.setDescription("Test Error");
+        e.setErrorType(ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT);
+        e.setId(1L);
+        e.setJobId("JOB123");
+        e.setTimeOfEvent(OffsetDateTime.now());
+        e.setUser("ME");
+
+        e.setAwsId("BOGUS");
+        logger.log(e, true);
+        String env = e.getEnvironment();
+        // Since we never logged, aws id was not reset
+        assertEquals("BOGUS", e.getAwsId());
+        ReflectionTestUtils.setField(logger, "appEnv", "dev");
+        logger.log(e, true);
+        assertTrue(e.getAwsId() == null || !e.getAwsId().equalsIgnoreCase("BOGUS"));
+    }
+
+    @Test
+    void camelCaseConvertestTest() {
+        LoggableEvent event = new ApiRequestEvent();
+        assertEquals("api_request_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new ApiResponseEvent();
+        assertEquals("api_response_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new BeneficiarySearchEvent();
+        assertEquals("beneficiary_search_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new ContractBeneSearchEvent();
+        assertEquals("contract_bene_search_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new ErrorEvent();
+        assertEquals("error_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new FileEvent();
+        assertEquals("file_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new JobStatusChangeEvent();
+        assertEquals("job_status_change_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+        event = new ReloadEvent();
+        assertEquals("reload_event", camelCaseToUnderscore(event.getClass().getSimpleName()));
+    }
+
+    @Test
+    void testJsonConversion() throws JSONException {
+        OffsetDateTime now = OffsetDateTime.now();
+        ErrorEvent e = new ErrorEvent();
+        e.setDescription("Test Error");
+        e.setErrorType(ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT);
+        e.setId(1L);
+        e.setJobId("JOB123");
+        e.setTimeOfEvent(now);
+        e.setUser("ME");
+        e.setAwsId("BOGUS");
+        e.setEnvironment("dev");
+
+        String jsonString = getJsonString(e);
+        JSONObject jsonObj = new JSONObject(jsonString);
+        assertEquals("Test Error", jsonObj.getString("description"));
+        assertEquals(1, jsonObj.getInt("id"));
+        assertEquals("JOB123", jsonObj.getString("job_id"));
+        assertEquals("UNAUTHORIZED_CONTRACT", jsonObj.getString("error_type"));
+        assertEquals("ME", jsonObj.getString("user"));
+        assertEquals("BOGUS", jsonObj.getString("aws_id"));
+        assertEquals("dev", jsonObj.getString("environment"));
+        String dateString = jsonObj.getString("time_of_event");
+        assertNotNull(dateString);
+        assertTrue(dateString.contains("Z"));
+        OffsetDateTime dateObj = OffsetDateTime.parse(dateString, DateTimeFormatter.ISO_DATE_TIME);
+        assertEquals(now.toEpochSecond(), dateObj.toEpochSecond());
     }
 }


### PR DESCRIPTION
<!-- A concise one sentence description of the PR -->

### Summary

This PR contains both variables to turn off sending requests to Kinesis fire hoses in build environments or anywhere the environment isn't "local", the default. You have to explicitly change the environment variable AB2D_EXECUTION_ENV to have it log.

I also made some changes related to sending the data so it met some of the standards to the data source table/column names on AWS from camelcase to underscores. For example jobId = job_id, ErrorEvent = error_event

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and linting pass
- [ ] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->