### PR TITLE
Feature/ab2d 2109 separation for eob data serialization

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/model/Beneficiary.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Beneficiary.java
@@ -16,7 +16,6 @@ import java.util.Set;
 @Getter
 @Setter
 public class Beneficiary {
-
     @Id
     @GeneratedValue
     private Long id;
@@ -27,6 +26,4 @@ public class Beneficiary {
 
     @OneToMany(mappedBy = "beneficiary")
     private Set<Coverage> coverages = new HashSet<>();
-
-
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -41,7 +41,6 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     @Query("UPDATE Job j SET j.status = 'SUBMITTED' WHERE j.jobUuid IN :jobUuids ")
     void resetJobsToSubmittedStatus(List<String> jobUuids);
 
-
     @Modifying
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Query("UPDATE Job j SET j.progress = :percentageCompleted WHERE j.jobUuid = :jobUuid ")

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobOutputServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobOutputServiceTest.java
@@ -8,6 +8,7 @@ import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,17 +64,20 @@ public class JobOutputServiceTest {
     // Be safe and make sure nothing from another test will impact current test
     @BeforeEach
     public void setup() {
-        contractRepository.deleteAll();
-        jobRepository.deleteAll();
-        userRepository.deleteAll();
-        sponsorRepository.deleteAll();
-
         dataSetup.setupUser(List.of());
 
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(
                         new org.springframework.security.core.userdetails.User(TEST_USER,
                                 "test", new ArrayList<>()), "pass"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        contractRepository.deleteAll();
+        jobRepository.deleteAll();
+        userRepository.deleteAll();
+        sponsorRepository.deleteAll();
     }
 
     @Test

--- a/common/src/test/java/gov/cms/ab2d/common/util/EventUtilsTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/EventUtilsTest.java
@@ -63,13 +63,13 @@ class EventUtilsTest {
 
         File f = null;
         try {
-            f = new File("/tmp/abcd");
+            f = File.createTempFile("abcd", "");
             f.createNewFile();
             FileUtils.writeStringToFile(f, "Hello World");
 
             event = EventUtils.getFileEvent(job, f, FileEvent.FileStatus.CLOSE);
             assertNotNull(event.getFileHash());
-            assertEquals("/tmp/abcd", event.getFileName());
+            assertTrue(event.getFileName().contains("abcd"));
             assertEquals(11, event.getFileSize());
             assertEquals(FileEvent.FileStatus.CLOSE, event.getStatus());
             assertEquals(jobId, event.getJobId());

--- a/filter/src/test/java/gov/cms/ab2d/filter/EOBToAB2DEOBTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/EOBToAB2DEOBTest.java
@@ -18,7 +18,7 @@ class EOBToAB2DEOBTest {
     static AB2DExplanationOfBenefit eobCarrier = null;
     static AB2DExplanationOfBenefit eobSNF = null;
     static {
-        eobCarrier = EOBToAB2DEOB.fromFileInClasspath("eobdata/EOB-for-Carrier-Claims.json");;
+        eobCarrier = EOBToAB2DEOB.fromFileInClasspath("eobdata/EOB-for-Carrier-Claims.json");
         eobSNF = EOBToAB2DEOB.fromFileInClasspath("eobdata/EOB-for-SNF-Claims.json");
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessor.java
@@ -1,14 +1,11 @@
 package gov.cms.ab2d.worker.processor;
 
 import gov.cms.ab2d.common.model.JobOutput;
-import gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
 
 import java.nio.file.Path;
 import java.util.List;
 
 public interface ContractProcessor {
-
-    List<JobOutput> process(Path outputDirPath, ContractData contractData, FileOutputType outputType);
-
+    List<JobOutput> process(Path outputDirPath, ContractData contractData);
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -92,6 +92,8 @@ public class ContractProcessorImpl implements ContractProcessor {
         long numberOfEobs = 0;
         var jobUuid = progressTracker.getJobUuid();
         Job job = jobRepository.findByJobUuid(jobUuid);
+        List<Path> dataFiles = new ArrayList<>();
+        List<Path> errorFiles = new ArrayList<>();
         int recordsProcessedCount = 0;
         try (StreamHelper helper = new TextStreamHelperImpl(outputDirPath, contractNumber, getRollOverThreshold(), tryLockTimeout,
                 eventLogger, job)) {
@@ -123,11 +125,12 @@ public class ContractProcessorImpl implements ContractProcessor {
 
             log.info("Finished writing {} EOBs for contract {}", numberOfEobs, contractNumber);
             // All jobs are done, return the job output records
-            return createJobOutputs(helper.getDataFiles(), helper.getErrorFiles());
+            dataFiles = helper.getDataFiles();
+            errorFiles = helper.getErrorFiles();
         } catch (IOException ex) {
             log.error("Unable to open output file");
         }
-        return null;
+        return createJobOutputs(dataFiles, errorFiles);
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -369,7 +369,7 @@ public class ContractProcessorImpl implements ContractProcessor {
      * @param errorFiles - any errors that arose due to writing the contract
      * @return the list of job output objects
      */
-    private List<JobOutput> createJobOutputs(List<Path> dataFiles, List<Path> errorFiles) {
+    List<JobOutput> createJobOutputs(List<Path> dataFiles, List<Path> errorFiles) {
 
         // create Job Output records for data files from the job writer
         final List<JobOutput> jobOutputs = dataFiles.stream()

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -277,8 +277,6 @@ public class ContractProcessorImpl implements ContractProcessor {
             log.warn("CancellationException while calling Future.get() - Job may have been cancelled");
         } catch (InterruptedException | ExecutionException | RuntimeException e) {
             analyzeException(futureHandles, progressTracker, e);
-        } catch (Exception ex) {
-            System.out.println("Other");
         }
         return null;
     }
@@ -325,7 +323,7 @@ public class ContractProcessorImpl implements ContractProcessor {
         }
     }
 
-    private void writeExceptionToContractErrorFile(StreamHelper helper, String data, Exception e) throws IOException {
+    void writeExceptionToContractErrorFile(StreamHelper helper, String data, Exception e) throws IOException {
         var errMsg = ExceptionUtils.getRootCauseMessage(e);
         var operationOutcome = FHIRUtil.getErrorOutcome(errMsg);
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -126,11 +126,11 @@ public class JobProcessorImpl implements JobProcessor {
         }
 
         // Create a holder for the contract, writer, progress tracker and attested date
-        ContractData contractData = new ContractData(contract, progressTracker, contract.getAttestedOn(), job.getSince(),
+        ContractData contractData = new ContractData(contract, progressTracker, job.getSince(),
                 job.getUser() != null ? job.getUser().getUsername() : null);
 
         final Segment contractSegment = NewRelic.getAgent().getTransaction().startSegment("Patient processing of contract " + contract.getContractNumber());
-        var jobOutputs = contractProcessor.process(outputDirPath, contractData, NDJSON);
+        var jobOutputs = contractProcessor.process(outputDirPath, contractData);
         contractSegment.end();
 
         // For each job output, add to the job and save the result

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessor.java
@@ -1,11 +1,10 @@
 package gov.cms.ab2d.worker.processor;
 
-import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
+import gov.cms.ab2d.worker.processor.domainmodel.EobSearchResult;
 import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
 
-import java.util.Map;
 import java.util.concurrent.Future;
 
 public interface PatientClaimsProcessor {
-    Future<Void> process(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map);
+    Future<EobSearchResult> process(PatientClaimsRequest request);
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/StreamHelper.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/StreamHelper.java
@@ -1,10 +1,11 @@
 package gov.cms.ab2d.worker.processor;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-public interface StreamHelper {
+public interface StreamHelper extends Closeable {
     void addData(byte[] data) throws IOException;
     void addError(String data) throws IOException;
     List<Path> getDataFiles();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/TextStreamHelperImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/TextStreamHelperImpl.java
@@ -46,7 +46,7 @@ public class TextStreamHelperImpl extends StreamHelperImpl {
      * @throws FileNotFoundException if you can't create the stream
      */
     private OutputStream createStream() throws FileNotFoundException {
-        String fileName = getPath().toString() + "/" + createFileName();
+        String fileName = getPath().toString() + File.separator + createFileName();
         File f = new File(fileName);
         f.getParentFile().mkdirs();
         currentFile = f;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ZipStreamHelperImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ZipStreamHelperImpl.java
@@ -61,7 +61,7 @@ public class ZipStreamHelperImpl extends StreamHelperImpl {
      * @throws FileNotFoundException if there was an error writing to the file system
      */
     private ZipOutputStream createStream() throws FileNotFoundException {
-        String zipFileName = getPath().toString() + "/" + createZipFileName();
+        String zipFileName = getPath().toString() + File.separator + createZipFileName();
         File f = new File(zipFileName);
         currentFile = f;
         getLogManager().log(EventUtils.getFileEvent(getJob(), f, FileEvent.FileStatus.OPEN));

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ContractData.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ContractData.java
@@ -11,7 +11,6 @@ import java.time.OffsetDateTime;
 public class ContractData {
     private final Contract contract;
     private final ProgressTracker progressTracker;
-    private final OffsetDateTime attestedTime;
     private final OffsetDateTime sinceTime;
     private final String userId;
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/EobSearchResult.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/EobSearchResult.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Data
 public class EobSearchResult {
-    String jobId;
-    String contractNum;
-    List<ExplanationOfBenefit> eobs;
+    private String jobId;
+    private String contractNum;
+    private List<ExplanationOfBenefit> eobs;
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/EobSearchResult.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/EobSearchResult.java
@@ -1,0 +1,13 @@
+package gov.cms.ab2d.worker.processor.domainmodel;
+
+import lombok.Data;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
+
+import java.util.List;
+
+@Data
+public class EobSearchResult {
+    String jobId;
+    String contractNum;
+    List<ExplanationOfBenefit> eobs;
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/PatientClaimsRequest.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/PatientClaimsRequest.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.worker.processor.domainmodel;
 
 import com.newrelic.api.agent.Token;
 import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries.PatientDTO;
-import gov.cms.ab2d.worker.processor.StreamHelper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,7 +11,6 @@ import java.time.OffsetDateTime;
 @AllArgsConstructor
 public class PatientClaimsRequest {
     private final PatientDTO patientDTO;
-    private final StreamHelper helper;
     private final OffsetDateTime attTime;
     private final OffsetDateTime sinceTime;
     private final String user;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/domainmodel/ProgressTracker.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.IntSummaryStatistics;
 import java.util.List;
+import java.util.Map;
+import java.util.Collections;
 
 @Getter
 @Builder
@@ -194,5 +196,14 @@ public class ProgressTracker {
 
         // This is the total completed threads done over the amount that needs to be done
         return ((double) this.totalContractBeneficiariesSearchFinished) / totalToSearch;
+    }
+
+    public Map<String, ContractBeneficiaries.PatientDTO> getPatientsByContract(String contractNumber) {
+        return getPatientsByContracts()
+                .stream()
+                .filter(byContract -> byContract.getContractNumber().equals(contractNumber))
+                .findFirst()
+                .map(ContractBeneficiaries::getPatients)
+                .orElse(Collections.emptyMap());
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJob.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJob.java
@@ -16,8 +16,6 @@ public class CancelStuckJob extends QuartzJobBean {
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
-
         processor.process();
-
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
@@ -110,8 +110,8 @@ public class ContractProcessorInvalidPatientTest {
         String output2 = outputs.get(1).getFilePath();
         assertTrue(output1.equalsIgnoreCase(fileName1) || output1.equalsIgnoreCase(fileName2));
         assertTrue(output2.equalsIgnoreCase(fileName1) || output2.equalsIgnoreCase(fileName2));
-        String actual1 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + output1));
-        String actual2 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + output2));
+        String actual1 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + File.separator + output1));
+        String actual2 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + File.separator + output2));
         assertTrue(actual1.contains("Patient/1") || actual1.contains("Patient/2"));
         assertTrue(actual2.contains("Patient/1") || actual2.contains("Patient/2"));
     }
@@ -125,7 +125,7 @@ public class ContractProcessorInvalidPatientTest {
                 tmpDirFolder.toPath(), contractId, 2000, 10, eventLogger, job);
         ((ContractProcessorImpl) cut).writeExceptionToContractErrorFile(
                 helper, val, new RuntimeException("Exception"));
-        String result = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + contractId + "_error.ndjson"));
+        String result = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + File.separator + contractId + "_error.ndjson"));
         assertEquals(val, result);
     }
 
@@ -137,7 +137,7 @@ public class ContractProcessorInvalidPatientTest {
                 tmpDirFolder.toPath(), contractId, 2000, 10, eventLogger, job);
         ((ContractProcessorImpl) cut).writeExceptionToContractErrorFile(
                 helper, null, new RuntimeException("Exception"));
-        assertThrows(NoSuchFileException.class, () -> Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + contractId + "_error.ndjson")));
+        assertThrows(NoSuchFileException.class, () -> Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + File.separator + contractId + "_error.ndjson")));
     }
 
     private static ExplanationOfBenefit createEOB(String patientId) {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.worker.processor;
 import ca.uhn.fhir.context.FhirContext;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobOutput;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.eventlogger.LogManager;
@@ -26,11 +27,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.text.ParseException;
 import java.time.OffsetDateTime;
 import java.util.*;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,28 +61,25 @@ public class ContractProcessorInvalidPatientTest {
     private ContractData contractData;
     private ProgressTracker tracker;
     private FhirContext fhirContext = FhirContext.forDstu3();
+    private String jobId = "1234";
+    private String contractId = "ABC";
 
     @BeforeEach
     void setup() throws ParseException {
 
-        String jobId = "1234";
-        String contractId = "ABC";
         patientClaimsProcessor = new PatientClaimsProcessorImpl(bfdClient, eventLogger);
         cut = new ContractProcessorImpl(fileService, jobRepository, patientClaimsProcessor, eventLogger, fhirContext);
         tracker = ProgressTracker.builder()
                 .currentMonth(9)
                 .jobUuid(jobId)
                 .numContracts(1)
-                .failureThreshold(5)
+                .failureThreshold(100)
                 .build();
 
         Contract contract = new Contract();
-        contract.setContractNumber("ABC");
+        contract.setContractNumber(contractId);
         contract.setAttestedOn(OffsetDateTime.now().minusYears(50));
         contractData = new ContractData(contract, tracker, OffsetDateTime.MIN, "User");
-        Bundle b1 = BundleUtils.createBundle(createBundleEntry("1"));
-        Bundle b2 = BundleUtils.createBundle(createBundleEntry("2"));
-        Bundle b4 = BundleUtils.createBundle(createBundleEntry("4"));
         ContractBeneficiaries cb = new ContractBeneficiaries();
         cb.setContractNumber(contractId);
         Map<String, ContractBeneficiaries.PatientDTO> map = new HashMap<>();
@@ -89,20 +89,23 @@ public class ContractProcessorInvalidPatientTest {
         map.put("2", ContractBeneficiaries.PatientDTO.builder().patientId("2").dateRangesUnderContract(dates).build());
         map.put("3", ContractBeneficiaries.PatientDTO.builder().patientId("3").dateRangesUnderContract(dates).build());
         tracker.addPatientsByContract(cb);
-        when(bfdClient.requestEOBFromServer(eq("1"), any())).thenReturn(b1);
-        when(bfdClient.requestEOBFromServer(eq("2"), any())).thenReturn(b2);
-        when(bfdClient.requestEOBFromServer(eq("3"), any())).thenReturn(b4);
         ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 20);
         ReflectionTestUtils.setField(patientClaimsProcessor, "startDate", "01/01/2020");
     }
 
     @Test
     void testInvalidBenes() throws IOException {
+        Bundle b1 = BundleUtils.createBundle(createBundleEntry("1"));
+        Bundle b2 = BundleUtils.createBundle(createBundleEntry("2"));
+        Bundle b4 = BundleUtils.createBundle(createBundleEntry("4"));
+        when(bfdClient.requestEOBFromServer(eq("1"), any())).thenReturn(b1);
+        when(bfdClient.requestEOBFromServer(eq("2"), any())).thenReturn(b2);
+        when(bfdClient.requestEOBFromServer(eq("3"), any())).thenReturn(b4);
         List<JobOutput> outputs = cut.process(tmpDirFolder.toPath(), contractData);
         assertNotNull(outputs);
         assertEquals(2, outputs.size());
-        String fileName1 = "ABC_0001.ndjson";
-        String fileName2 = "ABC_0002.ndjson";
+        String fileName1 = contractId + "_0001.ndjson";
+        String fileName2 = contractId + "_0002.ndjson";
         String output1 = outputs.get(0).getFilePath();
         String output2 = outputs.get(1).getFilePath();
         assertTrue(output1.equalsIgnoreCase(fileName1) || output1.equalsIgnoreCase(fileName2));
@@ -111,6 +114,30 @@ public class ContractProcessorInvalidPatientTest {
         String actual2 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + output2));
         assertTrue(actual1.contains("Patient/1") || actual1.contains("Patient/2"));
         assertTrue(actual2.contains("Patient/1") || actual2.contains("Patient/2"));
+    }
+
+    @Test
+    void testWriteErrors() throws IOException {
+        Job job = new Job();
+        job.setJobUuid(jobId);
+        String val = "Hello World";
+        StreamHelper helper = new TextStreamHelperImpl(
+                tmpDirFolder.toPath(), contractId, 2000, 10, eventLogger, job);
+        ((ContractProcessorImpl) cut).writeExceptionToContractErrorFile(
+                helper, val, new RuntimeException("Exception"));
+        String result = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + contractId + "_error.ndjson"));
+        assertEquals(val, result);
+    }
+
+    @Test
+    void testWriteNullErrors() throws IOException {
+        Job job = new Job();
+        job.setJobUuid(jobId);
+        StreamHelper helper = new TextStreamHelperImpl(
+                tmpDirFolder.toPath(), contractId, 2000, 10, eventLogger, job);
+        ((ContractProcessorImpl) cut).writeExceptionToContractErrorFile(
+                helper, null, new RuntimeException("Exception"));
+        assertThrows(NoSuchFileException.class, () -> Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + contractId + "_error.ndjson")));
     }
 
     private static ExplanationOfBenefit createEOB(String patientId) {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorInvalidPatientTest.java
@@ -1,0 +1,132 @@
+package gov.cms.ab2d.worker.processor;
+
+import ca.uhn.fhir.context.FhirContext;
+import gov.cms.ab2d.bfd.client.BFDClient;
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.JobOutput;
+import gov.cms.ab2d.common.repository.JobRepository;
+import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.filter.FilterOutByDate;
+import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractData;
+import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
+import gov.cms.ab2d.worker.service.FileService;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
+import org.hl7.fhir.dstu3.model.Period;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.time.OffsetDateTime;
+import java.util.*;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ContractProcessorInvalidPatientTest {
+    @Mock
+    private FileService fileService;
+    @Mock
+    private PatientClaimsProcessor patientClaimsProcessor;
+    @Mock
+    private LogManager eventLogger;
+    @Mock
+    private BFDClient bfdClient;
+    @Mock
+    private JobRepository jobRepository;
+
+    @TempDir
+    File tmpDirFolder;
+
+    private ContractProcessor cut;
+    private ContractData contractData;
+    private ProgressTracker tracker;
+    private FhirContext fhirContext = FhirContext.forDstu3();
+
+    @BeforeEach
+    void setup() throws ParseException {
+
+        String jobId = "1234";
+        String contractId = "ABC";
+        patientClaimsProcessor = new PatientClaimsProcessorImpl(bfdClient, eventLogger);
+        cut = new ContractProcessorImpl(fileService, jobRepository, patientClaimsProcessor, eventLogger, fhirContext);
+        tracker = ProgressTracker.builder()
+                .currentMonth(9)
+                .jobUuid(jobId)
+                .numContracts(1)
+                .failureThreshold(5)
+                .build();
+
+        Contract contract = new Contract();
+        contract.setContractNumber("ABC");
+        contract.setAttestedOn(OffsetDateTime.now().minusYears(50));
+        contractData = new ContractData(contract, tracker, OffsetDateTime.MIN, "User");
+        Bundle b1 = BundleUtils.createBundle(createBundleEntry("1"));
+        Bundle b2 = BundleUtils.createBundle(createBundleEntry("2"));
+        Bundle b4 = BundleUtils.createBundle(createBundleEntry("4"));
+        ContractBeneficiaries cb = new ContractBeneficiaries();
+        cb.setContractNumber(contractId);
+        Map<String, ContractBeneficiaries.PatientDTO> map = new HashMap<>();
+        cb.setPatients(map);
+        List<FilterOutByDate.DateRange> dates = Collections.singletonList(new FilterOutByDate.DateRange(new Date(0), new Date()));
+        map.put("1", ContractBeneficiaries.PatientDTO.builder().patientId("1").dateRangesUnderContract(dates).build());
+        map.put("2", ContractBeneficiaries.PatientDTO.builder().patientId("2").dateRangesUnderContract(dates).build());
+        map.put("3", ContractBeneficiaries.PatientDTO.builder().patientId("3").dateRangesUnderContract(dates).build());
+        tracker.addPatientsByContract(cb);
+        when(bfdClient.requestEOBFromServer(eq("1"), any())).thenReturn(b1);
+        when(bfdClient.requestEOBFromServer(eq("2"), any())).thenReturn(b2);
+        when(bfdClient.requestEOBFromServer(eq("3"), any())).thenReturn(b4);
+        ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 20);
+        ReflectionTestUtils.setField(patientClaimsProcessor, "startDate", "01/01/2020");
+    }
+
+    @Test
+    void testInvalidBenes() throws IOException {
+        List<JobOutput> outputs = cut.process(tmpDirFolder.toPath(), contractData);
+        assertNotNull(outputs);
+        assertEquals(2, outputs.size());
+        String fileName1 = "ABC_0001.ndjson";
+        String fileName2 = "ABC_0002.ndjson";
+        String output1 = outputs.get(0).getFilePath();
+        String output2 = outputs.get(1).getFilePath();
+        assertTrue(output1.equalsIgnoreCase(fileName1) || output1.equalsIgnoreCase(fileName2));
+        assertTrue(output2.equalsIgnoreCase(fileName1) || output2.equalsIgnoreCase(fileName2));
+        String actual1 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + output1));
+        String actual2 = Files.readString(Path.of(tmpDirFolder.getAbsolutePath() + "/" + output2));
+        assertTrue(actual1.contains("Patient/1") || actual1.contains("Patient/2"));
+        assertTrue(actual2.contains("Patient/1") || actual2.contains("Patient/2"));
+    }
+
+    private static ExplanationOfBenefit createEOB(String patientId) {
+        ExplanationOfBenefit b = new ExplanationOfBenefit();
+        Period p = new Period();
+        p.setStart(new Date(0));
+        p.setEnd(new Date());
+        b.setBillablePeriod(p);
+        Reference ref = new Reference("Patient/" + patientId);
+        b.setPatient(ref);
+        return b;
+    }
+
+    public static Bundle.BundleEntryComponent createBundleEntry(String patientId) {
+        var component = new Bundle.BundleEntryComponent();
+        component.setResource(createEOB(patientId));
+        return component;
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -120,6 +120,11 @@ class ContractProcessorUnitTest {
         assertFalse(jobOutputs.isEmpty());
     }
 
+    @Test
+    void testInvalidJobOutput() {
+        assertThrows(RuntimeException.class, () -> ((ContractProcessorImpl) cut).createJobOutputs(Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+    }
+
     private Sponsor createParentSponsor() {
         Sponsor parentSponsor = new Sponsor();
         parentSponsor.setOrgName("PARENT");

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -45,7 +45,7 @@ class ContractProcessorUnitTest {
     @Mock private FileService fileService;
     @Mock private JobRepository jobRepository;
     @Mock private LogManager eventLogger;
-    private final PatientClaimsProcessor patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
+    private PatientClaimsProcessor patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
 
     private ContractBeneficiaries patientsByContract;
     private Path outputDir;
@@ -111,13 +111,6 @@ class ContractProcessorUnitTest {
         assertFalse(jobOutputs.isEmpty());
         verify(jobRepository, times(9)).updatePercentageCompleted(anyString(), anyInt());
         verify(patientClaimsProcessor, atLeast(1)).process(any());
-    }
-
-    @Test
-    @DisplayName("When a patient is not a member of a contract, filter them out")
-    void filterOutInvalidPatients() {
-        var jobOutputs = cut.process(outputDir, contractData);
-        assertFalse(jobOutputs.isEmpty());
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -1,8 +1,8 @@
 package gov.cms.ab2d.worker.processor;
 
+import ca.uhn.fhir.context.FhirContext;
 import gov.cms.ab2d.common.model.*;
 import gov.cms.ab2d.common.repository.JobRepository;
-import gov.cms.ab2d.common.repository.OptOutRepository;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.filter.FilterOutByDate;
 import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
@@ -25,15 +25,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
-import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
 import static java.lang.Boolean.TRUE;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -45,17 +40,12 @@ class ContractProcessorUnitTest {
     // class under test
     private ContractProcessor cut;
 
-    private String jobUuid = "6d08bf08-f926-4e19-8d89-ad67ef89f17e";
-
-    private Random random = new Random();
-
     @TempDir Path efsMountTmpDir;
 
     @Mock private FileService fileService;
     @Mock private JobRepository jobRepository;
-    @Mock private OptOutRepository optOutRepository;
     @Mock private LogManager eventLogger;
-    private PatientClaimsProcessor patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
+    private final PatientClaimsProcessor patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
 
     private ContractBeneficiaries patientsByContract;
     private Path outputDir;
@@ -64,14 +54,15 @@ class ContractProcessorUnitTest {
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+        String jobUuid = "6d08bf08-f926-4e19-8d89-ad67ef89f17e";
+        FhirContext fhirContext = ca.uhn.fhir.context.FhirContext.forDstu3();
         cut = new ContractProcessorImpl(
                 fileService,
                 jobRepository,
                 patientClaimsProcessor,
-                optOutRepository,
-                eventLogger
+                eventLogger,
+                fhirContext
         );
-        ReflectionTestUtils.setField(cut, "optoutUsed", true);
         ReflectionTestUtils.setField(cut, "cancellationCheckFrequency", 2);
         ReflectionTestUtils.setField(cut, "reportProgressDbFrequency", 2);
         ReflectionTestUtils.setField(cut, "reportProgressLogFrequency", 3);
@@ -94,94 +85,39 @@ class ContractProcessorUnitTest {
                 .failureThreshold(10)
                 .build();
         progressTracker.addPatientsByContract(patientsByContract);
-        contractData = new ContractData(contract, progressTracker, contract.getAttestedOn(), job.getSince(),
+        contractData = new ContractData(contract, progressTracker, job.getSince(),
                 job.getUser() != null ? job.getUser().getUsername() : null);
     }
 
-
     @Test
     @DisplayName("When a job is cancelled while it is being processed, then attempt to stop the job gracefully without completing it")
-    void whenJobIsCancelledWhileItIsBeingProcessed_ThenAttemptToStopTheJob() throws Exception {
+    void whenJobIsCancelledWhileItIsBeingProcessed_ThenAttemptToStopTheJob() {
         when(jobRepository.findJobStatus(anyString())).thenReturn(JobStatus.CANCELLED);
 
         var exceptionThrown = assertThrows(JobCancelledException.class,
-                () -> cut.process(outputDir, contractData, NDJSON));
+                () -> cut.process(outputDir, contractData));
 
-        assertThat(exceptionThrown.getMessage(), startsWith("Job was cancelled while it was being processed"));
-        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
+        assertTrue(exceptionThrown.getMessage().startsWith("Job was cancelled while it was being processed"));
+        verify(patientClaimsProcessor, atLeast(1)).process(any());
         verify(jobRepository, atLeastOnce()).updatePercentageCompleted(anyString(), anyInt());
-    }
-
-    @Test
-    @DisplayName("When patient has opted out, but opt out is disabled their record will not be skipped.")
-    void processJob_whenSomePatientHasOptedOut_But_OptOut_Off_ShouldNotSkipThatPatientRecord() throws Exception {
-        ReflectionTestUtils.setField(cut, "optoutUsed", false);
-        final List<OptOut> optOuts = getOptOutRows(patientsByContract);
-        lenient().when(optOutRepository.findByCcwId(anyString()))
-                .thenReturn(new ArrayList<>())
-                .thenReturn(Arrays.asList(optOuts.get(1)))
-                .thenReturn(Arrays.asList(optOuts.get(2)));
-
-        List<JobOutput> jobOutputs = cut.process(outputDir, contractData, NDJSON);
-        // Verify that all outputs are returned
-        assertEquals(6, jobOutputs.size());
-    }
-
-    @Test
-    @DisplayName("When patient has opted out, their record will be skipped.")
-    void processJob_whenSomePatientHasOptedOut_ShouldSkipThatPatientRecord() throws Exception {
-        final List<OptOut> optOuts = getOptOutRows(patientsByContract);
-        when(optOutRepository.findByCcwId(anyString()))
-                .thenReturn(new ArrayList<>())
-                .thenReturn(Arrays.asList(optOuts.get(1)))
-                .thenReturn(Arrays.asList(optOuts.get(2)));
-
-        var jobOutputs = cut.process(outputDir, contractData, NDJSON);
-
-        assertFalse(jobOutputs.isEmpty());
-        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
-    }
-
-    @Test
-    @DisplayName("When all patients have opted out, should throw exception as no jobOutput rows were created")
-    void processJob_whenAllPatientsHaveOptedOut_ShouldThrowException() throws Exception {
-        final List<OptOut> optOuts = getOptOutRows(patientsByContract);
-        when(optOutRepository.findByCcwId(anyString()))
-                .thenReturn(Arrays.asList(optOuts.get(0)))
-                .thenReturn(Arrays.asList(optOuts.get(1)))
-                .thenReturn(Arrays.asList(optOuts.get(2)));
-
-        // Test data has 3 patientIds each of whom has opted out.
-        // So the patientsClaimsProcessor should never be called.
-        var exceptionThrown = assertThrows(RuntimeException.class,
-                () -> cut.process(outputDir, contractData, NDJSON));
-
-        assertThat(exceptionThrown.getMessage(), startsWith("The export process has produced no results"));
-        verify(patientClaimsProcessor, never()).process(any(), any());
     }
 
     @Test
     @DisplayName("When many patientId are present, 'PercentageCompleted' should be updated many times")
     void whenManyPatientIdsAreProcessed_shouldUpdatePercentageCompletedMultipleTimes() throws Exception {
         patientsByContract.setPatients(createPatients(18));
-        var jobOutputs = cut.process(outputDir, contractData, NDJSON);
+        var jobOutputs = cut.process(outputDir, contractData);
 
         assertFalse(jobOutputs.isEmpty());
         verify(jobRepository, times(9)).updatePercentageCompleted(anyString(), anyInt());
-        verify(patientClaimsProcessor, atLeast(1)).process(any(), any());
+        verify(patientClaimsProcessor, atLeast(1)).process(any());
     }
 
-    private List<OptOut> getOptOutRows(ContractBeneficiaries patientsByContract) {
-        return patientsByContract.getPatients().keySet().stream()
-                .map(this::createOptOut)
-                .collect(Collectors.toList());
-    }
-
-    private OptOut createOptOut(String patientId) {
-        OptOut optOut = new OptOut();
-        optOut.setHicn(patientId);
-        optOut.setEffectiveDate(LocalDate.now().minusDays(10));
-        return optOut;
+    @Test
+    @DisplayName("When a patient is not a member of a contract, filter them out")
+    void filterOutInvalidPatients() {
+        var jobOutputs = cut.process(outputDir, contractData);
+        assertFalse(jobOutputs.isEmpty());
     }
 
     private Sponsor createParentSponsor() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/EobTestDataUtil.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/EobTestDataUtil.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.Resource;
 
+import java.io.File;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public final class EobTestDataUtil {
 
         SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
         final String testInputFile = "test-data/EOB-for-Carrier-Claims.json";
-        final InputStream inputStream = EobTestDataUtil.class.getResourceAsStream("/" + testInputFile);
+        final InputStream inputStream = EobTestDataUtil.class.getResourceAsStream(File.separator + testInputFile);
 
         final EncodingEnum respType = EncodingEnum.forContentType(EncodingEnum.JSON_PLAIN_STRING);
         final IParser parser = respType.newParser(FhirContext.forDstu3());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -82,7 +82,7 @@ class JobPreProcessorIntegrationTest {
     @DisplayName("When a job is in submitted status, it can be put into progress upon starting processing")
     void whenJobIsInSubmittedStatus_ThenJobShouldBePutInProgress() {
         var processedJob = cut.preprocess("S0000");
-        assertThat(processedJob.getStatus(), is(JobStatus.IN_PROGRESS));
+        assertEquals(processedJob.getStatus(), JobStatus.IN_PROGRESS);
 
         List<LoggableEvent> jobStatusChange = doAll.load(JobStatusChangeEvent.class);
         assertEquals(1, jobStatusChange.size());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -11,7 +11,6 @@ import gov.cms.ab2d.common.model.User;
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.repository.JobOutputRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
-import gov.cms.ab2d.common.repository.OptOutRepository;
 import gov.cms.ab2d.common.repository.SponsorRepository;
 import gov.cms.ab2d.common.repository.UserRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
@@ -61,7 +60,7 @@ import static org.mockito.Mockito.when;
 @SpringIntegrationTest(noAutoStartup = {"inboundChannelAdapter", "*Source*"})
 @Transactional
 class JobProcessorIntegrationTest {
-    private Random random = new Random();
+    private final Random random = new Random();
 
     private JobProcessor cut;       // class under test
 
@@ -82,8 +81,6 @@ class JobProcessorIntegrationTest {
     @Autowired
     @Qualifier("contractAdapterStub")
     private ContractBeneSearch contractBeneSearchStub;
-    @Autowired
-    private OptOutRepository optOutRepository;
     @Autowired
     private SqlEventLogger sqlEventLogger;
     @Mock
@@ -129,14 +126,14 @@ class JobProcessorIntegrationTest {
         fail = new RuntimeException("TEST EXCEPTION");
 
         FhirContext fhirContext = FhirContext.forDstu3();
-        PatientClaimsProcessor patientClaimsProcessor = new PatientClaimsProcessorImpl(mockBfdClient, fhirContext, logManager);
+        PatientClaimsProcessor patientClaimsProcessor = new PatientClaimsProcessorImpl(mockBfdClient, logManager);
         ReflectionTestUtils.setField(patientClaimsProcessor, "startDate", "01/01/1900");
         ContractProcessor contractProcessor = new ContractProcessorImpl(
                 fileService,
                 jobRepository,
                 patientClaimsProcessor,
-                optOutRepository,
-                logManager
+                logManager,
+                fhirContext
         );
 
         ReflectionTestUtils.setField(contractProcessor, "cancellationCheckFrequency", 10);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -23,6 +23,7 @@ import gov.cms.ab2d.eventlogger.reports.sql.DoAll;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneSearch;
 import gov.cms.ab2d.worker.service.FileService;
+import gov.cms.ab2d.worker.util.HealthCheck;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.junit.Assert;
@@ -83,6 +84,8 @@ class JobProcessorIntegrationTest {
     private ContractBeneSearch contractBeneSearchStub;
     @Autowired
     private SqlEventLogger sqlEventLogger;
+    @Autowired
+    private HealthCheck healthCheck;
     @Mock
     private KinesisEventLogger kinesisEventLogger;
     @Mock
@@ -223,6 +226,11 @@ class JobProcessorIntegrationTest {
 
         final List<JobOutput> jobOutputs = job.getJobOutputs();
         assertFalse(jobOutputs.isEmpty());
+    }
+
+    @Test
+    void testHealth() {
+        assertTrue(healthCheck.healthy());
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.processor;
 
-import ca.uhn.fhir.context.FhirContext;
 import com.newrelic.api.agent.Token;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
@@ -11,7 +10,6 @@ import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
-import org.hl7.fhir.dstu3.model.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,10 +32,9 @@ import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,14 +53,14 @@ public class PatientClaimsProcessorUnitTest {
 
     private ExplanationOfBenefit eob;
     private Map<String, ContractBeneficiaries.PatientDTO> patientPTOMap;
-    private static String patientId = "1234567890";
-    private static String SAMPLE_CONTRACT_ID = "CONTRACT1";
+    private final static String patientId = "1234567890";
+    private final static String SAMPLE_CONTRACT_ID = "CONTRACT1";
 
-    private OffsetDateTime earlyAttDate = OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-    private OffsetDateTime laterAttDate = OffsetDateTime.of(2020, 2, 15, 0, 0, 0, 0, ZoneOffset.UTC);
+    private final OffsetDateTime earlyAttDate = OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    private final OffsetDateTime laterAttDate = OffsetDateTime.of(2020, 2, 15, 0, 0, 0, 0, ZoneOffset.UTC);
     private ContractBeneficiaries.PatientDTO patientDTO;
 
-    private Token noOpToken = new Token() {
+    private final Token noOpToken = new Token() {
         @Override
         public boolean link() {
             return false;
@@ -88,10 +85,8 @@ public class PatientClaimsProcessorUnitTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        FhirContext fhirContext = ca.uhn.fhir.context.FhirContext.forDstu3();
         cut = new PatientClaimsProcessorImpl(
                 mockBfdClient,
-                fhirContext,
                 eventLogger
         );
 
@@ -114,52 +109,8 @@ public class PatientClaimsProcessorUnitTest {
         StreamHelper helper = new TextStreamHelperImpl(tmpEfsMountDir.toPath(), contract.getContractNumber(),
                 30, 120, eventLogger, null);
 
-        request = new PatientClaimsRequest(patientDTO, helper, laterAttDate, null, "user", "job",
+        request = new PatientClaimsRequest(patientDTO, laterAttDate, null, "user", "job",
                 "contractNum", noOpToken);
-    }
-
-    @Test
-    void process_whenPatientInEOBIsNotInContract() throws ParseException {
-        Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        ExplanationOfBenefit eob = (ExplanationOfBenefit) bundle1.getEntry().get(0).getResource();
-        eob.getPatient().setReference("Patient/BADPATID");
-        List<Resource> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
-        assertEquals(resources.size(), 0);
-    }
-
-    @Test
-    void process_whenPatientInEOBIsNotInContract2() throws ParseException {
-        // Empty the patient list
-        Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        patientPTOMap.clear();
-        List<Resource> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
-        assertEquals(resources.size(), 0);
-
-        // Enter an invalid patient list
-        ContractBeneficiaries.PatientDTO badPatient = new ContractBeneficiaries.PatientDTO();
-        badPatient.setPatientId("BADPATID");
-        badPatient.setDateRangesUnderContract(List.of(new DateRange(new Date(0), new Date())));
-        patientPTOMap.put("BADPATID", badPatient);
-        resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
-        assertEquals(resources.size(), 0);
-
-        // Add a correct patient and verify it comes over
-        ContractBeneficiaries.PatientDTO goodPatient = new ContractBeneficiaries.PatientDTO();
-        String goodPatientId = "-199900000022040";
-        goodPatient.setPatientId(goodPatientId);
-        goodPatient.setDateRangesUnderContract(List.of(new DateRange(new Date(0), new Date())));
-        assertEquals(resources.size(), 0);
-        patientPTOMap.put(goodPatientId, goodPatient);
-        resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
-        assertEquals(resources.size(), 1);
     }
 
     @Test
@@ -176,25 +127,21 @@ public class PatientClaimsProcessorUnitTest {
 
         eob.getBillablePeriod().setStart(d1);
         eob.getBillablePeriod().setEnd(d1);
-        List<Resource> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
+        List<ExplanationOfBenefit> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10));
         assertEquals(1, resources.size());
 
         resources = cut.extractResources("Z0001", bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10));
         assertEquals(1, resources.size());
 
         eob.getBillablePeriod().setStart(d2);
         eob.getBillablePeriod().setEnd(d2);
         resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10));
         assertEquals(0, resources.size());
         resources = cut.extractResources("Z0001", bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10));
         assertEquals(1, resources.size());
     }
 
@@ -204,38 +151,33 @@ public class PatientClaimsProcessorUnitTest {
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
         ReflectionTestUtils.setField(cut, "startDate", "01/01/2020");
         // Attestation time is 10 years ago, eob date is 01/02/2020
-        List<Resource> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10),
-                patientPTOMap);
+        List<ExplanationOfBenefit> resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(10));
         assertEquals(1, resources.size());
         // Set the billable date to 1970 and attestation date to 1920, should return no results
         ExplanationOfBenefit eob = (ExplanationOfBenefit) bundle1.getEntry().get(0).getResource();
         eob.getBillablePeriod().setStart(new Date(10));
         eob.getBillablePeriod().setEnd(new Date(10));
         resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(100),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(100));
         assertEquals(0, resources.size());
         // Set billable date to late year and attestation date to a hundred years ago, shouldn't return results
         SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
         eob.getBillablePeriod().setStart(sdf.parse("12/29/2019"));
         eob.getBillablePeriod().setEnd(sdf.parse("12/30/2019"));
         resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(100),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now().minusYears(100));
         assertEquals(0, resources.size());
         // Set billable period to early 2020, attestation date in 2019, should return 1
         eob.getBillablePeriod().setStart(sdf.parse("01/02/2020"));
         eob.getBillablePeriod().setEnd(sdf.parse("01/03/2020"));
         resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
                 List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.of(2019, 1, 1,
-                        1, 1, 1, 1, ZoneOffset.UTC),
-                patientPTOMap);
+                        1, 1, 1, 1, ZoneOffset.UTC));
         assertEquals(1, resources.size());
         // billable period is early 2020, attestation date is today, should return 0
         resources = cut.extractResources(SAMPLE_CONTRACT_ID, bundle1.getEntry(),
-                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now(),
-                patientPTOMap);
+                List.of(new DateRange(new Date(0), new Date())), OffsetDateTime.now());
         assertEquals(0, resources.size());
     }
 
@@ -244,7 +186,7 @@ public class PatientClaimsProcessorUnitTest {
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
         when(mockBfdClient.requestEOBFromServer(patientId, request.getAttTime())).thenReturn(bundle1);
 
-        cut.process(request, patientPTOMap).get();
+        cut.process(request).get();
 
         verify(mockBfdClient).requestEOBFromServer(patientId, request.getAttTime());
         verify(mockBfdClient, never()).requestNextBundleFromServer(bundle1);
@@ -260,7 +202,7 @@ public class PatientClaimsProcessorUnitTest {
         when(mockBfdClient.requestEOBFromServer(patientId, request.getAttTime())).thenReturn(bundle1);
         when(mockBfdClient.requestNextBundleFromServer(bundle1)).thenReturn(bundle2);
 
-        cut.process(request, patientPTOMap).get();
+        cut.process(request).get();
 
         verify(mockBfdClient).requestEOBFromServer(patientId, request.getAttTime());
         verify(mockBfdClient).requestNextBundleFromServer(bundle1);
@@ -272,9 +214,9 @@ public class PatientClaimsProcessorUnitTest {
         when(mockBfdClient.requestEOBFromServer(patientId, request.getAttTime())).thenThrow(new RuntimeException("Test Exception"));
 
         var exceptionThrown = assertThrows(ExecutionException.class,
-                () -> cut.process(request, patientPTOMap).get());
+                () -> cut.process(request).get());
 
-        assertThat(exceptionThrown.getCause().getMessage(), startsWith("Test Exception"));
+        assertTrue(exceptionThrown.getCause().getMessage().startsWith("Test Exception"));
 
         verify(mockBfdClient).requestEOBFromServer(patientId, request.getAttTime());
         verify(mockBfdClient, never()).requestNextBundleFromServer(bundle1);
@@ -285,7 +227,7 @@ public class PatientClaimsProcessorUnitTest {
         Bundle bundle1 = new Bundle();
         when(mockBfdClient.requestEOBFromServer(patientId, request.getAttTime())).thenReturn(bundle1);
 
-        cut.process(request, patientPTOMap).get();
+        cut.process(request).get();
 
         verify(mockBfdClient).requestEOBFromServer(patientId, request.getAttTime());
         verify(mockBfdClient, never()).requestNextBundleFromServer(bundle1);
@@ -305,13 +247,13 @@ public class PatientClaimsProcessorUnitTest {
 
         OffsetDateTime sinceDate = earlyAttDate.plusDays(1);
 
-        request = new PatientClaimsRequest(patientDTO, helper, laterAttDate, sinceDate, "user", "job",
+        request = new PatientClaimsRequest(patientDTO, laterAttDate, sinceDate, "user", "job",
                 "contractNum", noOpToken);
 
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
         when(mockBfdClient.requestEOBFromServer(patientId, request.getSinceTime())).thenReturn(bundle1);
 
-        cut.process(request, patientPTOMap).get();
+        cut.process(request).get();
 
         verify(mockBfdClient).requestEOBFromServer(patientId, request.getSinceTime());
         verify(mockBfdClient, never()).requestNextBundleFromServer(bundle1);
@@ -329,13 +271,13 @@ public class PatientClaimsProcessorUnitTest {
         StreamHelper helper = new TextStreamHelperImpl(tmpEfsMountDir.toPath(), contract.getContractNumber(),
                 30, 120, eventLogger, null);
 
-        request = new PatientClaimsRequest(patientDTO, helper, earlyAttDate, null, "user", "job",
+        request = new PatientClaimsRequest(patientDTO, earlyAttDate, null, "user", "job",
                 "contractNum", noOpToken);
 
         Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
         when(mockBfdClient.requestEOBFromServer(patientId, null)).thenReturn(bundle1);
 
-        cut.process(request, patientPTOMap).get();
+        cut.process(request).get();
 
         verify(mockBfdClient).requestEOBFromServer(patientId, null);
         verify(mockBfdClient, never()).requestNextBundleFromServer(bundle1);
@@ -346,8 +288,8 @@ public class PatientClaimsProcessorUnitTest {
         final Path outputDirPath = Paths.get(tmpEfsMountDir.toPath().toString(), UUID.randomUUID().toString());
         Files.createDirectories(outputDirPath);
 
-        Path outputFile = createFile(outputDirPath, "contract_name.ndjson");
-        Path errorFile = createFile(outputDirPath, "contract_name_error.ndjson");
+        createFile(outputDirPath, "contract_name.ndjson");
+        createFile(outputDirPath, "contract_name_error.ndjson");
     }
 
     private Path createFile(Path outputDirPath, String output_filename) throws IOException {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
@@ -3,9 +3,13 @@ package gov.cms.ab2d.worker.processor.stub;
 import gov.cms.ab2d.worker.processor.PatientClaimsProcessor;
 import gov.cms.ab2d.worker.processor.domainmodel.EobSearchResult;
 import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
+import org.hl7.fhir.dstu3.model.Period;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.springframework.scheduling.annotation.AsyncResult;
 
-import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.concurrent.Future;
 
 public class PatientClaimsProcessorStub implements PatientClaimsProcessor {
@@ -13,7 +17,14 @@ public class PatientClaimsProcessorStub implements PatientClaimsProcessor {
     @Override
     public Future<EobSearchResult> process(PatientClaimsRequest request) {
         EobSearchResult result = new EobSearchResult();
-        result.setEobs(new ArrayList<>());
+        ExplanationOfBenefit eob = new ExplanationOfBenefit();
+        Reference ref = new Reference("Patient/" + request.getPatientDTO().getPatientId());
+        eob.setPatient(ref);
+        Period period = new Period();
+        period.setStart(new Date(0));
+        period.setEnd(new Date());
+        eob.setBillablePeriod(period);
+        result.setEobs(Collections.singletonList(eob));
         result.setJobId(request.getJob());
         result.setContractNum(request.getContractNum());
         return new AsyncResult<>(result);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/stub/PatientClaimsProcessorStub.java
@@ -1,21 +1,21 @@
 package gov.cms.ab2d.worker.processor.stub;
 
-import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
 import gov.cms.ab2d.worker.processor.PatientClaimsProcessor;
+import gov.cms.ab2d.worker.processor.domainmodel.EobSearchResult;
 import gov.cms.ab2d.worker.processor.domainmodel.PatientClaimsRequest;
 import org.springframework.scheduling.annotation.AsyncResult;
 
-import java.nio.file.Path;
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.concurrent.Future;
 
 public class PatientClaimsProcessorStub implements PatientClaimsProcessor {
 
     @Override
-    public Future<Void> process(PatientClaimsRequest request, Map<String, ContractBeneficiaries.PatientDTO> map) {
-
-        request.getHelper().getDataFiles().add(Path.of("TEST_DATA_FILE"));
-        request.getHelper().getErrorFiles().add(Path.of("TEST_ERROR_FILE"));
-        return new AsyncResult<>(null);
+    public Future<EobSearchResult> process(PatientClaimsRequest request) {
+        EobSearchResult result = new EobSearchResult();
+        result.setEobs(new ArrayList<>());
+        result.setJobId(request.getJob());
+        result.setContractNum(request.getContractNum());
+        return new AsyncResult<>(result);
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
@@ -5,21 +5,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FileServiceIntegrationTest {
@@ -51,5 +44,10 @@ public class FileServiceIntegrationTest {
                 () -> cut.createDirectory(tmpEfsMountDir.toPath()));
 
         assertThat(exceptionThrown.getMessage(), startsWith("Could not create output directory"));
+    }
+
+    @Test
+    void testGenerateChecksum() {
+        assertThrows(UncheckedIOException.class, () -> cut.generateChecksum(new File("/invalid/file")));
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2109](https://jira.cms.gov/browse/AB2D-2109) - Moved serialization from the EOB search Future to the contract processor.

### What Does This PR Do?

 First step in separation of the different components from worker - job management, EOB searching and data serialization. Instead of returning Void in the Future, it now returns a response object with the EOB values. Validation of the patients against the contract was also moved to the contract processor.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure