### PR TITLE
Feature/ab2d 2179 coverage period loading

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -88,6 +88,7 @@ public class AdminAPIPropertiesTests {
             put(ZIP_SUPPORT_ON, "false");
             put(WORKER_ENGAGEMENT, "engaged");
             put(HPMS_INGESTION_ENGAGEMENT, "engaged");
+            put(COVERAGE_SEARCH_ENGAGEMENT, "engaged");
         }};
 
         MvcResult mvcResult = this.mockMvc.perform(
@@ -102,7 +103,7 @@ public class AdminAPIPropertiesTests {
         ObjectMapper mapper = new ObjectMapper();
         List<PropertiesDTO> propertiesDTOs = mapper.readValue(result, new TypeReference<>() {} );
 
-        Assert.assertEquals(8, propertiesDTOs.size());
+        Assert.assertEquals(9, propertiesDTOs.size());
         for(PropertiesDTO propertiesDTO : propertiesDTOs) {
             Object value = propertyMap.get(propertiesDTO.getKey());
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -88,7 +88,7 @@ public class AdminAPIPropertiesTests {
             put(ZIP_SUPPORT_ON, "false");
             put(WORKER_ENGAGEMENT, "engaged");
             put(HPMS_INGESTION_ENGAGEMENT, "engaged");
-            put(COVERAGE_SEARCH_ENGAGEMENT, "engaged");
+            put(COVERAGE_SEARCH_ENGAGEMENT, "idle");
         }};
 
         MvcResult mvcResult = this.mockMvc.perform(

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -88,7 +88,8 @@ public class AdminAPIPropertiesTests {
             put(ZIP_SUPPORT_ON, "false");
             put(WORKER_ENGAGEMENT, "engaged");
             put(HPMS_INGESTION_ENGAGEMENT, "engaged");
-            put(COVERAGE_SEARCH_ENGAGEMENT, "idle");
+            put(COVERAGE_SEARCH_DISCOVERY, "idle");
+            put(COVERAGE_SEARCH_QUEUEING, "idle");
         }};
 
         MvcResult mvcResult = this.mockMvc.perform(
@@ -103,7 +104,7 @@ public class AdminAPIPropertiesTests {
         ObjectMapper mapper = new ObjectMapper();
         List<PropertiesDTO> propertiesDTOs = mapper.readValue(result, new TypeReference<>() {} );
 
-        Assert.assertEquals(9, propertiesDTOs.size());
+        Assert.assertEquals(10, propertiesDTOs.size());
         for(PropertiesDTO propertiesDTO : propertiesDTOs) {
             Object value = propertyMap.get(propertiesDTO.getKey());
 

--- a/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Contract.java
@@ -1,11 +1,13 @@
 package gov.cms.ab2d.common.model;
 
 
+import gov.cms.ab2d.common.util.DateUtil;
 import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
@@ -93,6 +95,13 @@ public class Contract extends TimestampBase {
         hpmsParentOrg = parentOrgName;
         hpmsOrgMarketingName = orgMarketingName;
         return this;
+    }
+
+    /**
+     * Get time zone in EST time which is the standard for CMS
+     */
+    public ZonedDateTime getESTAttestationTime() {
+        return hasAttestation() ? attestedOn.atZoneSameInstant(DateUtil.AB2D_ZONE) : null;
     }
 
     /*

--- a/common/src/main/java/gov/cms/ab2d/common/model/Sponsor.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Sponsor.java
@@ -15,7 +15,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @Entity
 @Getter
@@ -76,7 +77,7 @@ public class Sponsor extends TimestampBase {
         return children.stream()
                 .map(Sponsor::getAttestedContracts)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     /**
@@ -86,7 +87,7 @@ public class Sponsor extends TimestampBase {
      */
     public List<Contract> getAttestedContracts() {
         return getContracts().stream()
-                .filter(contract -> contract.getAttestedOn() != null)
-                .collect(Collectors.toList());
+                .filter(Contract::hasAttestation)
+                .collect(toList());
     }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/CoveragePeriodRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/CoveragePeriodRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface CoveragePeriodRepository extends JpaRepository<CoveragePeriod, Integer> {
 
@@ -15,6 +16,8 @@ public interface CoveragePeriodRepository extends JpaRepository<CoveragePeriod, 
     List<CoveragePeriod> findAllByLastSuccessfulJobIsNull();
 
     List<CoveragePeriod> findAllByMonthAndYearAndLastSuccessfulJobLessThanEqual(int month, int year, OffsetDateTime time);
+
+    Optional<CoveragePeriod> findByContractIdAndMonthAndYear(long contractId, int month, int year);
 
     CoveragePeriod getByContractIdAndMonthAndYear(Long contractId, int month, int year);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/ContractService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/ContractService.java
@@ -2,9 +2,12 @@ package gov.cms.ab2d.common.service;
 
 import gov.cms.ab2d.common.model.Contract;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContractService {
+
+    List<Contract> getAllAttestedContracts();
 
     Optional<Contract> getContractByContractNumber(String contractNumber);
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/ContractServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/ContractServiceImpl.java
@@ -6,7 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @Transactional
@@ -14,6 +17,11 @@ public class ContractServiceImpl implements ContractService {
 
     @Autowired
     private ContractRepository contractRepository;
+
+    public List<Contract> getAllAttestedContracts() {
+        return contractRepository.findAll()
+                .stream().filter(Contract::hasAttestation).collect(toList());
+    }
 
     public Optional<Contract> getContractByContractNumber(String contractNumber) {
         return contractRepository.findContractByContractNumber(contractNumber);

--- a/common/src/main/java/gov/cms/ab2d/common/service/ContractServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/ContractServiceImpl.java
@@ -19,6 +19,8 @@ public class ContractServiceImpl implements ContractService {
     private ContractRepository contractRepository;
 
     public List<Contract> getAllAttestedContracts() {
+        // There are about 100 contracts including test contracts so this call has minimal cost.
+        // This call is only made once a day as well.
         return contractRepository.findAll()
                 .stream().filter(Contract::hasAttestation).collect(toList());
     }

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.common.service;
 
+import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.CoverageMapping;
 import gov.cms.ab2d.common.model.CoveragePagingRequest;
 import gov.cms.ab2d.common.model.CoveragePagingResult;
@@ -19,11 +20,20 @@ public interface CoverageService {
 
     /**
      * Get {@link CoveragePeriod} in database matching provided triple
-     * @param contractId existing {@link gov.cms.ab2d.common.model.Contract#getId()}
+     * @param contract existing {@link gov.cms.ab2d.common.model.Contract#getId()}
      * @param month valid month
      * @param year valid year (not later than current year)
      */
-    CoveragePeriod getCoveragePeriod(long contractId, int month, int year);
+    CoveragePeriod getCoveragePeriod(Contract contract, int month, int year);
+
+    /**
+     * Create {@link CoveragePeriod} matching the provided triple
+     * @param contract contract to add coverage period for
+     * @param month month of the period
+     * @param year year of the period
+     * @return coverage period as it exists in database
+     */
+    CoveragePeriod getOrCreateCoveragePeriod(Contract contract, int month, int year);
 
     /**
      * Check current status of a {@link CoveragePeriod}

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
@@ -33,7 +33,7 @@ public interface CoverageService {
      * @param year year of the period
      * @return coverage period as it exists in database
      */
-    CoveragePeriod getOrCreateCoveragePeriod(Contract contract, int month, int year);
+    CoveragePeriod getCreateIfAbsentCoveragePeriod(Contract contract, int month, int year);
 
     /**
      * Check current status of a {@link CoveragePeriod}

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -183,6 +183,9 @@ public class CoverageServiceImpl implements CoverageService {
 
     @Override
     public List<CoveragePeriod> coveragePeriodNeverSearchedSuccessfully() {
+
+        log.info("attempting to find all never successfully searched coverage periods");
+
         List<CoveragePeriod> neverSuccessful = coveragePeriodRepo.findAllByLastSuccessfulJobIsNull();
 
         return neverSuccessful.stream().filter(period ->
@@ -197,6 +200,9 @@ public class CoverageServiceImpl implements CoverageService {
 
     @Override
     public List<CoveragePeriod> coveragePeriodStuckJobs(OffsetDateTime startedBefore) {
+
+        log.info("attempting to find all coverage searches that have been in progress for too long");
+
         List<CoverageSearchEvent> events = coverageSearchEventRepo
                 .findStuckAtStatus(JobStatus.IN_PROGRESS.name(), startedBefore);
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -66,7 +66,7 @@ public class CoverageServiceImpl implements CoverageService {
     }
 
     @Override
-    public CoveragePeriod getOrCreateCoveragePeriod(Contract contract, int month, int year) {
+    public CoveragePeriod getCreateIfAbsentCoveragePeriod(Contract contract, int month, int year) {
         checkMonthAndYear(month, year);
 
         Optional<CoveragePeriod> existing = coveragePeriodRepo.findByContractIdAndMonthAndYear(contract.getId(), month, year);

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.common.service;
 
+import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.CoverageMapping;
 import gov.cms.ab2d.common.model.CoveragePagingRequest;
 import gov.cms.ab2d.common.model.CoveragePagingResult;
@@ -20,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.*;
 import java.util.*;
 
-import static gov.cms.ab2d.common.util.Constants.AB2D_EPOCH;
+import static gov.cms.ab2d.common.util.DateUtil.AB2D_EPOCH;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -59,9 +60,27 @@ public class CoverageServiceImpl implements CoverageService {
     }
 
     @Override
-    public CoveragePeriod getCoveragePeriod(long contractId, int month, int year) {
+    public CoveragePeriod getCoveragePeriod(Contract contract, int month, int year) {
         checkMonthAndYear(month, year);
-        return coveragePeriodRepo.getByContractIdAndMonthAndYear(contractId, month, year);
+        return coveragePeriodRepo.getByContractIdAndMonthAndYear(contract.getId(), month, year);
+    }
+
+    @Override
+    public CoveragePeriod getOrCreateCoveragePeriod(Contract contract, int month, int year) {
+        checkMonthAndYear(month, year);
+
+        Optional<CoveragePeriod> existing = coveragePeriodRepo.findByContractIdAndMonthAndYear(contract.getId(), month, year);
+
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        CoveragePeriod period = new CoveragePeriod();
+        period.setContract(contract);
+        period.setMonth(month);
+        period.setYear(year);
+
+        return coveragePeriodRepo.save(period);
     }
 
     @Override

--- a/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
@@ -94,7 +94,8 @@ public class PropertiesServiceImpl implements PropertiesService {
 
         case WORKER_ENGAGEMENT:
         case HPMS_INGESTION_ENGAGEMENT:
-        case COVERAGE_SEARCH_ENGAGEMENT:
+        case COVERAGE_SEARCH_DISCOVERY:
+        case COVERAGE_SEARCH_QUEUEING:
             validateString(key, propertiesDTO);
             addUpdatedPropertiesToList(propertiesDTOsReturn, propertiesDTO);
             break;

--- a/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PropertiesServiceImpl.java
@@ -94,6 +94,7 @@ public class PropertiesServiceImpl implements PropertiesService {
 
         case WORKER_ENGAGEMENT:
         case HPMS_INGESTION_ENGAGEMENT:
+        case COVERAGE_SEARCH_ENGAGEMENT:
             validateString(key, propertiesDTO);
             addUpdatedPropertiesToList(propertiesDTOsReturn, propertiesDTO);
             break;

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -59,7 +59,9 @@ public final class Constants {
     // Accepted values: engaged, idle
     public static final String HPMS_INGESTION_ENGAGEMENT = "hpms.ingest.engaged";
 
-    public static final String COVERAGE_SEARCH_ENGAGEMENT = "coverage.update.engaged";
+    // Control when automatic metadata loading is and isn't enabled
+    public static final String COVERAGE_SEARCH_DISCOVERY = "coverage.update.discovery";
+    public static final String COVERAGE_SEARCH_QUEUEING = "coverage.update.queueing";
 
     public static final String CONTRACT_2_BENE_CACHING_ON = "ContractToBeneCachingOn";
 
@@ -67,7 +69,7 @@ public final class Constants {
 
     public static final Set<String> ALLOWED_PROPERTY_NAMES = Set.of(PCP_CORE_POOL_SIZE, PCP_MAX_POOL_SIZE,
             PCP_SCALE_TO_MAX_TIME, MAINTENANCE_MODE, CONTRACT_2_BENE_CACHING_ON, ZIP_SUPPORT_ON,
-            WORKER_ENGAGEMENT, HPMS_INGESTION_ENGAGEMENT, COVERAGE_SEARCH_ENGAGEMENT);
+            WORKER_ENGAGEMENT, HPMS_INGESTION_ENGAGEMENT, COVERAGE_SEARCH_DISCOVERY, COVERAGE_SEARCH_QUEUEING);
 
     // This is the earliest time the _since filter is valid - probably should be in the properties file but I
     // wanted to include it in the swagger documentation and for the swagger annotation, the value has to be

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -72,5 +72,4 @@ public final class Constants {
     // constant at compile time so I put it here.
     public static final String SINCE_EARLIEST_DATE = "2020-02-13T00:00:00.000-05:00";
 
-    public static final int AB2D_EPOCH = 2020;
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -59,13 +59,15 @@ public final class Constants {
     // Accepted values: engaged, idle
     public static final String HPMS_INGESTION_ENGAGEMENT = "hpms.ingest.engaged";
 
+    public static final String COVERAGE_SEARCH_ENGAGEMENT = "coverage.update.engaged";
+
     public static final String CONTRACT_2_BENE_CACHING_ON = "ContractToBeneCachingOn";
 
     public static final String ZIP_SUPPORT_ON = "ZipSupportOn";
 
     public static final Set<String> ALLOWED_PROPERTY_NAMES = Set.of(PCP_CORE_POOL_SIZE, PCP_MAX_POOL_SIZE,
             PCP_SCALE_TO_MAX_TIME, MAINTENANCE_MODE, CONTRACT_2_BENE_CACHING_ON, ZIP_SUPPORT_ON,
-            WORKER_ENGAGEMENT, HPMS_INGESTION_ENGAGEMENT);
+            WORKER_ENGAGEMENT, HPMS_INGESTION_ENGAGEMENT, COVERAGE_SEARCH_ENGAGEMENT);
 
     // This is the earliest time the _since filter is valid - probably should be in the properties file but I
     // wanted to include it in the swagger documentation and for the swagger annotation, the value has to be

--- a/common/src/main/java/gov/cms/ab2d/common/util/DateUtil.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/DateUtil.java
@@ -6,6 +6,10 @@ import java.util.Date;
 
 public final class DateUtil {
 
+    public static final int AB2D_EPOCH = 2020;
+
+    public static final ZoneId AB2D_ZONE = ZoneId.of("America/New_York");
+
     private DateUtil() { }
 
     // Since this is being sent to the client, return as UTC time
@@ -22,5 +26,14 @@ public final class DateUtil {
 
     public static String getESTOffset() {
         return String.format("%tz", Instant.now().atZone(ZoneId.of("America/New_York")));
+    }
+
+    /**
+     * Get OffsetDateTime
+     * @return earliest offset date time that AB2D reports EOBs for
+     */
+    public static ZonedDateTime getAB2DEpoch() {
+        return ZonedDateTime.of(2020, 1, 1,
+                0, 0, 0, 0, AB2D_ZONE);
     }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/DateUtil.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/DateUtil.java
@@ -25,7 +25,7 @@ public final class DateUtil {
     }
 
     public static String getESTOffset() {
-        return String.format("%tz", Instant.now().atZone(ZoneId.of("America/New_York")));
+        return String.format("%tz", Instant.now().atZone(AB2D_ZONE));
     }
 
     /**

--- a/common/src/main/java/gov/cms/ab2d/common/util/FilterOutByDate.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/FilterOutByDate.java
@@ -7,7 +7,6 @@ import org.hl7.fhir.dstu3.model.Period;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -23,7 +22,6 @@ public final class FilterOutByDate {
     private static final String FULL = "MM/dd/yyyy HH:mm:ss:SSS";
 
     public static final TimeZone TIMEZONE = TimeZone.getTimeZone("America/New_York");
-    public static final ZoneId ZONE_ID = ZoneId.of("America/New_York");
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.

--- a/common/src/main/java/gov/cms/ab2d/common/util/FilterOutByDate.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/FilterOutByDate.java
@@ -10,6 +10,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static gov.cms.ab2d.common.util.DateUtil.AB2D_ZONE;
+
 /**
  * Utility class to take different subscription ranges and attestation dates and
  * determine if an explanation of benefit object should be filtered out based on
@@ -21,7 +23,7 @@ public final class FilterOutByDate {
     private static final String SHORT = "MM/dd/yyyy";
     private static final String FULL = "MM/dd/yyyy HH:mm:ss:SSS";
 
-    public static final TimeZone TIMEZONE = TimeZone.getTimeZone("America/New_York");
+    public static final TimeZone TIMEZONE = TimeZone.getTimeZone(AB2D_ZONE);
 
     /**
      * Date range class used to define a from and to date for a subscribers membership.

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -80,3 +80,5 @@ databaseChangeLog:
       file: db/changelog/v001/add_mbi_to_coverage.sql
   - include:
       file: db/changelog/v001/add_update_mode_to_contract.sql
+  - include:
+      file: db/changelog/v001/add_property_coverage_search.sql

--- a/common/src/main/resources/db/changelog/v001/add_property_coverage_search.sql
+++ b/common/src/main/resources/db/changelog/v001/add_property_coverage_search.sql
@@ -3,4 +3,5 @@
 
 --changeset wnyffenegger:add_property_coverage_search failOnError:true
 
-INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'coverage.update.engaged', 'idle');
+INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'coverage.update.discovery', 'idle');
+INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'coverage.update.queueing', 'idle');

--- a/common/src/main/resources/db/changelog/v001/add_property_coverage_search.sql
+++ b/common/src/main/resources/db/changelog/v001/add_property_coverage_search.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+--changeset wnyffenegger:add_property_coverage_search failOnError:true
+
+INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'coverage.update.engaged', 'idle');

--- a/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
@@ -1,0 +1,96 @@
+package gov.cms.ab2d.common.service;
+
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.model.Sponsor;
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.DataSetup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+@SpringBootTest
+@Testcontainers
+@TestPropertySource(locations = "/application.common.properties")
+class ContractServiceImplTest {
+
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
+
+    @Autowired
+    private ContractRepository contractRepo;
+
+    @Autowired
+    private ContractServiceImpl contractService;
+
+    @Autowired
+    private DataSetup dataSetup;
+
+    private Sponsor sponsor;
+    private Contract contract;
+
+    @BeforeEach
+    private void before() {
+        sponsor = dataSetup.createSponsor("Parent Corp.", 456, "Test", 123);
+
+        contract = new Contract();
+        contract.setContractName("Test Contract");
+        contract.setContractNumber("NATTE");
+
+        contract.setSponsor(sponsor);
+
+        contract = contractRepo.save(contract);    }
+
+    @AfterEach
+    private void after() {
+        if (contract != null) {
+            dataSetup.deleteContract(contract);
+        }
+
+        if (sponsor != null) {
+            dataSetup.deleteSponsor(sponsor);
+        }
+    }
+
+    @DisplayName("Find all contracts and filter by attestation")
+    @Test
+    void contractServiceFilterAttestation() {
+
+        List<Contract> allContracts = contractRepo.findAll();
+        List<Contract> attestedContracts = contractService.getAllAttestedContracts();
+
+        // All manually added contracts are automatically attested so these lists should match
+        assertEquals(allContracts.size() - 1, attestedContracts.size());
+        assertTrue(allContracts.containsAll(attestedContracts));
+        assertFalse(attestedContracts.contains(contract));
+
+        attestedContracts.forEach(contract -> assertNotNull(contract.getESTAttestationTime()));
+    }
+
+    @DisplayName("Get a contract with an appropriate number")
+    @Test
+    void contractGetNumber() {
+        Optional<Contract> retrieved = contractService.getContractByContractNumber("NATTE");
+
+        assertTrue(retrieved.isPresent());
+
+        assertEquals("Test Contract", retrieved.get().getContractName());
+        assertEquals("NATTE", retrieved.get().getContractNumber());
+
+        assertEquals(contract, retrieved.get());
+    }
+}

--- a/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
@@ -134,7 +134,7 @@ class CoverageServiceImplTest {
 
         long periods = coveragePeriodRepo.count();
 
-        coverageService.getOrCreateCoveragePeriod(contract1, JANUARY, YEAR);
+        coverageService.getCreateIfAbsentCoveragePeriod(contract1, JANUARY, YEAR);
 
         assertEquals(periods, coveragePeriodRepo.count());
     }
@@ -142,7 +142,7 @@ class CoverageServiceImplTest {
     @DisplayName("Get or create does not insert duplicate period")
     @Test
     void getOrCreateInsertsNew() {
-        CoveragePeriod period = coverageService.getOrCreateCoveragePeriod(contract1, 12, 2020);
+        CoveragePeriod period = coverageService.getCreateIfAbsentCoveragePeriod(contract1, 12, 2020);
         coveragePeriodRepo.delete(period);
     }
 

--- a/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
@@ -120,12 +120,30 @@ class CoverageServiceImplTest {
     @DisplayName("Get a coverage period")
     @Test
     void getCoveragePeriod() {
-        CoveragePeriod period = coverageService.getCoveragePeriod(contract1.getId(), JANUARY, YEAR);
+        CoveragePeriod period = coverageService.getCoveragePeriod(contract1, JANUARY, YEAR);
         assertEquals(period1Jan, period);
 
-        assertThrows(IllegalArgumentException.class, () -> coverageService.getCoveragePeriod(contract1.getId(), JANUARY, 2000));
+        assertThrows(IllegalArgumentException.class, () -> coverageService.getCoveragePeriod(contract1, JANUARY, 2000));
 
-        assertThrows(IllegalArgumentException.class, () -> coverageService.getCoveragePeriod(contract1.getId(), JANUARY, 2100));
+        assertThrows(IllegalArgumentException.class, () -> coverageService.getCoveragePeriod(contract1, JANUARY, 2100));
+    }
+
+    @DisplayName("Get or create does not insert duplicate period")
+    @Test
+    void getOrCreateDoesNotDuplicate() {
+
+        long periods = coveragePeriodRepo.count();
+
+        coverageService.getOrCreateCoveragePeriod(contract1, JANUARY, YEAR);
+
+        assertEquals(periods, coveragePeriodRepo.count());
+    }
+
+    @DisplayName("Get or create does not insert duplicate period")
+    @Test
+    void getOrCreateInsertsNew() {
+        CoveragePeriod period = coverageService.getOrCreateCoveragePeriod(contract1, 12, 2020);
+        coveragePeriodRepo.delete(period);
     }
 
     @DisplayName("Coverage search status works")
@@ -945,16 +963,16 @@ class CoverageServiceImplTest {
     void checkMonthAndYear() {
 
         assertThrows(IllegalArgumentException.class,
-                () -> coverageService.getCoveragePeriod(contract1.getId(), 0, 2020));
+                () -> coverageService.getCoveragePeriod(contract1, 0, 2020));
 
         assertThrows(IllegalArgumentException.class,
-                () -> coverageService.getCoveragePeriod(contract1.getId(), 13, 2020));
+                () -> coverageService.getCoveragePeriod(contract1, 13, 2020));
 
         assertThrows(IllegalArgumentException.class,
-                () -> coverageService.getCoveragePeriod(contract1.getId(), 12, 2040));
+                () -> coverageService.getCoveragePeriod(contract1, 12, 2040));
 
         assertThrows(IllegalArgumentException.class,
-                () -> coverageService.getCoveragePeriod(contract1.getId(), 12, 2019));
+                () -> coverageService.getCoveragePeriod(contract1, 12, 2019));
     }
 
     private Identifiers createIdentifier(String suffix) {

--- a/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
@@ -53,6 +53,7 @@ public class PropertiesServiceTest {
             put(ZIP_SUPPORT_ON, "false");
             put(WORKER_ENGAGEMENT, "engaged");
             put(HPMS_INGESTION_ENGAGEMENT, "engaged");
+            put(COVERAGE_SEARCH_ENGAGEMENT, "idle");
         }};
 
         List<Properties> propertyListBeforeInsert = propertiesService.getAllProperties();

--- a/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/PropertiesServiceTest.java
@@ -53,7 +53,8 @@ public class PropertiesServiceTest {
             put(ZIP_SUPPORT_ON, "false");
             put(WORKER_ENGAGEMENT, "engaged");
             put(HPMS_INGESTION_ENGAGEMENT, "engaged");
-            put(COVERAGE_SEARCH_ENGAGEMENT, "idle");
+            put(COVERAGE_SEARCH_DISCOVERY, "idle");
+            put(COVERAGE_SEARCH_QUEUEING, "idle");
         }};
 
         List<Properties> propertyListBeforeInsert = propertiesService.getAllProperties();

--- a/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
@@ -152,7 +152,6 @@ public class DataSetup {
         contract.setAttestedOn(OffsetDateTime.now());
         contract.setContractName("Test Contract");
         contract.setContractNumber(contractNumber);
-        contract.setAttestedOn(OffsetDateTime.now());
 
         contract.setSponsor(sponsor);
 

--- a/common/src/test/java/gov/cms/ab2d/common/util/DateUtilTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DateUtilTest.java
@@ -9,6 +9,8 @@ import java.time.*;
 import java.util.Date;
 import java.util.TimeZone;
 
+import static gov.cms.ab2d.common.util.DateUtil.AB2D_ZONE;
+
 public class DateUtilTest {
 
     @Test
@@ -33,7 +35,7 @@ public class DateUtilTest {
 
     @Test
     public void testGetESTOffset() {
-        String expectedOffset = TimeZone.getTimeZone("America/New_York").inDaylightTime(new Date()) ? "-0400" : "-0500";
+        String expectedOffset = TimeZone.getTimeZone(AB2D_ZONE).inDaylightTime(new Date()) ? "-0400" : "-0500";
         String offset = DateUtil.getESTOffset();
         Assert.assertEquals(expectedOffset, offset);
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/CoverageProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/CoverageProcessor.java
@@ -13,6 +13,11 @@ public interface CoverageProcessor {
      */
     void queueStaleCoveragePeriods();
 
+    /**
+     * Check all {@link gov.cms.ab2d.common.model.Contract} for attestation dates and create {@link CoveragePeriod}s
+     * for all months since the attestation of those contracts.
+     */
+    void discoverCoveragePeriods();
 
     /**
      * Add a {@link CoveragePeriod} to the queue of periods to be mapped

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -285,7 +285,7 @@ public class JobProcessorImpl implements JobProcessor {
 
         // If a contract was specified for request, make sure the sponsor can access the contract and then return only it
         final Contract jobSpecificContract = job.getContract();
-        if (jobSpecificContract != null && jobSpecificContract.getAttestedOn() != null) {
+        if (jobSpecificContract != null && jobSpecificContract.hasAttestation()) {
             boolean ownsContract = attestedContracts.stream()
                     .anyMatch(c -> jobSpecificContract.getContractNumber().equalsIgnoreCase(c.getContractNumber()));
             if (!ownsContract) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
@@ -1,4 +1,4 @@
-package gov.cms.ab2d.worker.processor;
+package gov.cms.ab2d.worker.processor.coverage;
 
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.CoverageMapping;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzConfig.java
@@ -1,0 +1,41 @@
+package gov.cms.ab2d.worker.processor.coverage;
+
+import org.quartz.*;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoveragePeriodQuartzConfig {
+
+    @Value("${coverage.update.schedule}")
+    private String schedule;
+
+    @Qualifier("coverage_period_update")
+    @Bean
+    JobDetail coveragePeriodJobDetail() {
+        return JobBuilder.newJob(CoveragePeriodQuartzJob.class)
+                .withIdentity("coverage_period_update")
+                .storeDurably()
+                .build();
+    }
+
+    @Bean
+    Trigger coveragePeriodJobPeriodicTrigger(@Qualifier("coverage_period_update") JobDetail coveragePeriodJobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(coveragePeriodJobDetail)
+                .withIdentity("coverage_period_update_trigger_periodic")
+                .withSchedule(CronScheduleBuilder.cronSchedule(schedule))
+                .build();
+    }
+
+    @Bean
+    Trigger coveragePeriodJobStartupTrigger(@Qualifier("coverage_period_update") JobDetail coveragePeriodJobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(coveragePeriodJobDetail)
+                .withIdentity("coverage_period_update_trigger_startup")
+                .startNow()
+                .build();
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJob.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJob.java
@@ -1,0 +1,45 @@
+package gov.cms.ab2d.worker.processor.coverage;
+
+import gov.cms.ab2d.common.service.FeatureEngagement;
+import gov.cms.ab2d.common.service.PropertiesService;
+import gov.cms.ab2d.common.util.Constants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+@Slf4j
+@RequiredArgsConstructor
+@DisallowConcurrentExecution
+public class CoveragePeriodQuartzJob extends QuartzJobBean {
+
+    private final CoverageProcessor processor;
+    private final PropertiesService propertiesService;
+
+    @Override
+    protected void executeInternal(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+
+        String engagement = propertiesService.getPropertiesByKey(Constants.COVERAGE_SEARCH_ENGAGEMENT).getValue();
+        FeatureEngagement state = FeatureEngagement.fromString(engagement);
+
+        if (state != FeatureEngagement.IN_GEAR) {
+            log.warn("coverage search engagement is not engaged so skipping discovery and" +
+                    " queueing of coverage searches");
+            return;
+        }
+
+        log.info("running coverage period quartz job by first looking for new coverage periods and then queueing new" +
+                " and stale coverage periods");
+
+        try {
+            processor.discoverCoveragePeriods();
+
+            processor.queueStaleCoveragePeriods();
+        } catch (Exception exception) {
+            log.error("coverage period updates could not be conducted");
+            throw new JobExecutionException(exception);
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessor.java
@@ -1,4 +1,4 @@
-package gov.cms.ab2d.worker.processor;
+package gov.cms.ab2d.worker.processor.coverage;
 
 import gov.cms.ab2d.common.model.CoveragePeriod;
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
@@ -119,7 +119,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
 
             int coveragePeriodsForContracts = 0;
             while (attestationTime.isBefore(now)) {
-                coverageService.getOrCreateCoveragePeriod(contract, attestationTime.getMonthValue(), attestationTime.getYear());
+                coverageService.getCreateIfAbsentCoveragePeriod(contract, attestationTime.getMonthValue(), attestationTime.getYear());
                 coveragePeriodsForContracts += 1;
 
                 attestationTime = attestationTime.plusMonths(1);

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -43,6 +43,8 @@ coverage.core.pool.size=6
 coverage.max.pool.size=12
 
 # Coverage processor parameterization to find stale jobs, stuck jobs, and limit allowed failures
+# Run daily at midnight
+coverage.update.schedule=0 0 0 * * ?
 coverage.update.months.past=2
 coverage.update.stale.days=7
 coverage.update.max.attempts=3

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallableTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallableTest.java
@@ -1,6 +1,5 @@
-package gov.cms.ab2d.worker.processor;
+package gov.cms.ab2d.worker.processor.coverage;
 
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.*;
 import gov.cms.ab2d.common.model.Contract;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJobTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJobTest.java
@@ -1,0 +1,72 @@
+package gov.cms.ab2d.worker.processor.coverage;
+
+import gov.cms.ab2d.common.model.Properties;
+import gov.cms.ab2d.common.service.PropertiesService;
+import gov.cms.ab2d.common.util.Constants;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CoveragePeriodQuartzJobTest {
+
+    @DisplayName("Disengaging coverage search works")
+    @Test
+    void disengageSearchWorks() {
+
+        PropertiesService propertiesService = mock(PropertiesService.class);
+
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_ENGAGEMENT))).thenAnswer((arg) -> {
+            Properties engaged = new Properties();
+            engaged.setKey(Constants.COVERAGE_SEARCH_ENGAGEMENT);
+            engaged.setValue("idle");
+            return engaged;
+        });
+
+        CoverageProcessorStub coverageProcessor = new CoverageProcessorStub();
+
+        CoveragePeriodQuartzJob quartzJob = new CoveragePeriodQuartzJob(coverageProcessor, propertiesService);
+
+        try {
+            quartzJob.executeInternal(null);
+
+            assertFalse(coverageProcessor.discoveryCalled);
+            assertFalse(coverageProcessor.queueingCalled);
+
+        } catch (JobExecutionException jobExecutionException) {
+            // Exception never thrown by stubbed method
+        }
+    }
+
+    @DisplayName("Engaging coverage search works")
+    @Test
+    void engageSearchWorks() {
+
+        PropertiesService propertiesService = mock(PropertiesService.class);
+
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_ENGAGEMENT))).thenAnswer((arg) -> {
+            Properties engaged = new Properties();
+            engaged.setKey(Constants.COVERAGE_SEARCH_ENGAGEMENT);
+            engaged.setValue("engaged");
+            return engaged;
+        });
+
+        CoverageProcessorStub coverageProcessor = new CoverageProcessorStub();
+        CoveragePeriodQuartzJob quartzJob = new CoveragePeriodQuartzJob(coverageProcessor, propertiesService);
+
+        try {
+
+            quartzJob.executeInternal(null);
+
+            assertTrue(coverageProcessor.discoveryCalled);
+            assertTrue(coverageProcessor.queueingCalled);
+
+        } catch (JobExecutionException jobExecutionException) {
+            fail("could not execute normally", jobExecutionException);
+        }
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJobTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoveragePeriodQuartzJobTest.java
@@ -20,9 +20,16 @@ class CoveragePeriodQuartzJobTest {
 
         PropertiesService propertiesService = mock(PropertiesService.class);
 
-        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_ENGAGEMENT))).thenAnswer((arg) -> {
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_DISCOVERY))).thenAnswer((arg) -> {
             Properties engaged = new Properties();
-            engaged.setKey(Constants.COVERAGE_SEARCH_ENGAGEMENT);
+            engaged.setKey(Constants.COVERAGE_SEARCH_DISCOVERY);
+            engaged.setValue("idle");
+            return engaged;
+        });
+
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_QUEUEING))).thenAnswer((arg) -> {
+            Properties engaged = new Properties();
+            engaged.setKey(Constants.COVERAGE_SEARCH_QUEUEING);
             engaged.setValue("idle");
             return engaged;
         });
@@ -48,9 +55,16 @@ class CoveragePeriodQuartzJobTest {
 
         PropertiesService propertiesService = mock(PropertiesService.class);
 
-        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_ENGAGEMENT))).thenAnswer((arg) -> {
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_DISCOVERY))).thenAnswer((arg) -> {
             Properties engaged = new Properties();
-            engaged.setKey(Constants.COVERAGE_SEARCH_ENGAGEMENT);
+            engaged.setKey(Constants.COVERAGE_SEARCH_DISCOVERY);
+            engaged.setValue("engaged");
+            return engaged;
+        });
+
+        when(propertiesService.getPropertiesByKey(eq(Constants.COVERAGE_SEARCH_QUEUEING))).thenAnswer((arg) -> {
+            Properties engaged = new Properties();
+            engaged.setKey(Constants.COVERAGE_SEARCH_QUEUEING);
             engaged.setValue("engaged");
             return engaged;
         });

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorIntTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorIntTest.java
@@ -1,4 +1,4 @@
-package gov.cms.ab2d.worker.processor;
+package gov.cms.ab2d.worker.processor.coverage;
 
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.CoveragePeriod;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorStub.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorStub.java
@@ -1,0 +1,28 @@
+package gov.cms.ab2d.worker.processor.coverage;
+
+import gov.cms.ab2d.common.model.CoveragePeriod;
+
+public class CoverageProcessorStub implements CoverageProcessor {
+
+    public boolean discoveryCalled;
+    public boolean queueingCalled;
+
+    @Override
+    public void queueStaleCoveragePeriods() {
+        queueingCalled = true;
+    }
+
+    @Override
+    public void discoverCoveragePeriods() {
+        discoveryCalled = true;
+    }
+
+    @Override
+    public void queueCoveragePeriod(CoveragePeriod period, boolean prioritize) {}
+
+    @Override
+    public void queueCoveragePeriod(CoveragePeriod period, int attempts, boolean prioritize) {}
+
+    @Override
+    public void shutdown() {}
+}

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -43,6 +43,8 @@ contract.core.pool.size=6
 contract.max.pool.size=12
 
 ## These properties apply to "patientCoverageThreadPool"
+# Never run automatically in testing
+coverage.update.schedule=0 0 0 1 * ? 2099
 coverage.core.pool.size=6
 coverage.max.pool.size=12
 coverage.update.months.past=2
@@ -53,7 +55,7 @@ coverage.update.initial.delay=1
 
 ## ----------------------------------------------------------------------------- STUCK JOB
 ## -- run every 2 hours
-stuck.job.cron.schedule=0 0 0/2 * * ?
+stuck.job.cron.schedule=0 0 0 1 * ? 2099
 stuck.job.cancel.threshold=6
 
 ## ----------------------------------------------------------------------------- LOGGING LEVEL
@@ -69,7 +71,7 @@ health.requiredSpareMemoryInMB=32
 health.urlsToCheck=http://www.google.com,http://www.facebook.com
 
 ## ------------------------------------------------------------------------------ BFD Health Check
-bfd.health.check.schedule=0 * * * * ?
+bfd.health.check.schedule=0 0 0 1 * ? 2099
 bfd.health.check.consecutive.successes=3
 bfd.health.check.consecutive.failures=3
 bfd.health.check.enabled=false


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2179](https://jira.cms.gov/browse/AB2D-2179) - Coverage Period Loading and Rechecking Policy

***Related Tickets***

[AB2D-2180](https://jira.cms.gov/browse/AB2D-2180) - API trigger that allows manually turning this feature on and off
 
### What Does This PR Do?

Create a Quartz job that is by default disabled. This quartz job handles discovering new CoveragePeriods and queueing new and stale CoveragePeriods to have their metadata updated.

### What Should Reviewers Watch For?

* Quartz setup needs to be looked over to make sure there is no way for this to trigger without us updating the property.
* Any potential ways that a CoveragePeriod can be created for a project outside the AB2D epoch or before a contract is attested.

### Usage/Deployment Instructions

Does not impact deployments because it still must be activated manually.

### Impacted External Components

### Database Changes

* Adding an additional property to the properties table which toggles the newly created Quartz job. This property mirrors the HPMS Quartz job.

### Limitations

* No way to trigger coverage mapping for a specific contract via the API
* No way to immediately trigger coverage mapping only to enable it to run nightly.

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure