### PR TITLE
patient contract callable modified to filter by year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,9 @@ before_script:
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:
+# todo simplify back to original once fix is issued for coverage mapping
 - mvn clean package -DskipTests
-- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
+#- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
 - export PATIENT_CONTRACT_YEAR=3
 - mvn test -pl e2e-test
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ script:
 # todo simplify back to original once fix is issued for coverage mapping
 - mvn clean package -DskipTests
 #- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
-- export PATIENT_CONTRACT_YEAR=3
 - mvn test -pl e2e-test
 after_script:
 - export JACOCO_SOURCE_PATH=./api/src/main/java; ./cc-test-reporter format-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 script:
 - mvn clean package -DskipTests
 - mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
-- export PATIENT_COVERAGE_YEAR=3
+- export PATIENT_CONTRACT_YEAR=3
 - mvn test -pl e2e-test
 after_script:
 - export JACOCO_SOURCE_PATH=./api/src/main/java; ./cc-test-reporter format-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 script:
 # todo simplify back to original once fix is issued for coverage mapping
 - mvn clean package -DskipTests
-# - mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
+- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
 - mvn test -pl e2e-test
 after_script:
 - export JACOCO_SOURCE_PATH=./api/src/main/java; ./cc-test-reporter format-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,10 @@ before_script:
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:
-- mvn clean install -q
+- mvn clean package -DskipTests
+- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
+- export PATIENT_COVERAGE_YEAR=3
+- mvn test -pl e2e-test
 after_script:
 - export JACOCO_SOURCE_PATH=./api/src/main/java; ./cc-test-reporter format-coverage
   ./api/target/site/jacoco/jacoco.xml --input-type jacoco -o codeclimate.api.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 script:
 # todo simplify back to original once fix is issued for coverage mapping
 - mvn clean package -DskipTests
-#- mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
+# - mvn test -pl eventlogger,common,api,worker,bfd,filter,audit,hpms,mock-hpms
 - mvn test -pl e2e-test
 after_script:
 - export JACOCO_SOURCE_PATH=./api/src/main/java; ./cc-test-reporter format-coverage

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -112,9 +112,9 @@ public class TestRunner {
                     .withScaledService("worker", 2)
                     .withExposedService("db", 5432)
                     .withExposedService("api", 8443, new HostPortWaitStrategy()
-                    .withStartupTimeout(Duration.of(200, SECONDS)));
-//                    .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-//                    .withLogConsumer("api", new Slf4jLogConsumer(log));
+                    .withStartupTimeout(Duration.of(200, SECONDS)))
+                    .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+                    .withLogConsumer("api", new Slf4jLogConsumer(log));
             container.start();
         }
 

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -112,9 +112,9 @@ public class TestRunner {
                     .withScaledService("worker", 2)
                     .withExposedService("db", 5432)
                     .withExposedService("api", 8443, new HostPortWaitStrategy()
-                    .withStartupTimeout(Duration.of(200, SECONDS)))
-                    .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-                    .withLogConsumer("api", new Slf4jLogConsumer(log));
+                    .withStartupTimeout(Duration.of(200, SECONDS)));
+//                    .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+//                    .withLogConsumer("api", new Slf4jLogConsumer(log));
             container.start();
         }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchImpl.java
@@ -12,6 +12,7 @@ import gov.cms.ab2d.worker.processor.PatientContractCallable;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
 import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
@@ -38,11 +39,16 @@ public class ContractBeneSearchImpl implements ContractBeneSearch {
 
     public ContractBeneSearchImpl(BFDClient bfdClient, LogManager eventLogger,
                                   @Qualifier("patientContractThreadPool") ThreadPoolTaskExecutor patientPool,
-                                  @Value("${patient.contract.year}") int year) {
+                                  @Value("${patient.contract.year:}") String year) {
         this.bfdClient = bfdClient;
         this.eventLogger = eventLogger;
         this.patientContractThreadPool = patientPool;
-        this.year = year;
+
+        if (StringUtils.isBlank(year)) {
+            this.year = LocalDate.now().getYear();
+        } else {
+            this.year = Integer.parseInt(year);
+        }
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchImpl.java
@@ -12,7 +12,6 @@ import gov.cms.ab2d.worker.processor.PatientContractCallable;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
 import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientContractCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientContractCallable.java
@@ -5,63 +5,105 @@ import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.ResourceType;
+import org.hl7.fhir.dstu3.model.*;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
 
 @Slf4j
 public class PatientContractCallable implements Callable<ContractMapping> {
     private static final String BENEFICIARY_ID = "https://bluebutton.cms.gov/resources/variables/bene_id";
-    private int month;
-    private String contractNumber;
-    private BFDClient bfdClient;
 
-    public PatientContractCallable(String contractNumber, int month, BFDClient bfdClient) {
-        this.month = month;
+    private final int month;
+    private final int year;
+    private final String contractNumber;
+    private final BFDClient bfdClient;
+
+    private int missingIdentifier = 0;
+    private int pastYear = 0;
+
+    public PatientContractCallable(String contractNumber, int month, int year, BFDClient bfdClient) {
         this.contractNumber = contractNumber;
+        this.month = month;
+        this.year = year;
         this.bfdClient = bfdClient;
     }
 
     @Override
     public ContractMapping call() throws Exception {
+
+        final Set<String> patientIds = new HashSet<>();
         try {
             ContractMapping mapping = new ContractMapping();
             mapping.setMonth(month);
             Bundle bundle = getBundle(contractNumber, month);
-            final Set<String> patientIDs = extractPatientIDs(bundle);
+            patientIds.addAll(extractAndFilter(bundle));
 
             while (bundle.getLink(Bundle.LINK_NEXT) != null) {
                 bundle = bfdClient.requestNextBundleFromServer(bundle);
-                patientIDs.addAll(extractPatientIDs(bundle));
+                patientIds.addAll(extractAndFilter(bundle));
             }
-            mapping.setPatients(patientIDs);
-            log.debug("finished reading [{}] Set<String>resources", patientIDs.size());
+            mapping.setPatients(patientIds);
+            log.debug("finished reading [{}] Set<String>resources", patientIds.size());
             return mapping;
         } catch (Exception e) {
             log.error("Unable to get patient information for " + contractNumber + " for month " + month, e);
             throw e;
+        } finally {
+
+            int total = patientIds.size() + pastYear + missingIdentifier;
+            log.info("Search discarded {} entries not meeting year filter criteria out of {}", pastYear, total);
+            log.info("Search discarded {} entries missing an identifier out of {}", missingIdentifier, total);
+
         }
     }
 
-    /**
-     * Given a Bundle, filters resources of type Patient and returns a list of patientIds
-     *
-     * @param bundle the bundle to extract data from
-     * @return a list of patientIds
-     */
-    private Set<String> extractPatientIDs(Bundle bundle) {
-        return bundle.getEntry().stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .filter(resource -> resource.getResourceType() == ResourceType.Patient)
-                .map(resource -> (Patient) resource)
+    private Set<String> extractAndFilter(Bundle bundle) {
+        return getPatientStream(bundle)
+                .filter(this::filterByYear)
                 .map(this::extractPatientId)
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toSet());
+                .filter(this::notMissingIdentifier)
+                .collect(toSet());
+    }
+
+    private Stream<Patient> getPatientStream(Bundle bundle) {
+        return bundle.getEntry().stream().map(Bundle.BundleEntryComponent::getResource)
+                .filter(resource -> resource.getResourceType() == ResourceType.Patient)
+                .map(resource -> (Patient) resource);
+    }
+
+    private boolean filterByYear(Patient patient) {
+        List<Extension> referenceYearList = patient.getExtensionsByUrl("https://bluebutton.cms.gov/resources/variables/rfrnc_yr");
+
+        if (referenceYearList.isEmpty()) {
+            log.error("patient returned without reference year violating assumptions");
+            pastYear += 1;
+            return false;
+        } else {
+            DateType refYear = (DateType) (referenceYearList.get(0).getValue());
+
+            if (refYear.getYear() != this.year) {
+                pastYear += 1;
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private boolean notMissingIdentifier(String id) {
+        boolean blankId = StringUtils.isBlank(id);
+
+        // If blank increment count to log issues
+        if (blankId) {
+            missingIdentifier += 1;
+        }
+
+        return !blankId;
     }
 
     /**
@@ -72,7 +114,7 @@ public class PatientContractCallable implements Callable<ContractMapping> {
      */
     private String extractPatientId(Patient patient) {
         return patient.getIdentifier().stream()
-                .filter(identifier -> isBeneficiaryId(identifier))
+                .filter(this::isBeneficiaryId)
                 .map(Identifier::getValue)
                 .findFirst()
                 .orElse(null);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientContractCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientContractCallable.java
@@ -21,17 +21,19 @@ public class PatientContractCallable implements Callable<ContractMapping> {
 
     private final int month;
     private final int year;
+    private final boolean skipBillablePeriodCheck;
     private final String contractNumber;
     private final BFDClient bfdClient;
 
     private int missingIdentifier;
     private int pastYear;
 
-    public PatientContractCallable(String contractNumber, int month, int year, BFDClient bfdClient) {
+    public PatientContractCallable(String contractNumber, int month, int year, BFDClient bfdClient, boolean skipBillablePeriodCheck) {
         this.contractNumber = contractNumber;
         this.month = month;
         this.year = year;
         this.bfdClient = bfdClient;
+        this.skipBillablePeriodCheck = skipBillablePeriodCheck;
     }
 
     @Override
@@ -63,7 +65,7 @@ public class PatientContractCallable implements Callable<ContractMapping> {
 
     private Set<String> extractAndFilter(Bundle bundle) {
         return getPatientStream(bundle)
-                .filter(this::filterByYear)
+                .filter(patient -> skipBillablePeriodCheck || filterByYear(patient))
                 .map(this::extractPatientId)
                 .filter(this::isValidIdentifier)
                 .collect(toSet());

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -65,7 +65,3 @@ claims.skipBillablePeriodCheck=${AB2D_CLAIMS_SKIP_BILLABLE_PERIOD_CHECK:#{false}
 bfd.earliest.data.date=${AB2D_EARLIEST_DATA_DATE:#{'01/01/2020'}}
 bfd.earliest.data.date.special.contracts=01/01/1990
 bfd.special.contracts=Z0001,S0001
-
-
-## ----------------------------------------------------------------------------- Filter out coverage by year
-patient.contract.year=2020

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -65,3 +65,7 @@ claims.skipBillablePeriodCheck=${AB2D_CLAIMS_SKIP_BILLABLE_PERIOD_CHECK:#{false}
 bfd.earliest.data.date=${AB2D_EARLIEST_DATA_DATE:#{'01/01/2020'}}
 bfd.earliest.data.date.special.contracts=01/01/1990
 bfd.special.contracts=Z0001,S0001
+
+
+## ----------------------------------------------------------------------------- Filter out coverage by year
+patient.contract.year=2020

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
@@ -5,12 +5,11 @@ import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.common.util.FilterOutByDate;
+import gov.cms.ab2d.worker.processor.BundleUtils;
 import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.dstu3.model.Bundle.BundleLinkComponent;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +25,7 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import static gov.cms.ab2d.worker.processor.BundleUtils.BENEFICIARY_ID;
+import static gov.cms.ab2d.worker.processor.BundleUtils.createBundleEntry;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -38,6 +37,9 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ContractBeneSearchTest {
+
+    private static final int YEAR = 2020;
+
     private ProgressTracker tracker;
 
     @Mock BFDClient client;
@@ -55,7 +57,7 @@ class ContractBeneSearchTest {
         taskExecutor.setMaxPoolSize(12);
         taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         taskExecutor.initialize();
-        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor);
+        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, YEAR);
 
         bundle = createBundle();
         lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);
@@ -116,13 +118,13 @@ class ContractBeneSearchTest {
         Bundle bundle1 = bundle.copy();
         // add 2nd patient
         List<BundleEntryComponent> entries = bundle1.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
 
-        Date startJanuary = FilterOutByDate.getStartOfMonth(1, 2020);
-        Date endJanuary = FilterOutByDate.getEndOfMonth(1, 2020);
+        Date startJanuary = FilterOutByDate.getStartOfMonth(1, YEAR);
+        Date endJanuary = FilterOutByDate.getEndOfMonth(1, YEAR);
 
-        Date startMarch = FilterOutByDate.getStartOfMonth(3, 2020);
-        Date endMarch = FilterOutByDate.getEndOfMonth(3, 2020);
+        Date startMarch = FilterOutByDate.getStartOfMonth(3, YEAR);
+        Date endMarch = FilterOutByDate.getEndOfMonth(3, YEAR);
 
         when(client.requestPartDEnrolleesFromServer("S0000", 1))
                 .thenReturn(bundle1);    // January - patient1 is active
@@ -161,7 +163,7 @@ class ContractBeneSearchTest {
 
         // add 2nd patient
         List<BundleEntryComponent> entries = bundle1.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
 
         when(client.requestPartDEnrolleesFromServer(anyString(), anyInt()))
                 .thenReturn(bundle, bundle1);
@@ -195,7 +197,7 @@ class ContractBeneSearchTest {
 
         // bundle1 has 2 patients in January
         List<BundleEntryComponent> entries = bundle1.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
 
         // bundle2  has 1 patient in February, coz patient_001 left and is no longer active in contract
         Bundle bundle2 = bundle.copy();
@@ -225,7 +227,7 @@ class ContractBeneSearchTest {
     @Test
     void GivenTwoPatientsActiveInJanAndFeb_ShouldReturnTwoPatientRowsEachWithTwoRowsInDateRangesUnderContract() throws ExecutionException, InterruptedException {
         List<BundleEntryComponent> entries = bundle.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
 
         ContractBeneficiaries response = cut.getPatients(contractNumber, Month.FEBRUARY.getValue(), tracker);
 
@@ -249,10 +251,10 @@ class ContractBeneSearchTest {
         Bundle bundle1 = bundle.copy();
 
         List<BundleEntryComponent> entries = bundle1.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
         bundle1.addLink(addNextLink());
 
-        Bundle bundle2 = createBundle("ccw_patient_002");
+        Bundle bundle2 = createBundle("ccw_patient_002", YEAR);
 
         when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle1);
         when(client.requestNextBundleFromServer(Mockito.any(Bundle.class))).thenReturn(bundle2);
@@ -282,9 +284,9 @@ class ContractBeneSearchTest {
     @Test
     void GivenDuplicatePatientRowsFromBFD_ShouldEliminateDuplicates() throws ExecutionException, InterruptedException {
         List<BundleEntryComponent> entries = bundle.getEntry();
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
         //simulate duplicate patient record coming from BDF
-        entries.add(createBundleEntry("ccw_patient_001"));
+        entries.add(createBundleEntry("ccw_patient_001", YEAR));
 
         when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);
 
@@ -318,33 +320,13 @@ class ContractBeneSearchTest {
     }
 
     private Bundle createBundle() {
-        return createBundle("ccw_patient_000");
+        BundleEntryComponent component = createBundleEntry("ccw_patient_000", YEAR);
+        return BundleUtils.createBundle(component);
     }
 
-    private Bundle createBundle(final String patientId) {
-        Bundle bundle = new Bundle();
-        List<BundleEntryComponent> entries = bundle.getEntry();
-        entries.add(createBundleEntry(patientId));
-        return bundle;
-    }
-
-    private BundleEntryComponent createBundleEntry(String patientId) {
-        BundleEntryComponent component = new BundleEntryComponent();
-        component.setResource(createPatient(patientId));
-        return component;
-    }
-
-    private Patient createPatient(String patientId) {
-        Patient patient = new Patient();
-        patient.getIdentifier().add(createIdentifier(patientId));
-        return patient;
-    }
-
-    private Identifier createIdentifier(String patientId) {
-        Identifier identifier = new Identifier();
-        identifier.setSystem(BENEFICIARY_ID);
-        identifier.setValue(patientId);
-        return identifier;
+    private Bundle createBundle(String id, int year) {
+        BundleEntryComponent component = createBundleEntry(id, year);
+        return BundleUtils.createBundle(component);
     }
 
     private BundleLinkComponent addNextLink() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
@@ -58,7 +58,7 @@ class ContractBeneSearchTest {
         taskExecutor.setMaxPoolSize(12);
         taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         taskExecutor.initialize();
-        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, "2020-01-01");
+        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, "2020");
 
         bundle = createBundle();
         lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.Month;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -57,7 +58,7 @@ class ContractBeneSearchTest {
         taskExecutor.setMaxPoolSize(12);
         taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         taskExecutor.initialize();
-        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, YEAR);
+        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, "2020-01-01");
 
         bundle = createBundle();
         lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/ContractBeneSearchTest.java
@@ -58,7 +58,7 @@ class ContractBeneSearchTest {
         taskExecutor.setMaxPoolSize(12);
         taskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         taskExecutor.initialize();
-        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, "2020");
+        cut = new ContractBeneSearchImpl(client, eventLogger, taskExecutor, false);
 
         bundle = createBundle();
         lenient().when(client.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle);

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
@@ -13,12 +13,11 @@ import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import gov.cms.ab2d.worker.SpringBootApp;
 import gov.cms.ab2d.worker.processor.domainmodel.ProgressTracker;
 import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -30,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static gov.cms.ab2d.worker.processor.BundleUtils.BENEFICIARY_ID;
+import static gov.cms.ab2d.worker.processor.BundleUtils.createBundleEntry;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -50,13 +49,16 @@ import static org.mockito.Mockito.lenient;
     @Autowired
     private SqlEventLogger sqlEventLogger;
 
+    @Value("${patient.contract.year}")
+    private int year;
+
     @Mock
     private KinesisEventLogger kinesisEventLogger;
 
     private LogManager logManager;
 
     @Container
-    private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
+    private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @BeforeEach
     void setUp() {
@@ -75,7 +77,7 @@ import static org.mockito.Mockito.lenient;
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool);
+        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, 2020);
 
         String contractId = "C1234";
         Bundle bundle = createBundle();
@@ -112,25 +114,7 @@ import static org.mockito.Mockito.lenient;
     private Bundle createBundle(final String patientId) {
         var bundle = new Bundle();
         var entries = bundle.getEntry();
-        entries.add(createBundleEntry(patientId));
+        entries.add(createBundleEntry(patientId, year));
         return bundle;
-    }
-
-    private Bundle.BundleEntryComponent createBundleEntry(String patientId) {
-        var component = new Bundle.BundleEntryComponent();
-        component.setResource(createPatient(patientId));
-        return component;
-    }
-    private Patient createPatient(String patientId) {
-        var patient = new Patient();
-        patient.getIdentifier().add(createIdentifier(patientId));
-        return patient;
-    }
-
-    private Identifier createIdentifier(String patientId) {
-        var identifier = new Identifier();
-        identifier.setSystem(BENEFICIARY_ID);
-        identifier.setValue(patientId);
-        return identifier;
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.lenient;
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, "2020-01-01");
+        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, "2020");
 
         String contractId = "C1234";
         Bundle bundle = createBundle();

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
@@ -24,6 +24,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -77,7 +78,7 @@ import static org.mockito.Mockito.lenient;
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, 2020);
+        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, "2020-01-01");
 
         String contractId = "C1234";
         Bundle bundle = createBundle();

--- a/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/adapter/bluebutton/LoadPatientsByContractLoggingTest.java
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.lenient;
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, "2020");
+        ContractBeneSearchImpl cai = new ContractBeneSearchImpl(bfdClient, logManager, patientContractThreadPool, false);
 
         String contractId = "C1234";
         Bundle bundle = createBundle();

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/BundleUtils.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/BundleUtils.java
@@ -1,10 +1,9 @@
 package gov.cms.ab2d.worker.processor;
 
 import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneficiaries;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.*;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,15 +23,16 @@ public class BundleUtils {
         return patients.stream().filter(c -> c.getPatientId().equalsIgnoreCase(id)).collect(Collectors.toList());
     }
 
-    public static Bundle.BundleEntryComponent createBundleEntry(String patientId) {
+    public static Bundle.BundleEntryComponent createBundleEntry(String patientId, int year) {
         var component = new Bundle.BundleEntryComponent();
-        component.setResource(createPatient(patientId));
+        component.setResource(createPatient(patientId, year));
         return component;
     }
 
-    public static Patient createPatient(String patientId) {
+    public static Patient createPatient(String patientId, int year) {
         var patient = new Patient();
         patient.getIdentifier().add(createIdentifier(patientId));
+        patient.getExtension().add(createReferenceYearExtension(year));
         return patient;
     }
 
@@ -41,5 +41,17 @@ public class BundleUtils {
         identifier.setSystem(BENEFICIARY_ID);
         identifier.setValue(patientId);
         return identifier;
+    }
+
+    public static Extension createReferenceYearExtension(int year) {
+        DateType dateType = new DateType();
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(year, 1, 1, 0, 0, 0);
+        dateType.setValue(calendar.getTime());
+
+        return new Extension()
+                .setUrl("https://bluebutton.cms.gov/resources/variables/rfrnc_yr")
+                .setValue(dateType);
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -48,7 +49,7 @@ class MultiThreadContractProcessTest {
                 .numContracts(1)
                 .failureThreshold(1)
                 .build();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, YEAR);
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020-01-01");
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
@@ -49,7 +49,7 @@ class MultiThreadContractProcessTest {
                 .numContracts(1)
                 .failureThreshold(1)
                 .build();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020");
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, false);
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MultiThreadContractProcessTest {
+
+    private static final int YEAR = 2020;
+
     private ProgressTracker tracker;
 
     @Mock
@@ -45,17 +48,17 @@ class MultiThreadContractProcessTest {
                 .numContracts(1)
                 .failureThreshold(1)
                 .build();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool);
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, YEAR);
     }
 
     @Test
     void testMultipleContract() throws ExecutionException, InterruptedException {
         String contractNo = "0001";
-        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1");
-        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2");
-        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3");
-        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4");
-        Bundle.BundleEntryComponent entry5 = BundleUtils.createBundleEntry("P5");
+        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1", YEAR);
+        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2", YEAR);
+        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3", YEAR);
+        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4", YEAR);
+        Bundle.BundleEntryComponent entry5 = BundleUtils.createBundleEntry("P5", YEAR);
 
         Bundle bundleA = BundleUtils.createBundle(entry1, entry2, entry3);
         Bundle bundleB = BundleUtils.createBundle(entry2, entry3, entry4);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractProcessTest.java
@@ -49,7 +49,7 @@ class MultiThreadContractProcessTest {
                 .numContracts(1)
                 .failureThreshold(1)
                 .build();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020-01-01");
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020");
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractSearchIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractSearchIntegrationTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 @Testcontainers
 class MultiThreadContractSearchIntegrationTest {
 
-
     private ProgressTracker tracker;
 
     @Container

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractSearchIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/MultiThreadContractSearchIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -27,6 +28,8 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @Testcontainers
 class MultiThreadContractSearchIntegrationTest {
+
+
     private ProgressTracker tracker;
 
     @Container
@@ -34,6 +37,10 @@ class MultiThreadContractSearchIntegrationTest {
 
     @Autowired
     private ContractBeneSearch contractBeneSearch;
+
+    // Only year of data being accepted right now
+    @Value("${patient.contract.year}")
+    private int year;
 
     @Mock
     private BFDClient bfdClient;
@@ -51,11 +58,11 @@ class MultiThreadContractSearchIntegrationTest {
     @Test
     void testMultipleContract() throws ExecutionException, InterruptedException {
         String contractNo = "0001";
-        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1");
-        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2");
-        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3");
-        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4");
-        Bundle.BundleEntryComponent entry5 = BundleUtils.createBundleEntry("P5");
+        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1", year);
+        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2", year);
+        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3", year);
+        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4", year);
+        Bundle.BundleEntryComponent entry5 = BundleUtils.createBundleEntry("P5", year);
 
         Bundle bundleA = BundleUtils.createBundle(entry1, entry2, entry3);
         Bundle bundleB = BundleUtils.createBundle(entry2, entry3, entry4);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
@@ -1,0 +1,40 @@
+package gov.cms.ab2d.worker.processor;
+
+import gov.cms.ab2d.bfd.client.BFDClient;
+import gov.cms.ab2d.common.model.*;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Disabled
+@SpringBootTest
+class PatientContractCallableLiveTest {
+
+    @Autowired
+    BFDClient bfdClient;
+
+    @DisplayName("Successfully completing marks as done and transfers results")
+    @Test
+    void callableFunctions() {
+
+        Contract contract = new Contract();
+        contract.setContractNumber("Z0001");
+        contract.setContractName("Z0001");
+
+        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 3, bfdClient);
+
+        try {
+            ContractMapping results = callable.call();
+
+            assertFalse(results.getPatients().isEmpty());
+        } catch (Exception exception) {
+            fail("could not execute against sandbox", exception);
+        }
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
@@ -9,9 +9,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Live test meant to be run locally against the BFD Prod sandbox. Test assumes that you are running a Postgres
+ * database locally exposed on a port
+ *
+ * You need all of the following environment variables
+ * to run this test
+ *
+ * AB2D_HICN_HASH_PEPPER
+ * AB2D_HICN_HASH_ITER=1000
+ * AB2D_CLAIMS_SKIP_BILLABLE_PERIOD_CHECK
+ * DB_URL=jdbc:postgresql://localhost:5432/ab2d (port is machine dependent)
+ * DB_USERNAME=ab2d
+ * DB_PASSWORD=ab2d
+ * AB2D_BFD_KEYSTORE_LOCATION (machine dependent)
+ * AB2D_BFD_KEYSTORE_PASSWORD
+ */
 @Disabled
 @SpringBootTest
 class PatientContractCallableLiveTest {
@@ -19,9 +34,9 @@ class PatientContractCallableLiveTest {
     @Autowired
     BFDClient bfdClient;
 
-    @DisplayName("Successfully completing marks as done and transfers results")
+    @DisplayName("With Year C.E. 3 returns all data available")
     @Test
-    void callableFunctions() {
+    void findAll() {
 
         Contract contract = new Contract();
         contract.setContractNumber("Z0001");
@@ -33,6 +48,26 @@ class PatientContractCallableLiveTest {
             ContractMapping results = callable.call();
 
             assertFalse(results.getPatients().isEmpty());
+            assertEquals(1000, results.getPatients().size());
+        } catch (Exception exception) {
+            fail("could not execute against sandbox", exception);
+        }
+    }
+
+    @DisplayName("With Year 2020 returns no data")
+    @Test
+    void filterAll() {
+
+        Contract contract = new Contract();
+        contract.setContractNumber("Z0001");
+        contract.setContractName("Z0001");
+
+        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 2020, bfdClient);
+
+        try {
+            ContractMapping results = callable.call();
+
+            assertTrue(results.getPatients().isEmpty());
         } catch (Exception exception) {
             fail("could not execute against sandbox", exception);
         }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -67,6 +68,8 @@ class PatientContractCallableLiveTest {
         try {
             ContractMapping results = callable.call();
 
+            int discarded = (int) ReflectionTestUtils.getField(callable, "pastYear");
+            assertEquals(1000, discarded);
             assertTrue(results.getPatients().isEmpty());
         } catch (Exception exception) {
             fail("could not execute against sandbox", exception);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableLiveTest.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.worker.processor;
 
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.*;
+import gov.cms.ab2d.worker.adapter.bluebutton.ContractBeneSearchImpl;
 import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class PatientContractCallableLiveTest {
 
     @Autowired
+    ContractBeneSearchImpl contractBeneSearch;
+
+    @Autowired
     BFDClient bfdClient;
 
     @DisplayName("With Year C.E. 3 returns all data available")
@@ -43,7 +47,27 @@ class PatientContractCallableLiveTest {
         contract.setContractNumber("Z0001");
         contract.setContractName("Z0001");
 
-        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 3, bfdClient);
+        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 3, bfdClient, true);
+
+        try {
+            ContractMapping results = callable.call();
+
+            assertFalse(results.getPatients().isEmpty());
+            assertEquals(1000, results.getPatients().size());
+        } catch (Exception exception) {
+            fail("could not execute against sandbox", exception);
+        }
+    }
+
+    @DisplayName("With Year 2020 and filter set to false still return all (sandbox scenario)")
+    @Test
+    void findAllEvenWithYear() {
+
+        Contract contract = new Contract();
+        contract.setContractNumber("Z0001");
+        contract.setContractName("Z0001");
+
+        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 2020, bfdClient, true);
 
         try {
             ContractMapping results = callable.call();
@@ -63,7 +87,7 @@ class PatientContractCallableLiveTest {
         contract.setContractNumber("Z0001");
         contract.setContractName("Z0001");
 
-        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 2020, bfdClient);
+        PatientContractCallable callable = new PatientContractCallable("Z0001", 1, 2020, bfdClient, false);
 
         try {
             ContractMapping results = callable.call();

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableTest.java
@@ -44,7 +44,7 @@ class PatientContractCallableTest {
         contract.setContractNumber("TESTING");
         contract.setContractName("TESTING");
 
-        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient, false);
 
         try {
             ContractMapping mapping = patientContractCallable.call();
@@ -72,7 +72,7 @@ class PatientContractCallableTest {
         contract.setContractNumber("TESTING");
         contract.setContractName("TESTING");
 
-        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient, false);
 
         try {
             ContractMapping mapping = patientContractCallable.call();
@@ -108,7 +108,7 @@ class PatientContractCallableTest {
         contract.setContractNumber("TESTING");
         contract.setContractName("TESTING");
 
-        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient, false);
 
         try {
             ContractMapping mapping = patientContractCallable.call();
@@ -134,7 +134,7 @@ class PatientContractCallableTest {
         contract.setContractNumber("TESTING");
         contract.setContractName("TESTING");
 
-        PatientContractCallable callable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+        PatientContractCallable callable = new PatientContractCallable("TESTING", 1, 2020, bfdClient, false);
         assertThrows(RuntimeException.class, callable::call);
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientContractCallableTest.java
@@ -1,0 +1,152 @@
+package gov.cms.ab2d.worker.processor;
+
+import gov.cms.ab2d.bfd.client.BFDClient;
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.worker.processor.domainmodel.ContractMapping;
+import org.hl7.fhir.dstu3.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static gov.cms.ab2d.worker.processor.BundleUtils.createPatient;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+class PatientContractCallableTest {
+
+    private BFDClient bfdClient;
+
+    @BeforeEach
+    public void before() {
+
+        bfdClient = Mockito.mock(BFDClient.class);
+
+    }
+
+    @DisplayName("Successfully completing marks as done and transfers results")
+    @Test
+    void callableFunctions() {
+
+        Bundle bundle1 = buildBundle(0, 10, 2020);
+        bundle1.setLink(singletonList(new Bundle.BundleLinkComponent().setRelation(Bundle.LINK_NEXT)));
+
+        Bundle bundle2 = buildBundle(10, 20, 2020);
+
+        when(bfdClient.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestNextBundleFromServer(any(Bundle.class))).thenReturn(bundle2);
+
+        Contract contract = new Contract();
+        contract.setContractNumber("TESTING");
+        contract.setContractName("TESTING");
+
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+
+        try {
+            ContractMapping mapping = patientContractCallable.call();
+
+            assertEquals(20, mapping.getPatients().size());
+        } catch (Exception exception) {
+            fail("could not execute basic job with mock client", exception);
+        }
+
+    }
+
+    @DisplayName("Filter out years that do not match the provided year")
+    @Test
+    void filterYear() {
+
+        Bundle bundle1 = buildBundle(0, 10, 2020);
+        bundle1.setLink(singletonList(new Bundle.BundleLinkComponent().setRelation(Bundle.LINK_NEXT)));
+
+        Bundle bundle2 = buildBundle(10, 20, 2019);
+
+        when(bfdClient.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestNextBundleFromServer(any(Bundle.class))).thenReturn(bundle2);
+
+        Contract contract = new Contract();
+        contract.setContractNumber("TESTING");
+        contract.setContractName("TESTING");
+
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+
+        try {
+            ContractMapping mapping = patientContractCallable.call();
+
+            assertEquals(10, mapping.getPatients().size());
+
+            int pastYear = (int) ReflectionTestUtils.getField(patientContractCallable, "pastYear");
+
+            assertEquals(10, pastYear);
+        } catch (Exception exception) {
+            fail("could not execute basic job with mock client", exception);
+        }
+
+    }
+
+    @DisplayName("Filter out patients without identifiers")
+    @Test
+    void filterMissingIdentifier() {
+
+        Bundle bundle1 = buildBundle(0, 10, 2020);
+        bundle1.setLink(singletonList(new Bundle.BundleLinkComponent().setRelation(Bundle.LINK_NEXT)));
+
+        Bundle bundle2 = buildBundle(10, 20, 2020);
+        bundle2.getEntry().forEach(ec -> {
+            Patient patient = (Patient) ec.getResource();
+            patient.setIdentifier(emptyList());
+        });
+
+        when(bfdClient.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestNextBundleFromServer(any(Bundle.class))).thenReturn(bundle2);
+
+        Contract contract = new Contract();
+        contract.setContractNumber("TESTING");
+        contract.setContractName("TESTING");
+
+        PatientContractCallable patientContractCallable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+
+        try {
+            ContractMapping mapping = patientContractCallable.call();
+
+            assertEquals(10, mapping.getPatients().size());
+
+            int missingIdentifier = (int) ReflectionTestUtils.getField(patientContractCallable, "missingIdentifier");
+
+            assertEquals(10, missingIdentifier);
+        } catch (Exception exception) {
+            fail("could not execute basic job with mock client", exception);
+        }
+
+    }
+
+    @DisplayName("Exceptional behavior leads to failure")
+    @Test
+    void exceptionCaught() {
+
+        when(bfdClient.requestPartDEnrolleesFromServer(anyString(), anyInt())).thenThrow(new RuntimeException("exception"));
+
+        Contract contract = new Contract();
+        contract.setContractNumber("TESTING");
+        contract.setContractName("TESTING");
+
+        PatientContractCallable callable = new PatientContractCallable("TESTING", 1, 2020, bfdClient);
+        assertThrows(RuntimeException.class, callable::call);
+    }
+
+    private Bundle buildBundle(int startIndex, int endIndex, int year) {
+        Bundle bundle1 = new Bundle();
+
+        for (int i = startIndex; i < endIndex; i++) {
+            Bundle.BundleEntryComponent component = new Bundle.BundleEntryComponent();
+            Patient patient = createPatient("test-" + i, year);
+            component.setResource(patient);
+            bundle1.addEntry(component);
+        }
+        return bundle1;
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.transaction.Transactional;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.concurrent.ExecutionException;
 
@@ -76,7 +77,7 @@ public class ProgressTrackerIntegrationTest {
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, 2020);
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020-01-01");
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository, contractBeneSearch, contractProcessor, eventLogger);
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -77,7 +77,7 @@ public class ProgressTrackerIntegrationTest {
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020-01-01");
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020");
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository, contractBeneSearch, contractProcessor, eventLogger);
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -50,6 +51,9 @@ public class ProgressTrackerIntegrationTest {
     @Autowired
     private ContractBeneSearch contractBeneSearch;
 
+    @Value("${patient.contract.year}")
+    private int year;
+
     @Mock
     private LogManager eventLogger;
 
@@ -72,7 +76,7 @@ public class ProgressTrackerIntegrationTest {
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool);
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, 2020);
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository, contractBeneSearch, contractProcessor, eventLogger);
     }
 
@@ -92,10 +96,10 @@ public class ProgressTrackerIntegrationTest {
                 .currentMonth(2)
                 .build();
 
-        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1");
-        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2");
-        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3");
-        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4");
+        Bundle.BundleEntryComponent entry1 = BundleUtils.createBundleEntry("P1", year);
+        Bundle.BundleEntryComponent entry2 = BundleUtils.createBundleEntry("P2", year);
+        Bundle.BundleEntryComponent entry3 = BundleUtils.createBundleEntry("P3", year);
+        Bundle.BundleEntryComponent entry4 = BundleUtils.createBundleEntry("P4", year);
 
         Bundle bundleA = BundleUtils.createBundle(entry1, entry2, entry3);
         Bundle bundleB = BundleUtils.createBundle(entry1, entry2, entry3, entry4);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -77,7 +77,7 @@ public class ProgressTrackerIntegrationTest {
         patientContractThreadPool.setMaxPoolSize(12);
         patientContractThreadPool.setThreadNamePrefix("contractp-");
         patientContractThreadPool.initialize();
-        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, "2020");
+        contractBeneSearch = new ContractBeneSearchImpl(bfdClient, eventLogger, patientContractThreadPool, false);
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository, contractBeneSearch, contractProcessor, eventLogger);
     }
 

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -64,4 +64,7 @@ bfd.earliest.data.date=01/01/2020
 bfd.earliest.data.date.special.contracts=01/01/1990
 bfd.special.contracts=Z0001,S0001
 
+## ----------------------------------------------------------------------------- Filter out coverage by year
+patient.contract.year=2020
+
 


### PR DESCRIPTION

**JIRA Tickets:**

[AB2D-2325](https://jira.cms.gov/browse/AB2D-2325) - Filtering Coverage By Year
 
### What Does This PR Do?

Changes to prevent leaking PHI by filtering for accurate coverage periods. These changes enforce date filtering when finding coverage mapping information by forcing the specific year.

1. PatientContractCallable now filters by a provided year.
2. Year is set via an environment variable PATIENT_CONTRACT_YEAR.
3. PatientContractCallable now logs discarded patients by provided year and those missing an identifier
4. Clean up tests by removing duplicate methods in BundleUtils

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [x] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure