### PR TITLE
Add Authentication Headers on the HPMS call

### DIFF
--- a/common/src/main/resources/application.common.properties
+++ b/common/src/main/resources/application.common.properties
@@ -3,3 +3,4 @@ efs.mount=${AB2D_EFS_MOUNT:#{systemProperties['java.io.tmpdir']+'/jobdownloads'}
 audit.files.ttl.hours=24
 
 hpms.base.url=${AB2D_HPMS_URL:#{'https://hpmsimpl.cms.gov'}}
+hpms.auth.url=${AB2D_HPMS_AUTH_URL:#{'https://hpmsimpl.cms.gov/api/idm/oauth/token?ACS=wlVuThEThipRlBu37Pra'}}

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -16,3 +16,4 @@ spring.liquibase.enabled=true
 logging.level.liquibase=ERROR
 
 hpms.base.url=${AB2D_HPMS_URL:#{'http://localhost:8080'}}
+hpms.auth.url=${AB2D_HPMS_AUTH_URL:#{'https://hpmsimpl.cms.gov/api/idm/oauth/token?ACS=wlVuThEThipRlBu37Pra'}}

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -14,6 +14,3 @@ spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.enabled=true
 
 logging.level.liquibase=ERROR
-
-hpms.base.url=${AB2D_HPMS_URL:#{'http://localhost:8080'}}
-hpms.auth.url=${AB2D_HPMS_AUTH_URL:#{'https://hpmsimpl.cms.gov/api/idm/oauth/token?ACS=wlVuThEThipRlBu37Pra'}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - AB2D_DB_SSL_MODE=allow
       - AB2D_DB_USER=ab2d
       - AB2D_DB_PASSWORD=ab2d
+      - HPMS_AUTH_KEY_ID="${HPMS_AUTH_KEY_ID}"
+      - HPMS_AUTH_KEY_SECRET="${HPMS_AUTH_KEY_SECRET}"
       - AB2D_EFS_MOUNT=/opt/ab2d
       - AB2D_EXECUTION_ENV=local
       - NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}"

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -112,9 +112,9 @@ public class TestRunner {
                     .withScaledService("worker", 2)
                     .withExposedService("db", 5432)
                     .withExposedService("api", 8443, new HostPortWaitStrategy()
-                        .withStartupTimeout(Duration.of(150, SECONDS)))
-                     .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-                     .withLogConsumer("api", new Slf4jLogConsumer(log));
+                        .withStartupTimeout(Duration.of(150, SECONDS)));
+//                     .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+//                     .withLogConsumer("api", new Slf4jLogConsumer(log));
             container.start();
         }
 

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -112,9 +112,9 @@ public class TestRunner {
                     .withScaledService("worker", 2)
                     .withExposedService("db", 5432)
                     .withExposedService("api", 8443, new HostPortWaitStrategy()
-                        .withStartupTimeout(Duration.of(150, SECONDS)));
-                     //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-                     //.withLogConsumer("api", new Slf4jLogConsumer(log));
+                        .withStartupTimeout(Duration.of(150, SECONDS)))
+                     .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+                     .withLogConsumer("api", new Slf4jLogConsumer(log));
             container.start();
         }
 

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/hmsapi/HPMSAuthResponse.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/hmsapi/HPMSAuthResponse.java
@@ -1,0 +1,10 @@
+package gov.cms.ab2d.hpms.hmsapi;
+
+import lombok.Data;
+
+@Data
+public class HPMSAuthResponse {
+
+    private String accessToken;
+    private int expires;
+}

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthService.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthService.java
@@ -1,0 +1,8 @@
+package gov.cms.ab2d.hpms.service;
+
+import org.springframework.http.HttpHeaders;
+
+public interface HPMSAuthService {
+
+    void buildAuthHeaders(HttpHeaders headers);
+}

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -87,7 +87,7 @@ public class HPMSAuthServiceImpl implements HPMSAuthService {
         return tokenExpires;
     }
 
-    public void setTokenExpires(long tokenExpires) {
+    void setTokenExpires(long tokenExpires) {
         this.tokenExpires = tokenExpires;
     }
 }

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -87,7 +87,7 @@ public class HPMSAuthServiceImpl implements HPMSAuthService {
         return tokenExpires;
     }
 
-    void setTokenExpires(long tokenExpires) {
-        this.tokenExpires = tokenExpires;
+    void clearTokenExpires() {
+        this.tokenExpires = 0;
     }
 }

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -1,0 +1,93 @@
+package gov.cms.ab2d.hpms.service;
+
+import gov.cms.ab2d.hpms.hmsapi.HPMSAuthResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+
+import static org.springframework.http.HttpHeaders.*;
+
+@Service
+public class HPMSAuthServiceImpl implements HPMSAuthService {
+
+    @Value("${hpms.auth.url}")
+    private String authURL;
+
+    @Value("${HPMS_AUTH_KEY_ID}")
+    private String hpmsAPIKeyId;
+
+    @Value("${HPMS_AUTH_KEY_SECRET}")
+    private String hpmsSecret;
+
+    private volatile String authToken;
+
+    private volatile long tokenExpires;
+
+    @Override
+    public void buildAuthHeaders(HttpHeaders headers) {
+        headers.set("X-API-CONSUMER-ID", hpmsAPIKeyId);
+        headers.set(AUTHORIZATION, retrieveAuthToken());
+    }
+
+    private String retrieveAuthToken() {
+        final long currentTimestamp = System.currentTimeMillis();
+        if (authToken == null || currentTimestamp >= tokenExpires) {
+            refreshToken(currentTimestamp);
+        }
+
+        return authToken;
+    }
+
+    private void refreshToken(long currentTimestamp) {
+        authToken = null;
+
+        Flux<HPMSAuthResponse> orgInfoFlux = WebClient.create(authURL)
+                .post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(retrieveAuthRequestPayload())
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(HPMSAuthResponse.class);
+
+        // Cough up blood if we can't get an Auth response in a minute.
+        HPMSAuthResponse authResponse = orgInfoFlux.blockFirst(Duration.ofMinutes(1));
+        if (authResponse == null) {
+            throw new RuntimeException("Failed to procure Auth Token");
+        }
+
+        // Convert seconds to millis at a 90% level to pad refreshing of a token so that we are not in the middle of
+        // a significant operation when the token expires.
+        tokenExpires = currentTimestamp + authResponse.getExpires() * 900;
+        authToken = authResponse.getAccessToken();
+    }
+
+    private String retrieveAuthRequestPayload() {
+        return String.format(AUTH_PAYLOAD_TEMPLATE, hpmsAPIKeyId, hpmsSecret);
+    }
+
+    // Text Blocks are still a preview feature in JDK 13 and 14, otherwise, it would really clean this up.
+    private static final String AUTH_PAYLOAD_TEMPLATE = "{\n" +
+            "    \"userName\": \"CDA-AB2D-API\",\n" +
+            "    \"keyId\": \"%s\",\n" +
+            "    \"keySecret\": \"%s\",\n" +
+            "    \"scopes\": \"cda_org_att\"\n" +
+            "}";
+
+
+    String getAuthToken() {
+        return authToken;
+    }
+
+    long getTokenExpires() {
+        return tokenExpires;
+    }
+
+    public void setTokenExpires(long tokenExpires) {
+        this.tokenExpires = tokenExpires;
+    }
+}

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSFetcherImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSFetcherImpl.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.hpms.service;
 
 import gov.cms.ab2d.hpms.hmsapi.HPMSAttestationsHolder;
 import gov.cms.ab2d.hpms.hmsapi.HPMSOrganizations;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -18,10 +19,18 @@ public class HPMSFetcherImpl implements HPMSFetcher {
     @Value("${hpms.base.url}/api/cda/contracts/status")
     private String attestationBaseUrl;
 
+    private final HPMSAuthService authService;
+
+    @Autowired
+    public HPMSFetcherImpl(HPMSAuthService authService) {
+        this.authService = authService;
+    }
+
     @Override
     public void retrieveSponsorInfo(Consumer<HPMSOrganizations> hpmsOrgCallback) {
         Flux<HPMSOrganizations> orgInfoFlux = WebClient.create(organizationBaseUrl)
                 .get()
+                .headers(authService::buildAuthHeaders)
                 .retrieve()
                 .bodyToFlux(HPMSOrganizations.class);
 

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -55,7 +55,7 @@ public class HPMSAuthServiceTest {
         // Force an expiry and see a new token is retrieved, can't depend upon the actual token being physically
         // refreshed (without inserting a 500 ms pause), so just check expiry hear (which with 1 clock tick, will be
         // different.
-        authService.setTokenExpires(0L);
+        authService.clearTokenExpires();
         headers = new HttpHeaders();
         authService.buildAuthHeaders(headers);
         assertNotEquals(tokenExpiry, authService.getTokenExpires());

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.hpms.service;
 
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.hpms.SpringBootTestApp;
-import org.junit.AfterClass;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -1,0 +1,63 @@
+package gov.cms.ab2d.hpms.service;
+
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.hpms.SpringBootTestApp;
+import org.junit.AfterClass;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@SpringBootTest(classes = SpringBootTestApp.class)
+@TestPropertySource(locations = "/application.hpms.properties")
+@Testcontainers
+public class HPMSAuthServiceTest {
+
+    @Autowired
+    HPMSAuthServiceImpl authService;
+
+    @SuppressWarnings({"rawtypes", "unused"})
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
+
+    @Test
+    public void tokenTest() {
+        assertNotNull(authService);
+
+        // Verifying initial state
+        assertNull(authService.getAuthToken());
+        assertEquals(0L, authService.getTokenExpires());
+
+        // Verifying the first time
+        HttpHeaders headers = new HttpHeaders();
+        authService.buildAuthHeaders(headers);
+        //noinspection ConstantConditions
+        assertEquals(authService.getAuthToken(), headers.get(HttpHeaders.AUTHORIZATION).get(0));
+        assertNotEquals(0, authService.getTokenExpires());
+
+        String firstAuthToken = authService.getAuthToken();
+        // Second call should return identical token (since it is cached)
+        headers = new HttpHeaders();
+        authService.buildAuthHeaders(headers);
+        //noinspection ConstantConditions
+        assertEquals(firstAuthToken, headers.get(HttpHeaders.AUTHORIZATION).get(0));
+        long tokenExpiry = authService.getTokenExpires();
+
+        // Force an expiry and see a new token is retrieved, can't depend upon the actual token being physically
+        // refreshed (without inserting a 500 ms pause), so just check expiry hear (which with 1 clock tick, will be
+        // different.
+        authService.setTokenExpires(0L);
+        headers = new HttpHeaders();
+        authService.buildAuthHeaders(headers);
+        assertNotEquals(tokenExpiry, authService.getTokenExpires());
+    }
+}

--- a/hpms/src/test/resources/application.hpms.properties
+++ b/hpms/src/test/resources/application.hpms.properties
@@ -8,6 +8,3 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.enabled=true
-
-hpms.base.url=${AB2D_HPMS_URL:#{'http://localhost:8080'}}
-hpms.auth.url=${AB2D_HPMS_AUTH_URL:#{'https://hpmsimpl.cms.gov/api/idm/oauth/token?ACS=wlVuThEThipRlBu37Pra'}}

--- a/hpms/src/test/resources/application.hpms.properties
+++ b/hpms/src/test/resources/application.hpms.properties
@@ -10,3 +10,4 @@ spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.enabled=true
 
 hpms.base.url=${AB2D_HPMS_URL:#{'http://localhost:8080'}}
+hpms.auth.url=${AB2D_HPMS_AUTH_URL:#{'https://hpmsimpl.cms.gov/api/idm/oauth/token?ACS=wlVuThEThipRlBu37Pra'}}


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-1969](https://jira.cms.gov/browse/AB2D-1969) - Add Authentication Headers on the HPMS call

***Related Tickets***

None
 
### What Does This PR Do?

This PR authenticates with HPMS and retrieves an authorization token for use in future HPMS API calls.

### What Should Reviewers Watch For?

The token is cached for subsequent calls.

### Usage/Deployment Instructions

None

### Impacted External Components

None

### Database Changes

None

### Limitations

Dependent upon HPMS to issue more permanent credentials.  The current credential is limited to the IMPL environment for the month of September 2020.

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure