### PR TITLE
change from developer v2 level token to prod v3 token

### DIFF
--- a/Deploy/bash/functions/fn_get_temporary_aws_credentials_via_cloudtamer_api.sh
+++ b/Deploy/bash/functions/fn_get_temporary_aws_credentials_via_cloudtamer_api.sh
@@ -46,11 +46,11 @@ fn_get_temporary_aws_credentials_via_cloudtamer_api ()
   echo "--------------------"
   echo ""
 
-  BEARER_TOKEN=$(curl --location --request POST 'https://cloudtamer.cms.gov/api/v2/token' \
+  BEARER_TOKEN=$(curl --location --request POST 'https://cloudtamer.cms.gov/api/v3/token' \
     --header 'Accept: application/json' \
     --header 'Accept-Language: en-US,en;q=0.5' \
     --header 'Content-Type: application/json' \
-    --data-raw "{\"username\":\"${CLOUDTAMER_USER_NAME}\",\"password\":\"${CLOUDTAMER_PASSWORD}\",\"idms\":{\"id\":2}}" \
+    --data-raw "{\"username\":\"${CLOUDTAMER_USER_NAME}\",\"password\":\"${CLOUDTAMER_PASSWORD}\",\"idms\":2}" \
     | jq --raw-output ".data.access.token")
 
   if [ "${BEARER_TOKEN}" == "null" ]; then


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-1519](https://jira.cms.gov/browse/AB2D-1519) - Fix CloudTamer scripts to use different API endpoints

***Related Tickets***

N/A
 
### What Does This PR Do?

- updates the shared CloudTamer function from v2/token (developer only) to the recently released production v3/token

### What Should Reviewers Watch For?

N/A

### Usage/Deployment Instructions

1. Change to the "ab2d" repo directory

1. Test "connect-to-node.sh" which used the changed function by entering the following

   ```ShellSession
   $ ./Deploy/bash/connect-to-node.sh
   ```

### Impacted External Components

N/A

### Database Changes

N/A

### Limitations

N/A

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure