### PR TITLE
Feature/ab2d 2118 add created modified

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/model/Beneficiary.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Beneficiary.java
@@ -15,7 +15,7 @@ import java.util.Set;
 @Entity
 @Getter
 @Setter
-public class Beneficiary {
+public class Beneficiary extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -23,8 +23,8 @@ import static gov.cms.ab2d.common.util.DateUtil.getESTOffset;
 @Entity
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Contract {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class Contract extends TimestampBase {
 
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MM/dd/yyyy H:m Z");
 

--- a/common/src/main/java/gov/cms/ab2d/common/model/Coverage.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Coverage.java
@@ -15,8 +15,8 @@ import javax.persistence.ManyToOne;
 @Entity
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Coverage {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class Coverage extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/OptOut.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/OptOut.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Setter
-public class OptOut {
+public class OptOut extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/OptOutFile.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/OptOutFile.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 @Entity
 @Getter
 @Setter
-public class OptOutFile {
+public class OptOutFile extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/Properties.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Properties.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 @Entity
 @Getter
 @Setter
-public class Properties {
+public class Properties extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/Role.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Role.java
@@ -13,8 +13,8 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class Role {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class Role extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/Sponsor.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Sponsor.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @Entity
 @Getter
 @Setter
-public class Sponsor {
+public class Sponsor extends TimestampBase {
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/TimestampBase.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/TimestampBase.java
@@ -1,0 +1,21 @@
+package gov.cms.ab2d.common.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+public abstract class TimestampBase {
+
+    @CreationTimestamp
+    private LocalDateTime created;
+
+    @UpdateTimestamp
+    private LocalDateTime modified;
+}

--- a/common/src/main/java/gov/cms/ab2d/common/model/User.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/User.java
@@ -15,8 +15,8 @@ import java.util.*;
 @Table(name = "user_account")
 @Getter
 @Setter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class User implements UserDetails {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class User extends TimestampBase implements UserDetails {
 
     @Id
     @GeneratedValue
@@ -52,6 +52,7 @@ public class User implements UserDetails {
         roles.add(role);
     }
 
+    @SuppressWarnings("unused")
     public void removeRole(Role role) {
         roles.remove(role);
     }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -62,3 +62,5 @@ databaseChangeLog:
       file: db/changelog/v001/add_properties_data_01.sql
   - include:
       file: db/changelog/v001/add_attestor_role.sql
+  - include:
+      file: db/changelog/v001/add_created_modified_date.sql

--- a/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
+++ b/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
@@ -23,13 +23,6 @@ ALTER TABLE coverage
 -- noinspection SqlWithoutWhere
 UPDATE coverage SET created='2000-01-01', modified='2000-01-01';
 
-ALTER TABLE coverage
-    ADD COLUMN created timestamp,
-    ADD COLUMN modified timestamp;
-
--- noinspection SqlWithoutWhere
-UPDATE coverage SET created='2000-01-01', modified='2000-01-01';
-
 ALTER TABLE opt_out
     ADD COLUMN created timestamp,
     ADD COLUMN modified timestamp;

--- a/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
+++ b/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
@@ -1,6 +1,15 @@
 --liquibase formatted sql
 --  -------------------------------------------------------------------------------------------------------------------
 
+--changeset enolan:add_created_modified_date failOnError:true
+ALTER TABLE beneficiary
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+
+-- noinspection SqlWithoutWhere
+UPDATE beneficiary SET created='2000-01-01', modified='2000-01-01';
+
 ALTER TABLE role
     ADD COLUMN created timestamp,
     ADD COLUMN modified timestamp;

--- a/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
+++ b/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+ALTER TABLE role
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+
+-- noinspection SqlWithoutWhere
+UPDATE role SET created='2000-01-01', modified='2000-01-01';
+

--- a/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
+++ b/common/src/main/resources/db/changelog/v001/add_created_modified_date.sql
@@ -6,15 +6,69 @@ ALTER TABLE beneficiary
     ADD COLUMN created timestamp,
     ADD COLUMN modified timestamp;
 
-
 -- noinspection SqlWithoutWhere
 UPDATE beneficiary SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE contract
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE contract SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE coverage
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE coverage SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE coverage
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE coverage SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE opt_out
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE opt_out SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE opt_out_file
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE opt_out_file SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE properties
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE properties SET created='2000-01-01', modified='2000-01-01';
 
 ALTER TABLE role
     ADD COLUMN created timestamp,
     ADD COLUMN modified timestamp;
 
-
 -- noinspection SqlWithoutWhere
 UPDATE role SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE sponsor
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE sponsor SET created='2000-01-01', modified='2000-01-01';
+
+ALTER TABLE user_account
+    ADD COLUMN created timestamp,
+    ADD COLUMN modified timestamp;
+
+-- noinspection SqlWithoutWhere
+UPDATE user_account SET created='2000-01-01', modified='2000-01-01';
 

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -54,11 +54,8 @@ public class CreateUpdateTimestampTest {
         Beneficiary finaleBeneficiary = beneficiaryRepository.save(savedBeneficiary);
         assertEquals(created, finaleBeneficiary.getCreated());
         assertNotEquals(modified, finaleBeneficiary.getModified());
-    }
 
-    @SuppressWarnings("unused")
-    @AfterEach
-    private void tearDown() {
-        beneficiaryRepository.deleteAll();
+        // Cleanup
+        beneficiaryRepository.delete(finaleBeneficiary);
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -1,0 +1,63 @@
+package gov.cms.ab2d.common.model;
+
+import gov.cms.ab2d.common.repository.RoleRepository;
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@SpringBootTest
+@Testcontainers
+@TestPropertySource(locations = "/application.common.properties")
+public class CreateUpdateTimestampTest {
+
+    private static final String ROLE_NAME = "Timestamp Test Role";
+    private static final String ROLE_NAME_TOO = "Timestamp Test Role 2";
+
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    @SuppressWarnings("rawtypes")
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
+
+    @Test
+    public void testTimestamps() {
+        Role role = new Role();
+        role.setName(ROLE_NAME);
+        assertNull(role.getId());
+        assertNull(role.getCreated());
+        assertNull(role.getModified());
+
+        Role savedRole = roleRepository.save(role);
+        assertEquals(ROLE_NAME, savedRole.getName());
+        assertNotNull(savedRole.getId());
+        assertNotNull(savedRole.getCreated());
+        assertNotNull(savedRole.getModified());
+
+        LocalDateTime created = savedRole.getCreated();
+        LocalDateTime modified = savedRole.getModified();
+        savedRole.setName(ROLE_NAME_TOO);
+        Role finaleRole = roleRepository.save(savedRole);
+        assertEquals(created, finaleRole.getCreated());
+        assertNotEquals(modified, finaleRole.getModified());
+    }
+
+    @AfterEach
+    private void tearDown() {
+        roleRepository.deleteAll();
+    }
+}

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.common.model;
 
 import gov.cms.ab2d.common.repository.BeneficiaryRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -1,6 +1,6 @@
 package gov.cms.ab2d.common.model;
 
-import gov.cms.ab2d.common.repository.RoleRepository;
+import gov.cms.ab2d.common.repository.BeneficiaryRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -23,41 +23,42 @@ import static org.junit.Assert.assertNull;
 @TestPropertySource(locations = "/application.common.properties")
 public class CreateUpdateTimestampTest {
 
-    private static final String ROLE_NAME = "Timestamp Test Role";
-    private static final String ROLE_NAME_TOO = "Timestamp Test Role 2";
+    private static final String PATIENT_ID_STR = "Timestamp Test Beneficiary";
+    private static final String PATIENT_ID_STR_TOO = "Timestamp Test Beneficiary 2";
 
 
     @Autowired
-    RoleRepository roleRepository;
+    BeneficiaryRepository beneficiaryRepository;
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unused"})
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @Test
     public void testTimestamps() {
-        Role role = new Role();
-        role.setName(ROLE_NAME);
-        assertNull(role.getId());
-        assertNull(role.getCreated());
-        assertNull(role.getModified());
+        Beneficiary bene = new Beneficiary();
+        bene.setPatientId(PATIENT_ID_STR);
+        assertNull(bene.getId());
+        assertNull(bene.getCreated());
+        assertNull(bene.getModified());
 
-        Role savedRole = roleRepository.save(role);
-        assertEquals(ROLE_NAME, savedRole.getName());
-        assertNotNull(savedRole.getId());
-        assertNotNull(savedRole.getCreated());
-        assertNotNull(savedRole.getModified());
+        Beneficiary savedBeneficiary = beneficiaryRepository.save(bene);
+        assertEquals(PATIENT_ID_STR, savedBeneficiary.getPatientId());
+        assertNotNull(savedBeneficiary.getId());
+        assertNotNull(savedBeneficiary.getCreated());
+        assertNotNull(savedBeneficiary.getModified());
 
-        LocalDateTime created = savedRole.getCreated();
-        LocalDateTime modified = savedRole.getModified();
-        savedRole.setName(ROLE_NAME_TOO);
-        Role finaleRole = roleRepository.save(savedRole);
-        assertEquals(created, finaleRole.getCreated());
-        assertNotEquals(modified, finaleRole.getModified());
+        LocalDateTime created = savedBeneficiary.getCreated();
+        LocalDateTime modified = savedBeneficiary.getModified();
+        savedBeneficiary.setPatientId(PATIENT_ID_STR_TOO);
+        Beneficiary finaleBeneficiary = beneficiaryRepository.save(savedBeneficiary);
+        assertEquals(created, finaleBeneficiary.getCreated());
+        assertNotEquals(modified, finaleBeneficiary.getModified());
     }
 
+    @SuppressWarnings("unused")
     @AfterEach
     private void tearDown() {
-        roleRepository.deleteAll();
+        beneficiaryRepository.deleteAll();
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2118](https://jira.cms.gov/browse/AB2D-2118) - Add CreatedDate and UpdatedDate fields to all non-Job domain objects

***Related Tickets***
 
### What Does This PR Do?

Adds DB fields and domain object fields so that when we are investigating, we know when a row is created and when it last changed.

### What Should Reviewers Watch For?

For any issues in the liquidbase update scripts.

### Usage/Deployment Instructions

None

### Impacted External Components

None

### Database Changes

Created and Updated columns added to most of the domain tables.

### Limitations

None

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

None

### Submitter Checklist

- [x ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ x] Code checked for PHI/PII exposure