### PR TITLE
Feature/ab2d 2683 manual override attestation

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -3,14 +3,7 @@ package gov.cms.ab2d.common.model;
 
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.PreRemove;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -27,6 +20,8 @@ import static gov.cms.ab2d.common.util.DateUtil.getESTOffset;
 public class Contract extends TimestampBase {
 
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s Z");
+
+    enum UpdateMode {AUTOMATIC, TEST, MANUAL}
 
     @Id
     @GeneratedValue
@@ -47,6 +42,9 @@ public class Contract extends TimestampBase {
 
     @Column(name = "hpms_org_marketing_name")
     private String hpmsOrgMarketingName;
+
+    @Enumerated(EnumType.STRING)
+    private UpdateMode updateMode = UpdateMode.AUTOMATIC;
 
     public Contract(@NotNull String contractNumber, String contractName, Long hpmsParentOrgId, String hpmsParentOrg,
                     String hpmsOrgMarketingName, @NotNull Sponsor sponsor) {
@@ -81,6 +79,9 @@ public class Contract extends TimestampBase {
      * Returns true if new state differs from existing which requires a save.
      */
     public boolean updateAttestation(boolean attested, String attestationDate) {
+        if (updateMode != UpdateMode.AUTOMATIC)
+            return false;
+
         boolean hasAttestation = hasAttestation();
         if (attested == hasAttestation) {
             return false;   // No changes needed

--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -21,7 +21,7 @@ public class Contract extends TimestampBase {
 
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s Z");
 
-    enum UpdateMode {AUTOMATIC, TEST, MANUAL}
+    enum UpdateMode { AUTOMATIC, TEST, MANUAL }
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -67,6 +67,10 @@ public class Contract extends TimestampBase {
     @OneToMany(mappedBy = "contract")
     private Set<CoveragePeriod> coveragePeriods = new HashSet<>();
 
+    public boolean isTestContract() {
+        return updateMode == UpdateMode.TEST;
+    }
+
     public boolean hasAttestation() {
         return attestedOn != null;
     }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -78,3 +78,5 @@ databaseChangeLog:
       file: db/changelog/v001/add_last_success_to_coverage_period.sql
   - include:
       file: db/changelog/v001/add_mbi_to_coverage.sql
+  - include:
+      file: db/changelog/v001/add_update_mode_to_contract.sql

--- a/common/src/main/resources/db/changelog/v001/add_update_mode_to_contract.sql
+++ b/common/src/main/resources/db/changelog/v001/add_update_mode_to_contract.sql
@@ -1,0 +1,6 @@
+ALTER TABLE contract ADD COLUMN "update_mode" VARCHAR(32) NOT NULL DEFAULT('AUTOMATIC');  -- Is there a standard size for an enum?  32 is arbitrary
+
+-- Fix the test contracts
+update contract
+set update_mode = 'TEST'
+where contract_name like 'Z%';

--- a/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
@@ -1,0 +1,72 @@
+package gov.cms.ab2d.common.model;
+
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.repository.SponsorRepository;
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SpringBootTest
+@Testcontainers
+@TestPropertySource(locations = "/application.common.properties")
+class ContractUpdateModeTest {
+
+    private static final String TEST_DATE_STR = "2020-04-15 14:57:34";
+
+    @SuppressWarnings({"rawtypes", "unused"})
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
+
+    @Autowired
+    private ContractRepository contractRepository;
+
+    @Autowired
+    private SponsorRepository sponsorRepository;
+
+    @Test
+    void testAutomaticUpdate() {
+        Contract contract = buildContract();
+        assertFalse(contract.hasAttestation());
+        contract.updateAttestation(true, TEST_DATE_STR);
+        assertTrue(contract.hasAttestation());
+
+        cleanup(contract);
+    }
+
+    @Test
+    void testManualOverride() {
+        Contract contract = buildContract();
+        assertFalse(contract.hasAttestation());
+        contract.setUpdateMode(Contract.UpdateMode.MANUAL);
+        contract.updateAttestation(true, TEST_DATE_STR);
+        assertFalse(contract.hasAttestation());
+
+        cleanup(contract);
+    }
+
+    private void cleanup(Contract contract) {
+        Sponsor sponsor = contract.getSponsor();
+        // Cleanup
+        contractRepository.delete(contract);
+        sponsorRepository.delete(sponsor);
+    }
+
+    private Contract buildContract() {
+        Sponsor sponsor = new Sponsor();
+        sponsor.setHpmsId(52);
+        sponsor.setOrgName("TEST");
+        Sponsor savedSponsor = sponsorRepository.save(sponsor);
+
+        return contractRepository.save(new Contract("Z1234", "Test Contract",
+                9999L, "Test Parent Org",
+                "Test Parent Org Marketing Name", savedSponsor));
+    }
+}

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
@@ -105,7 +105,7 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
     private void considerContract(List<Contract> contractAttestList, Contract contract,
                                   HPMSOrganizationInfo hpmsOrganizationInfo) {
         // Ignore Test contracts
-        if (contract.getContractNumber().startsWith("Z")) {
+        if (contract.isTestContract()) {
             return;
         }
 


### PR DESCRIPTION
**JIRA Tickets:**

AB2D-2683 - Add Ability to Manually Override Attestation Dates

***Related Tickets***
 
### What Does This PR Do?
Adds a new column to the Contract table to allow to explicit separate manually administered contracts from the test and automatic ones.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure