### PR TITLE
AB2D-2063: Adding a ATTESTOR role that won't be able to acccess any U…

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
@@ -92,7 +92,7 @@ public class AdminAPIUserTests {
         roleRepository.deleteAll();
         sponsorRepository.deleteAll();
 
-        token = testUtil.setupToken(List.of(ADMIN_ROLE, SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(ADMIN_ROLE, SPONSOR_ROLE, ATTESTOR_ROLE));
     }
 
     @Test
@@ -107,6 +107,41 @@ public class AdminAPIUserTests {
         userDTO.setSponsor(new SponsorDTO(sponsor.getHpmsId(), sponsor.getOrgName()));
         userDTO.setRole(ADMIN_ROLE);
         Role role = roleService.findRoleByName(ADMIN_ROLE);
+        userDTO.setRole(role.getName());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+                post(API_PREFIX + ADMIN_PREFIX + USER_URL)
+                        .contentType(MediaType.APPLICATION_JSON).content(mapper.writeValueAsString(userDTO))
+                        .header("Authorization", "Bearer " + token))
+                .andReturn();
+
+        Assert.assertEquals(201, mvcResult.getResponse().getStatus());
+
+        String result = mvcResult.getResponse().getContentAsString();
+        UserDTO createdUserDTO = mapper.readValue(result, UserDTO.class);
+        Assert.assertEquals(createdUserDTO.getEmail(), userDTO.getEmail());
+        Assert.assertEquals(createdUserDTO.getUsername(), userDTO.getUsername());
+        Assert.assertEquals(createdUserDTO.getFirstName(), userDTO.getFirstName());
+        Assert.assertEquals(createdUserDTO.getLastName(), userDTO.getLastName());
+        Assert.assertEquals(createdUserDTO.getEnabled(), userDTO.getEnabled());
+        Assert.assertEquals(createdUserDTO.getSponsor().getHpmsId(), userDTO.getSponsor().getHpmsId());
+        Assert.assertEquals(createdUserDTO.getSponsor().getOrgName(), userDTO.getSponsor().getOrgName());
+        Assert.assertEquals(createdUserDTO.getRole(), userDTO.getRole());
+    }
+
+    @Test
+    public void testCreateUserAttestor() throws Exception {
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUsername("test@test.com");
+        userDTO.setEmail("test@test.com");
+        userDTO.setEnabled(true);
+        userDTO.setFirstName("Test");
+        userDTO.setLastName("User");
+        Sponsor sponsor = sponsorRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
+        userDTO.setSponsor(new SponsorDTO(sponsor.getHpmsId(), sponsor.getOrgName()));
+        Role role = roleService.findRoleByName(ATTESTOR_ROLE);
         userDTO.setRole(role.getName());
 
         ObjectMapper mapper = new ObjectMapper();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -76,10 +76,36 @@ public class RoleTests {
                 .andExpect(status().is(202));
     }
 
+    // This will test the API using a role that should not be able to access sponsor URLs
+    @Test
+    public void testAttestorRoleAccessingSponsorApi() throws Exception {
+        token = testUtil.setupToken(List.of(ATTESTOR_ROLE));
+
+        this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/Patient/$export")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().is(403));
+    }
+
     // This will test the API using a role that should not be able to access admin URLs
     @Test
     public void testWrongRoleAdminApi() throws Exception {
         token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+
+        String fileName = "parent_org_and_legal_entity_20191031_111812.xls";
+        InputStream inputStream = this.getClass().getResourceAsStream("/" + fileName);
+
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("file", fileName, "application/vnd.ms-excel", inputStream);
+        this.mockMvc.perform(MockMvcRequestBuilders.multipart(API_PREFIX + ADMIN_PREFIX + "/uploadOrgStructureReport")
+                .file(mockMultipartFile).contentType(MediaType.MULTIPART_FORM_DATA)
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().is(403));
+    }
+
+    // This will test the API using a role that should not be able to access admin URLs
+    @Test
+    public void testWrongRoleAttestorAdminApi() throws Exception {
+        token = testUtil.setupToken(List.of(ATTESTOR_ROLE));
 
         String fileName = "parent_org_and_legal_entity_20191031_111812.xls";
         InputStream inputStream = this.getClass().getResourceAsStream("/" + fileName);

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -26,6 +26,8 @@ public final class Constants {
 
     public static final String ADMIN_ROLE = "ADMIN";
 
+    public static final String ATTESTOR_ROLE = "ATTESTOR";
+
     public static final String EOB = "ExplanationOfBenefit";
 
     public static final int ONE_MEGA_BYTE = 1024 * 1024;

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -60,3 +60,5 @@ databaseChangeLog:
       file: db/changelog/v001/create_opt_out_file_table.sql
   - include:
       file: db/changelog/v001/add_properties_data_01.sql
+  - include:
+      file: db/changelog/v001/add_attestor_role.sql

--- a/common/src/main/resources/db/changelog/v001/add_attestor_role.sql
+++ b/common/src/main/resources/db/changelog/v001/add_attestor_role.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+--changeset adaykin:add_attestor_role failOnError:true
+INSERT INTO role (id, name) VALUES ((select nextval('hibernate_sequence')), 'ATTESTOR');


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2063](https://jira.cms.gov/browse/AB2D-2063) - 
Adding a ATTESTOR role that won't be able to access any URLs, but will exist for the purpose of tracking users. We will
maintain the user's email so that if we need to notify a user of anything programmatically we can do so.

 
### What Does This PR Do?

Adds an attestor role that will be used for keeping track of users

### What Should Reviewers Watch For?

Make sure the attestor can't access anything it should not be able to

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure