### PR TITLE
Bug/ab2d 1667 earliest data date is jan 1 2020

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
 - export AB2D_HICN_HASH_PEPPER=`cat bfd_sbx_hash_pepper`
 - export AB2D_HICN_HASH_ITER=1000
 - export AB2D_CLAIMS_SKIP_BILLABLE_PERIOD_CHECK=true
+- export AB2D_EARLIEST_DATA_DATE=01/01/1900
 install: true
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64

--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -44,6 +44,4 @@ public class Contract {
 
     @OneToMany(mappedBy = "contract")
     private Set<Coverage> coverages = new HashSet<>();
-
-
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
@@ -63,7 +63,6 @@ public abstract class LoggableEvent {
      * @return true if they have the same data
      */
     public boolean equals(final Object o) {
-        System.out.println("In equals");
         if (o == this) {
             return true;
         } else if (!(o instanceof LoggableEvent)) {

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
@@ -34,4 +34,81 @@ public abstract class LoggableEvent {
         this.user = user;
         this.jobId = jobId;
     }
+
+    /**
+     * Override this because in our situation equals for time of event shouldn't care about timezone
+     *
+     * @param o - the other object to care about
+     * @return true if they have the same data
+     */
+    public boolean equals(final Object o) {
+        System.out.println("In equals");
+        if (o == this) {
+            return true;
+        } else if (!(o instanceof LoggableEvent)) {
+            return false;
+        }
+        LoggableEvent other = (LoggableEvent) o;
+        String thisEnvironment = this.getEnvironment();
+        String otherEnvironment = other.getEnvironment();
+        if (thisEnvironment == null) {
+            if (otherEnvironment != null) {
+                return false;
+            }
+        } else if (!thisEnvironment.equals(otherEnvironment)) {
+            return false;
+        }
+
+        Long thisId = this.getId();
+        Long otherId = other.getId();
+        if (thisId == null) {
+            if (otherId != null) {
+                return false;
+            }
+        } else if (!thisId.equals(otherId)) {
+            return false;
+        }
+
+        String thisAwsId = this.getAwsId();
+        String otherAwsId = other.getAwsId();
+        if (thisAwsId == null) {
+            if (otherAwsId != null) {
+                return false;
+            }
+        } else if (!thisAwsId.equals(otherAwsId)) {
+            return false;
+        }
+
+        OffsetDateTime thisTimeOfEvent = this.getTimeOfEvent();
+        OffsetDateTime otherTimeOfEvent = other.getTimeOfEvent();
+        if (thisTimeOfEvent == null) {
+            if (otherTimeOfEvent != null) {
+                return false;
+            }
+        } else if (thisTimeOfEvent.toEpochSecond() != otherTimeOfEvent.toEpochSecond()) {
+            return false;
+        }
+
+        String thisUser = this.getUser();
+        String otherUser = other.getUser();
+        if (thisUser == null) {
+        if (otherUser != null) {
+                return false;
+            }
+        } else if (!thisUser.equals(otherUser)) {
+            return false;
+        }
+
+        String thisJobId = this.getJobId();
+        String otherJobId = other.getJobId();
+        if (thisJobId == null) {
+            if (otherJobId != null) {
+                return false;
+            }
+        } else if (!thisJobId.equals(otherJobId)) {
+            return false;
+        }
+
+        return true;
+     }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
@@ -36,6 +36,27 @@ public abstract class LoggableEvent {
     }
 
     /**
+     * If you implement equals, you have to do hashCode. I gook the one created by lombok and cleaned it.
+     * @return the hash code
+     */
+    public int hashCode() {
+        int result = 1;
+        String environment = this.getEnvironment();
+        result = result * 59 + (environment == null ? 43 : environment.hashCode());
+        Long id = this.getId();
+        result = result * 59 + (id == null ? 43 : id.hashCode());
+        String awsId = this.getAwsId();
+        result = result * 59 + (awsId == null ? 43 : awsId.hashCode());
+        OffsetDateTime timeOfEvent = this.getTimeOfEvent();
+        result = result * 59 + (timeOfEvent == null ? 43 : timeOfEvent.hashCode());
+        String user = this.getUser();
+        result = result * 59 + (user == null ? 43 : user.hashCode());
+        String jobId = this.getJobId();
+        result = result * 59 + (jobId == null ? 43 : jobId.hashCode());
+        return result;
+    }
+
+    /**
      * Override this because in our situation equals for time of event shouldn't care about timezone
      *
      * @param o - the other object to care about

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
@@ -46,5 +46,6 @@ public class SqlEventLogger implements EventLogger {
             this.template.update("UPDATE " + mapperConfig.getTableMapper(event.getClass()) +
                     " SET aws_id = ? WHERE id = ?", awsId, event.getId());
         }
+        event.setAwsId(awsId);
     }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventMapper.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventMapper.java
@@ -30,7 +30,7 @@ public abstract class SqlEventMapper implements RowMapper {
 
     MapSqlParameterSource addSuperParams(LoggableEvent event) {
         return new MapSqlParameterSource()
-                .addValue("time", UtilMethods.convertToUtc(event.getTimeOfEvent()))
+                .addValue("time", event.getTimeOfEvent())
                 .addValue("user", event.getUser())
                 .addValue("job", event.getJobId())
                 .addValue("awsId", event.getAwsId())

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventMapper.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventMapper.java
@@ -1,7 +1,6 @@
 package gov.cms.ab2d.eventlogger.eventloggers.sql;
 
 import gov.cms.ab2d.eventlogger.LoggableEvent;
-import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.support.KeyHolder;

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
@@ -49,10 +49,26 @@ public class AllMapperEventTest {
     }
 
     @Test
+    void createError() {
+        // There is no mapping. Make sure it doesn't create an issue
+        BeneficiarySearchEvent bene = new BeneficiarySearchEvent();
+        sqlEventLogger.log(bene);
+        sqlEventLogger.updateAwsId("TEST", bene);
+    }
+
+    @Test
+    void createErrorTable() {
+        // There is no mapping. Make sure it doesn't create an issue
+        BeneficiarySearchEvent bene = new BeneficiarySearchEvent();
+        sqlEventLogger.updateAwsId("TEST", bene);
+    }
+
+    @Test
     void logApiRequest() {
         ApiRequestEvent jsce = new ApiRequestEvent("laila", "job123", "http://localhost",
                 "127.0.0.1", "token", "123");
         sqlEventLogger.log(jsce);
+        sqlEventLogger.updateAwsId("ABC", jsce);
         assertEquals("dev", jsce.getEnvironment());
         long id = jsce.getId();
         OffsetDateTime val = jsce.getTimeOfEvent();
@@ -61,6 +77,9 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = doAll.load();
         assertEquals(events.size(), events2.size());
         ApiRequestEvent event = (ApiRequestEvent) events.get(0);
+        assertEquals(event.getAwsId(), "ABC");
+        jsce.setId(event.getId());
+        assertTrue(jsce.equals(event));
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -100,7 +119,7 @@ public class AllMapperEventTest {
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getUser());
         assertEquals("job123", event.getJobId());
-        assertEquals(val.getNano(), event.getTimeOfEvent().getNano());
+        assertTrue(jsce.equals(event));
         assertEquals("Description", event.getDescription());
         assertEquals("Not Found", event.getResponseString());
         assertEquals(404, event.getResponseCode());
@@ -131,6 +150,7 @@ public class AllMapperEventTest {
         ContractBeneSearchEvent event = (ContractBeneSearchEvent) events.get(0);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
+        assertTrue(cbse.equals(event));
         assertEquals(event.getId(), cbse.getId());
         assertEquals("laila", event.getUser());
         assertEquals("jobIdVal", event.getJobId());
@@ -164,6 +184,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = doAll.load();
         assertEquals(events.size(), events2.size());
         ErrorEvent event = (ErrorEvent) events.get(0);
+        assertTrue(jsce.equals(event));
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -200,6 +221,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = doAll.load();
         assertEquals(events.size(), events2.size());
         FileEvent event = (FileEvent) events.get(0);
+        assertTrue(jsce.equals(event));
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -236,6 +258,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = doAll.load();
         assertEquals(events.size(), events2.size());
         JobStatusChangeEvent event = (JobStatusChangeEvent) events.get(0);
+        assertTrue(jsce.equals(event));
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -269,6 +292,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
         assertEquals(1, events.size());
         ReloadEvent event = (ReloadEvent) events.get(0);
+        assertTrue(cbse.equals(event));
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), cbse.getId());

--- a/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
@@ -215,29 +215,6 @@ public final class FilterOutByDate {
      * This does most of the work of the class. It takes a list of explanation of benefit objects,
      * the attestation date and list of valid date ranges and returns the list of qualifying objects
      *
-     * @param benes - the explanation of benefit objects
-     * @param attestationDate - the attestation date
-     * @param dateRanges - the list of date ranges
-     * @return - the list of objects done after the attestation date and in the date ranges
-     * @throws ParseException - if there is an issue parsing the dates
-     */
-    public static List<ExplanationOfBenefit> filterByDate(List<ExplanationOfBenefit> benes,
-                                              Date attestationDate,
-                                              List<DateRange> dateRanges) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz");
-        Date earliest = null;
-        try {
-            earliest = sdf.parse(ATTESTATION_EARLIEST_DATE);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        return filterByDate(benes, attestationDate, earliest, dateRanges);
-    }
-
-    /**
-     * This does most of the work of the class. It takes a list of explanation of benefit objects,
-     * the attestation date and list of valid date ranges and returns the list of qualifying objects
-     *
      * @param benes           - the explanation of benefit objects
      * @param attestationDate - the attestation date
      * @param earliestDate    - the earliest date that ab2d data is available for any PDP

--- a/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 public final class FilterOutByDate {
     private static final String SHORT = "MM/dd/yyyy";
     private static final String FULL = "MM/dd/yyyy HH:mm:ss";
+    private static final String ATTESTATION_EARLIEST_DATE = "2020-01-01T00:00:00.000-05:00";
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.
@@ -223,18 +224,43 @@ public final class FilterOutByDate {
     public static List<ExplanationOfBenefit> filterByDate(List<ExplanationOfBenefit> benes,
                                               Date attestationDate,
                                               List<DateRange> dateRanges) throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz");
+        Date earliest = null;
+        try {
+            earliest = sdf.parse(ATTESTATION_EARLIEST_DATE);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return filterByDate(benes, attestationDate, earliest, dateRanges);
+    }
+
+    /**
+     * This does most of the work of the class. It takes a list of explanation of benefit objects,
+     * the attestation date and list of valid date ranges and returns the list of qualifying objects
+     *
+     * @param benes           - the explanation of benefit objects
+     * @param attestationDate - the attestation date
+     * @param earliestDate    - the earliest date that ab2d data is available for any PDP
+     * @param dateRanges      - the list of date ranges
+     * @return - the list of objects done after the attestation date and in the date ranges
+     * @throws ParseException - if there is an issue parsing the dates
+     */
+    public static List<ExplanationOfBenefit> filterByDate(List<ExplanationOfBenefit> benes,
+                                              Date attestationDate,
+                                              Date earliestDate,
+                                              List<DateRange> dateRanges) throws ParseException {
         if (benes == null || benes.isEmpty()) {
             return new ArrayList<>();
         }
-        return benes.stream().filter(b -> valid(b, attestationDate, dateRanges)).collect(Collectors.toList());
+        return benes.stream().filter(b -> valid(b, attestationDate, earliestDate, dateRanges)).collect(Collectors.toList());
     }
 
-    public static boolean valid(ExplanationOfBenefit bene, Date attestationDate, List<DateRange> dateRanges) {
+    public static boolean valid(ExplanationOfBenefit bene, Date attestationDate, Date earliestDate, List<DateRange> dateRanges) {
         if (bene == null) {
             return false;
         }
         try {
-            if (afterAttestation(attestationDate, bene)) {
+            if (afterDate(attestationDate, bene) && afterDate(earliestDate, bene)) {
                 for (DateRange r : dateRanges) {
                     if (withinDateRange(bene, r)) {
                         return true;
@@ -253,18 +279,18 @@ public final class FilterOutByDate {
      * and the billable end time is 10/01/2020 00:00:00 it will be included because they were on
      * the same day
      *
-     * @param attestation - attestation date
+     * @param dateVal - attestation date
      * @param ben - the explanation of benefit object
      * @return if the EOB object is after the attestation date
      * @throws ParseException - if there is an issue parsing the dates
      */
-    static boolean afterAttestation(Date attestation, ExplanationOfBenefit ben) throws ParseException {
+    static boolean afterDate(Date dateVal, ExplanationOfBenefit ben) throws ParseException {
         SimpleDateFormat fullDateFormat = new SimpleDateFormat(FULL);
         SimpleDateFormat shortDateFormat = new SimpleDateFormat(SHORT);
-        if (ben == null || ben.getBillablePeriod() == null || attestation == null) {
+        if (ben == null || ben.getBillablePeriod() == null || dateVal == null) {
             return false;
         }
-        Date attToUse = fullDateFormat.parse(shortDateFormat.format(attestation) + " 00:00:00");
+        Date attToUse = fullDateFormat.parse(shortDateFormat.format(dateVal) + " 00:00:00");
         Period p = ben.getBillablePeriod();
         Date end = p.getEnd();
         return end != null && end.getTime() >= attToUse.getTime();

--- a/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/FilterOutByDate.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 public final class FilterOutByDate {
     private static final String SHORT = "MM/dd/yyyy";
     private static final String FULL = "MM/dd/yyyy HH:mm:ss";
-    private static final String ATTESTATION_EARLIEST_DATE = "2020-01-01T00:00:00.000-05:00";
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.

--- a/filter/src/test/java/gov/cms/ab2d/filter/FilterOutByDateTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/FilterOutByDateTest.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.filter;
 
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.Period;
-import org.hl7.fhir.dstu3.model.Resource;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -35,18 +34,19 @@ class FilterOutByDateTest {
                 createEOB("10/31/2020", "11/02/2020")  // In
         );
 
-        assertEquals(6, FilterOutByDate.filterByDate(list, sdf.parse("12/01/2000"), ranges).size());
-        assertEquals(5, FilterOutByDate.filterByDate(list, sdf.parse("10/01/2018"), ranges).size());
-        assertEquals(0, FilterOutByDate.filterByDate(list, sdf.parse("12/01/2021"), ranges).size());
+        assertEquals(6, FilterOutByDate.filterByDate(list, sdf.parse("12/01/2000"), sdf.parse("01/01/2000"), ranges).size());
+        assertEquals(5, FilterOutByDate.filterByDate(list, sdf.parse("10/01/2018"), sdf.parse("01/01/2000"), ranges).size());
+        assertEquals(0, FilterOutByDate.filterByDate(list, sdf.parse("12/01/2021"), sdf.parse("01/01/2000"), ranges).size());
+        assertEquals(4, FilterOutByDate.filterByDate(list, sdf.parse("12/01/2000"), sdf.parse("12/01/2018"), ranges).size());
     }
 
     @Test
     void testAfterAttestation() throws ParseException {
         ExplanationOfBenefit b = createEOB("10/01/2020", "10/03/2020");
-        assertTrue(FilterOutByDate.afterAttestation(sdf.parse("10/01/2020"), b));
-        assertTrue(FilterOutByDate.afterAttestation(sdf.parse("10/03/2020"), b));
-        assertTrue(FilterOutByDate.afterAttestation(sdf.parse("10/03/2002"), b));
-        assertFalse(FilterOutByDate.afterAttestation(sdf.parse("10/04/2020"), b));
+        assertTrue(FilterOutByDate.afterDate(sdf.parse("10/01/2020"), b));
+        assertTrue(FilterOutByDate.afterDate(sdf.parse("10/03/2020"), b));
+        assertTrue(FilterOutByDate.afterDate(sdf.parse("10/03/2002"), b));
+        assertFalse(FilterOutByDate.afterDate(sdf.parse("10/04/2020"), b));
     }
 
     @Test

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -51,7 +51,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
 
     @Value("${claims.skipBillablePeriodCheck}")
     private boolean skipBillablePeriodCheck;
-    @Value("${bfd.earliest.data.data}")
+    @Value("${bfd.earliest.data.data:01/01/2020}")
     private String startDate;
 
     /**
@@ -149,14 +149,14 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         return resources;
     }
 
-    private List<Resource> extractResources(List<BundleEntryComponent> entries, final List<FilterOutByDate.DateRange> dateRanges,
+    List<Resource> extractResources(List<BundleEntryComponent> entries, final List<FilterOutByDate.DateRange> dateRanges,
                                             OffsetDateTime attTime) {
         if (attTime == null) {
             return new ArrayList<>();
         }
         long epochMilli = attTime.toInstant().toEpochMilli();
         Date attDate = new Date(epochMilli);
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
         Date date;
         try {
             date = sdf.parse(startDate);

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -61,3 +61,5 @@ bfd.health.check.consecutive.failures=5
 
 claims.skipBillablePeriodCheck=${AB2D_CLAIMS_SKIP_BILLABLE_PERIOD_CHECK:#{false}}
 
+## -----------------------------------------------------------------------------------------------------  Earliest Data Date
+bfd.earliest.data.data=${AB2D_EARLIEST_DATA_DATE:#{'01/01/2020'}}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -137,6 +137,7 @@ class JobProcessorIntegrationTest {
 
         FhirContext fhirContext = FhirContext.forDstu3();
         PatientClaimsProcessor patientClaimsProcessor = new PatientClaimsProcessorImpl(mockBfdClient, fhirContext, logManager);
+        ReflectionTestUtils.setField(patientClaimsProcessor, "startDate", "01/01/1900");
         ContractProcessor contractProcessor = new ContractProcessorImpl(
                 fileService,
                 jobRepository,

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
@@ -91,6 +91,7 @@ public class PatientClaimsProcessorUnitTest {
                 fhirContext,
                 eventLogger
         );
+        ReflectionTestUtils.setField(cut, "startDate", "01/01/1900");
 
         eob = EobTestDataUtil.createEOB();
         createOutputFiles();

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -60,4 +60,4 @@ bfd.health.check.enabled=false
 claims.skipBillablePeriodCheck=true
 
 ## -----------------------------------------------------------------------------------------------------  Earliest Data Date
-bfd.earliest.data.data=01/01/1900
+bfd.earliest.data.data=01/01/2020

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -57,5 +57,7 @@ bfd.health.check.consecutive.successes=3
 bfd.health.check.consecutive.failures=3
 bfd.health.check.enabled=false
 
-
 claims.skipBillablePeriodCheck=true
+
+## -----------------------------------------------------------------------------------------------------  Earliest Data Date
+bfd.earliest.data.data=01/01/1900


### PR DESCRIPTION
### Summary

Previously, we only checked to see if the data was past the attestation date but if they attested in December of last year, they still can only have data past 1/1/2020. Fixed that. Also noticed a bug in eventlogger and fixed it.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and linting pass
- [ ] Code checked for PHI/PII exposure

### Security
What secure items does this touch, how does this PR affect our security posture, etc?

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->