### PR TITLE
Make sure patients not belonging to contracts are not included in files

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -28,6 +28,7 @@ import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_PREFIX;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
@@ -158,5 +159,16 @@ public class AdminAPIPropertiesTests {
             Assert.assertNotNull(value);
             Assert.assertEquals(value.toString(), propertiesDTO.getValue());
         }
+
+        // Cleanup
+        propertiesDTOs.clear();
+        maintenanceModeDTO.setValue("false");
+        propertiesDTOs.add(maintenanceModeDTO);
+
+        this.mockMvc.perform(
+                put(API_PREFIX + ADMIN_PREFIX + PROPERTIES_URL)
+                        .contentType(MediaType.APPLICATION_JSON).content(mapper.writeValueAsString(propertiesDTOs))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().is(200));
     }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -5,7 +5,10 @@ import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import org.hamcrest.core.Is;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MaintenanceModeAPITests {
 
     @Container
@@ -37,6 +41,7 @@ public class MaintenanceModeAPITests {
     private PropertiesService propertiesService;
 
     @Test
+    @Order(1)
     public void testMaintenanceModeOff() throws Exception {
         PropertiesDTO propertiesDTO = new PropertiesDTO();
         propertiesDTO.setKey(MAINTENANCE_MODE);
@@ -48,6 +53,7 @@ public class MaintenanceModeAPITests {
     }
 
     @Test
+    @Order(2)
     public void testMaintenanceModeOn() throws Exception {
         PropertiesDTO propertiesDTO = new PropertiesDTO();
         propertiesDTO.setKey(MAINTENANCE_MODE);

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -38,6 +38,9 @@ public class MaintenanceModeAPITests {
 
     @Test
     public void testMaintenanceModeOff() throws Exception {
+        PropertiesDTO propertiesDTO = new PropertiesDTO();
+        propertiesDTO.setKey(MAINTENANCE_MODE);
+        propertiesDTO.setValue("false");
         this.mockMvc.perform(get(STATUS_ENDPOINT)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().is(200))

--- a/filter/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
@@ -26,7 +26,7 @@ class EOBLoadUtilitiesTest {
 
     @Test
     public void testConvertFromFilePatient() throws IOException {
-        assertEquals(eobCarrier.getPatient().getReference(), "Patient/567834");
+        assertEquals(eobCarrier.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test
@@ -35,7 +35,7 @@ class EOBLoadUtilitiesTest {
         assertNull(EOBLoadUtilities.getEOBFromFileInClassPath(null, context));
         ExplanationOfBenefit eob = EOBLoadUtilities.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json", context);
         assertNotNull(eob);
-        assertEquals(eob.getPatient().getReference(), "Patient/567834");
+        assertEquals(eob.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test
@@ -170,7 +170,7 @@ class EOBLoadUtilitiesTest {
         assertNull(EOBLoadUtilities.getEOBFromReader(null, context));
         ExplanationOfBenefit benefit = EOBLoadUtilities.getEOBFromReader(reader, context);
         assertNotNull(benefit);
-        assertEquals(benefit.getPatient().getReference(), "Patient/567834");
+        assertEquals(benefit.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test

--- a/filter/src/test/java/gov/cms/ab2d/filter/EOBToAB2DEOBTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/EOBToAB2DEOBTest.java
@@ -30,7 +30,7 @@ class EOBToAB2DEOBTest {
 
     @Test
     public void testConvertFromFilePatient() throws IOException {
-        assertEquals(eobCarrier.getPatient().getReference(), "Patient/567834");
+        assertEquals(eobCarrier.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test
@@ -39,7 +39,7 @@ class EOBToAB2DEOBTest {
         assertNull(EOBToAB2DEOB.getEOBFromFileInClassPath(null));
         ExplanationOfBenefit eob = EOBToAB2DEOB.getEOBFromFileInClassPath("eobdata/EOB-for-Carrier-Claims.json");
         assertNotNull(eob);
-        assertEquals(eob.getPatient().getReference(), "Patient/567834");
+        assertEquals(eob.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test
@@ -173,7 +173,7 @@ class EOBToAB2DEOBTest {
         assertNull(EOBToAB2DEOB.getEOBFromReader(null));
         ExplanationOfBenefit benefit = EOBToAB2DEOB.getEOBFromReader(reader);
         assertNotNull(benefit);
-        assertEquals(benefit.getPatient().getReference(), "Patient/567834");
+        assertEquals(benefit.getPatient().getReference(), "Patient/-199900000022040");
     }
 
     @Test
@@ -185,6 +185,6 @@ class EOBToAB2DEOBTest {
         Reader reader = new java.io.InputStreamReader(inputStream);
         AB2DExplanationOfBenefit benefit = EOBToAB2DEOB.fromReader(reader);
         assertNotNull(benefit);
-        assertEquals(benefit.getPatient().getReference(), "Patient/567834");
+        assertEquals(benefit.getPatient().getReference(), "Patient/-199900000022040");
     }
 }

--- a/filter/src/test/resources/eobdata/EOB-for-Carrier-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-Carrier-Claims.json
@@ -7,7 +7,7 @@
 			"id": "1",
 			"status": "completed",
 			"subject": {
-				"reference": "Patient/567834"
+				"reference": "Patient/-199900000022040"
 			},
 			"requester": {
 				"agent": {
@@ -159,7 +159,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"start": "1999-10-27",
@@ -293,7 +293,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-b-567834"
+			"reference": "Coverage/part-b-199900000022040"
 		}
 	},
 	"item": [

--- a/filter/src/test/resources/eobdata/EOB-for-DME-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-DME-Claims.json
@@ -7,7 +7,7 @@
 			"id": "1",
 			"status": "completed",
 			"subject": {
-				"reference": "Patient/567834"
+				"reference": "Patient/-199900000022040"
 			},
 			"requester": {
 				"agent": {
@@ -156,7 +156,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"start": "2014-02-03",
@@ -253,7 +253,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-b-567834"
+			"reference": "Coverage/part-b-199900000022040"
 		}
 	},
 	"item": [

--- a/filter/src/test/resources/eobdata/EOB-for-HHA-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-HHA-Claims.json
@@ -60,7 +60,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"start": "2015-06-23",
@@ -320,7 +320,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-b-567834"
+			"reference": "Coverage/part-b-199900000022040"
 		}
 	},
 	"hospitalization": {

--- a/filter/src/test/resources/eobdata/EOB-for-Hospice-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-Hospice-Claims.json
@@ -65,7 +65,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"start": "2014-01-01",
@@ -304,7 +304,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-a-567834"
+			"reference": "Coverage/part-a-199900000022040"
 		}
 	},
 	"hospitalization": {

--- a/filter/src/test/resources/eobdata/EOB-for-Inpatient-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-Inpatient-Claims.json
@@ -201,7 +201,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"extension": [
@@ -777,7 +777,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-a-567834"
+			"reference": "Coverage/part-a-199900000022040"
 		}
 	},
 	"hospitalization": {

--- a/filter/src/test/resources/eobdata/EOB-for-Outpatient-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-Outpatient-Claims.json
@@ -113,7 +113,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"extension": [
@@ -435,7 +435,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-b-567834"
+			"reference": "Coverage/part-b-199900000022040"
 		}
 	},
 	"item": [

--- a/filter/src/test/resources/eobdata/EOB-for-Part-D-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-Part-D-Claims.json
@@ -30,7 +30,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"organization": {
 		"identifier": {
@@ -349,7 +349,7 @@
 					}
 				}
 			],
-			"reference": "Coverage/part-d-567834"
+			"reference": "Coverage/part-d-199900000022040"
 		}
 	},
 	"item": [

--- a/filter/src/test/resources/eobdata/EOB-for-SNF-Claims.json
+++ b/filter/src/test/resources/eobdata/EOB-for-SNF-Claims.json
@@ -153,7 +153,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"extension": [
@@ -608,7 +608,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-a-567834"
+			"reference": "Coverage/part-a-199900000022040"
 		}
 	},
 	"hospitalization": {

--- a/website/assets/downloads/sample-data.ndjson
+++ b/website/assets/downloads/sample-data.ndjson
@@ -39,7 +39,7 @@
      ]
    },
    "patient": {
-     "reference": "Patient/567834"
+     "reference": "Patient/-199900000022040"
    },
    "billablePeriod": {
    	 "start": "1999-10-27",

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -114,7 +114,7 @@ public class ContractProcessorImpl implements ContractProcessor {
                     continue;
                 }
 
-                futureHandles.add(processPatient(patient.getValue(), contractData, helper));
+                futureHandles.add(processPatient(patient.getValue(), contractData, helper, patients));
 
                 // Periodically check if cancelled
                 if (recordsProcessedCount % cancellationCheckFrequency == 0) {
@@ -195,7 +195,7 @@ public class ContractProcessorImpl implements ContractProcessor {
      * @param helper - the helper used to write to the file
      * @return a Future<Void>
      */
-    private Future<Void> processPatient(PatientDTO patient, ContractData contractData, StreamHelper helper) {
+    private Future<Void> processPatient(PatientDTO patient, ContractData contractData, StreamHelper helper, Map<String, PatientDTO> map) {
         final Token token = NewRelic.getAgent().getTransaction().getToken();
 
         // Using a ThreadLocal to communicate contract number to RoundRobinBlockingQueue
@@ -209,7 +209,7 @@ public class ContractProcessorImpl implements ContractProcessor {
             var patientClaimsRequest = new PatientClaimsRequest(patient, helper, attestedOn, sinceTime,
                     contractData.getUserId(), jobUuid,
                     contractData.getContract() != null ? contractData.getContract().getContractNumber() : null, token);
-            return patientClaimsProcessor.process(patientClaimsRequest);
+            return patientClaimsProcessor.process(patientClaimsRequest, map);
 
         } finally {
             RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
@@ -1,9 +1,11 @@
 package gov.cms.ab2d.worker.processor;
 
+import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
 import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
 
+import java.util.Map;
 import java.util.concurrent.Future;
 
 public interface PatientClaimsProcessor {
-    Future<Void> process(PatientClaimsRequest request);
+    Future<Void> process(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map);
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -218,6 +218,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         patientId = patientId.replaceFirst("Patient/", "");
         if (patients.get(patientId) == null) {
             log.error(patientId + " returned in EOB, but not a member of a contract");
+            return false;
         }
         return true;
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -208,6 +208,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
      */
     boolean validPatientInContract(ExplanationOfBenefit benefit, Map<String, ContractBeneficiaries.PatientDTO> patients) {
         if (benefit == null || patients == null) {
+            log.debug("Passed an invalid benefit or an invalid list of patients");
             return false;
         }
         String patientId = benefit.getPatient().getReference();
@@ -215,6 +216,9 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
             return false;
         }
         patientId = patientId.replaceFirst("Patient/", "");
-        return patients.get(patientId) != null;
+        if (patients.get(patientId) == null) {
+            log.error(patientId + " returned in EOB, but not a member of a contract");
+        }
+        return true;
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
@@ -65,7 +66,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
      */
     @Trace(async = true)
     @Async("patientProcessorThreadPool")
-    public Future<Void> process(PatientClaimsRequest request) {
+    public Future<Void> process(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map) {
         final Token token = request.getToken();
         token.link();
 
@@ -74,7 +75,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         String payload = "";
         try {
             // Retrieve the resource bundle of EOB objects
-            var resources = getEobBundleResources(request);
+            var resources = getEobBundleResources(request, map);
 
             var jsonParser = fhirContext.newJsonParser();
 
@@ -118,7 +119,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         helper.addError(data);
     }
 
-    private List<Resource> getEobBundleResources(PatientClaimsRequest request) {
+    private List<Resource> getEobBundleResources(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map) {
         ContractBeneficiaries.PatientDTO patient = request.getPatientDTO();
         OffsetDateTime attTime = request.getAttTime();
 
@@ -150,12 +151,12 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         }
 
         final List<BundleEntryComponent> entries = eobBundle.getEntry();
-        final List<Resource> resources = extractResources(entries, patient.getDateRangesUnderContract(), attTime);
+        final List<Resource> resources = extractResources(entries, patient.getDateRangesUnderContract(), attTime, map);
 
         while (eobBundle.getLink(Bundle.LINK_NEXT) != null) {
             eobBundle = bfdClient.requestNextBundleFromServer(eobBundle);
             final List<BundleEntryComponent> nextEntries = eobBundle.getEntry();
-            resources.addAll(extractResources(nextEntries, patient.getDateRangesUnderContract(), attTime));
+            resources.addAll(extractResources(nextEntries, patient.getDateRangesUnderContract(), attTime, map));
         }
 
         log.debug("Bundle - Total: {} - Entries: {} ", eobBundle.getTotal(), entries.size());
@@ -163,7 +164,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
     }
 
     List<Resource> extractResources(List<BundleEntryComponent> entries, final List<FilterOutByDate.DateRange> dateRanges,
-                                            OffsetDateTime attTime) {
+                                    OffsetDateTime attTime, Map<String, ContractBeneficiaries.PatientDTO> patientsMap) {
         if (attTime == null) {
             return new ArrayList<>();
         }
@@ -191,7 +192,29 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
                 .filter(Objects::nonNull)
                 // Remove Plan D
                 .filter(resource -> !isPartD(resource))
+                // Make sure the returned patient ID is actually part of the contract
+                .filter(resource -> validPatientInContract(resource, patientsMap))
                 // compile the list
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * returns true if the patient is a valid member of a contract, false otherwise. If either value is empty,
+     * it returns false
+     *
+     * @param benefit - The benefit to check
+     * @param patients - the patient map containing the patient id & patient object
+     * @return true if this patient is a member of the correct contract
+     */
+    boolean validPatientInContract(ExplanationOfBenefit benefit, Map<String, ContractBeneficiaries.PatientDTO> patients) {
+        if (benefit == null || patients == null) {
+            return false;
+        }
+        String patientId = benefit.getPatient().getReference();
+        if (patientId == null) {
+            return false;
+        }
+        patientId = patientId.replaceFirst("Patient/", "");
+        return patients.get(patientId) != null;
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -107,7 +107,7 @@ class ContractProcessorUnitTest {
                 () -> cut.process(outputDir, contractData, NDJSON));
 
         assertThat(exceptionThrown.getMessage(), startsWith("Job was cancelled while it was being processed"));
-        verify(patientClaimsProcessor, atLeast(1)).process(any());
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
         verify(jobRepository, atLeastOnce()).updatePercentageCompleted(anyString(), anyInt());
     }
 
@@ -138,7 +138,7 @@ class ContractProcessorUnitTest {
         var jobOutputs = cut.process(outputDir, contractData, NDJSON);
 
         assertFalse(jobOutputs.isEmpty());
-        verify(patientClaimsProcessor, atLeast(1)).process(any());
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
     }
 
     @Test
@@ -156,7 +156,7 @@ class ContractProcessorUnitTest {
                 () -> cut.process(outputDir, contractData, NDJSON));
 
         assertThat(exceptionThrown.getMessage(), startsWith("The export process has produced no results"));
-        verify(patientClaimsProcessor, never()).process(any());
+        verify(patientClaimsProcessor, never()).process(any(), any());
     }
 
     @Test
@@ -167,7 +167,7 @@ class ContractProcessorUnitTest {
 
         assertFalse(jobOutputs.isEmpty());
         verify(jobRepository, times(9)).updatePercentageCompleted(anyString(), anyInt());
-        verify(patientClaimsProcessor, atLeast(1)).process(any());
+        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
     }
 
     private List<OptOut> getOptOutRows(ContractBeneficiaries patientsByContract) {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobStatus;
 import gov.cms.ab2d.common.model.Sponsor;
 import gov.cms.ab2d.common.model.User;
+import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.common.repository.SponsorRepository;
 import gov.cms.ab2d.common.repository.UserRepository;
@@ -47,6 +48,8 @@ class JobPreProcessorIntegrationTest {
     @Autowired
     private SponsorRepository sponsorRepository;
     @Autowired
+    private ContractRepository contractRepository;
+    @Autowired
     private UserRepository userRepository;
     @Autowired
     private DoAll doAll;
@@ -67,6 +70,7 @@ class JobPreProcessorIntegrationTest {
         cut = new JobPreProcessorImpl(jobRepository, manager);
         jobRepository.deleteAll();
         userRepository.deleteAll();
+        contractRepository.deleteAll();
         sponsorRepository.deleteAll();
         doAll.delete();
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -71,7 +71,7 @@ class JobPreProcessorIntegrationTest {
         jobRepository.deleteAll();
         userRepository.deleteAll();
         contractRepository.deleteAll();
-        sponsorRepository.deleteAll();
+        //sponsorRepository.deleteAll();
         doAll.delete();
 
         var sponsor = createSponsor();

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
@@ -1,16 +1,18 @@
 package gov.cms.ab2d.worker.processor.stub;
 
+import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
 import gov.cms.ab2d.worker.processor.PatientClaimsProcessor;
 import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
 import org.springframework.scheduling.annotation.AsyncResult;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 public class PatientClaimsProcessorStub implements PatientClaimsProcessor {
 
     @Override
-    public Future<Void> process(PatientClaimsRequest request) {
+    public Future<Void> process(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map) {
 
         request.getHelper().getDataFiles().add(Path.of("TEST_DATA_FILE"));
         request.getHelper().getErrorFiles().add(Path.of("TEST_ERROR_FILE"));

--- a/worker/src/test/resources/test-data/EOB-for-Carrier-Claims.json
+++ b/worker/src/test/resources/test-data/EOB-for-Carrier-Claims.json
@@ -7,7 +7,7 @@
 			"id": "1",
 			"status": "completed",
 			"subject": {
-				"reference": "Patient/567834"
+				"reference": "Patient/-199900000022040"
 			},
 			"requester": {
 				"agent": {
@@ -159,7 +159,7 @@
 		]
 	},
 	"patient": {
-		"reference": "Patient/567834"
+		"reference": "Patient/-199900000022040"
 	},
 	"billablePeriod": {
 		"start": "1999-10-27",
@@ -293,7 +293,7 @@
 	],
 	"insurance": {
 		"coverage": {
-			"reference": "Coverage/part-b-567834"
+			"reference": "Coverage/part-b-199900000022040"
 		}
 	},
 	"item": [


### PR DESCRIPTION
### Summary

If the patients not found in the contract beneficiary map, they should be excluded from the file.

Cleaned up the sample test data so they all referred to the same patient ID because some tests were using one patient ID but returning an EOB file with a different patient so based on this update, it would have been excluded.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and linting pass
- [ ] Code checked for PHI/PII exposure

### Security
This increases security by double checking results from BFD making sure the EOB records are only from patients who were included in the list of the contract's beneficiaries

### Additional JIRA Tickets (optional)

<!-- JIRA tickets not included in the PR title -->