### PR TITLE
Disable MBI Searches Temporarily

### DIFF
--- a/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -212,7 +212,9 @@ public class BFDClientImpl implements BFDClient {
         return client
                 .loadPage()
                 .next(bundle)
-                .withAdditionalHeader("IncludeIdentifiers", "mbi")
+// todo uncomment when issue regarding retrieving mbis is complete
+//
+//                .withAdditionalHeader("IncludeIdentifiers", "mbi")
                 .encodedJson()
                 .execute();
     }
@@ -232,7 +234,9 @@ public class BFDClientImpl implements BFDClient {
         return client.search()
                 .forResource(Patient.class)
                 .where(theCriterion)
-                .withAdditionalHeader("IncludeIdentifiers", "mbi")
+// todo uncomment when issue regarding retrieving mbis is complete
+//
+//                .withAdditionalHeader("IncludeIdentifiers", "mbi")
                 .count(contractToBenePageSize)
                 .returnBundle(Bundle.class)
                 .encodedJson()

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -335,7 +335,8 @@ public class TestRunner {
             checkStandardEOBFields(jsonObject);
 
             // Check whether extensions are correct
-            checkEOBExtensions(jsonObject);
+            // todo uncomment when mbi search issue is fixed
+//            checkEOBExtensions(jsonObject);
 
             // Check correctness of metadata
             checkMetadata(since, jsonObject);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2606](https://jira.cms.gov/browse/AB2D-2606) - Description
 
### What Does This PR Do?

Disable portion of contract membership search corresponding to MBIs. Null values are passed through system and ignored for the moment.

All disabled areas are marked with todos to re-enable once this issue has been resolved.

### What Should Reviewers Watch For?

Any potential issues writing out eobs to file with null mbis. Any potential issues with MBIs being null that might cause an NPE.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure