### PR TITLE
Changed default file deletion from 24 hours to 72 for slow or large PDPs

### DIFF
--- a/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
+++ b/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
@@ -122,8 +122,8 @@ class FileDeletionServiceTest {
         job = new Job();
         job.setStatus(JobStatus.SUCCESSFUL);
         job.setJobUuid(UUID.randomUUID().toString());
-        job.setCreatedAt(OffsetDateTime.now().minusDays(3));
-        job.setCompletedAt(OffsetDateTime.now().minusDays(2));
+        job.setCreatedAt(OffsetDateTime.now().minusDays(5));
+        job.setCompletedAt(OffsetDateTime.now().minusDays(4));
         job.setExpiresAt(OffsetDateTime.now().minusDays(1));
         job.setUser(user);
         jobService.updateJob(job);
@@ -140,9 +140,9 @@ class FileDeletionServiceTest {
         jobNotExpiredYet = new Job();
         jobNotExpiredYet.setStatus(JobStatus.SUCCESSFUL);
         jobNotExpiredYet.setJobUuid(UUID.randomUUID().toString());
-        jobNotExpiredYet.setCreatedAt(OffsetDateTime.now().minusHours(10));
-        jobNotExpiredYet.setCompletedAt(OffsetDateTime.now().minusHours(5));
-        jobNotExpiredYet.setExpiresAt(OffsetDateTime.now().plusHours(19));
+        jobNotExpiredYet.setCreatedAt(OffsetDateTime.now().minusHours(60));
+        jobNotExpiredYet.setCompletedAt(OffsetDateTime.now().minusHours(55));
+        jobNotExpiredYet.setExpiresAt(OffsetDateTime.now().plusHours(17));
         jobNotExpiredYet.setUser(user);
 
         jobCancelled = new Job();

--- a/common/src/main/resources/application.common.properties
+++ b/common/src/main/resources/application.common.properties
@@ -1,6 +1,6 @@
 efs.mount=${AB2D_EFS_MOUNT:#{systemProperties['java.io.tmpdir']+'/jobdownloads'}}/
 
-audit.files.ttl.hours=24
+audit.files.ttl.hours=72
 
 hpms.base.url=${AB2D_HPMS_URL:https://hpmsimpl.cms.gov}
 # The following parameter translates into a map to make it easy to add any number of parameters.

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -1,6 +1,6 @@
 efs.mount=${java.io.tmpdir}/jobdownloads/
 
-audit.files.ttl.hours=24
+audit.files.ttl.hours=72
 
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.util.Pair;
 import org.testcontainers.containers.DockerComposeContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.yaml.snakeyaml.Yaml;
 
@@ -170,9 +169,9 @@ public class TestRunner {
                 .withScaledService("worker", 2)
                 .withScaledService("api", 1)
                 .withExposedService("api", DEFAULT_API_PORT, new HostPortWaitStrategy()
-                    .withStartupTimeout(Duration.of(200, SECONDS)))
-                .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-                .withLogConsumer("api", new Slf4jLogConsumer(log));
+                    .withStartupTimeout(Duration.of(200, SECONDS)));
+//                .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+//                .withLogConsumer("api", new Slf4jLogConsumer(log));
 
         container.start();
     }

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.util.Pair;
 import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.yaml.snakeyaml.Yaml;
 
@@ -169,9 +170,9 @@ public class TestRunner {
                 .withScaledService("worker", 2)
                 .withScaledService("api", 1)
                 .withExposedService("api", DEFAULT_API_PORT, new HostPortWaitStrategy()
-                    .withStartupTimeout(Duration.of(200, SECONDS)));
-        //.withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
-        //.withLogConsumer("api", new Slf4jLogConsumer(log));
+                    .withStartupTimeout(Duration.of(200, SECONDS)))
+                .withLogConsumer("worker", new Slf4jLogConsumer(log)) // Use to debug, for now there's too much log data
+                .withLogConsumer("api", new Slf4jLogConsumer(log));
 
         container.start();
     }

--- a/website/advanced-user-guide.md
+++ b/website/advanced-user-guide.md
@@ -231,7 +231,7 @@ Once the search job has been completed, the contents of the of the created file(
 GET /api/v1/fhir/Job/{jobUuid}/file/{filename}
 ```
 
-The file(s) are specified as the output of the status request. Each file will only be available for 24 hours after the 
+The file(s) are specified as the output of the status request. Each file will only be available for 72 hours after the 
 job has completed. Files are also unavailable after they have been successfully downloaded. 
 
 ### Cancellation
@@ -299,8 +299,8 @@ $status but $ means a variable value in the bash command line.
 - Your file name or job name are not correct. You can call the $status command again and verify that you have the file 
 name & job name correct.
 - You can only download the file once. If you have already done that, it no longer exists on our system
-- The time between when the job completed and you requested the file was greater than 24 hours. Files are 
-automatically deleted (or expired) after 24 hours.
+- The time between when the job completed and you requested the file was greater than 72 hours. Files are 
+automatically deleted (or expired) after 72 hours.
 - There was an error on our server. If this continues to happen, contact technical support
 
 ### Other

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -54,7 +54,7 @@ coverage.update.initial.delay=1
 ## ---------------------------------------------------------------------------- STUCK JOB
 ## -- run every hour
 stuck.job.cron.schedule=0 0 * * * ?
-stuck.job.cancel.threshold=24
+stuck.job.cancel.threshold=72
 
 ## ---------------------------------------------------------------------------- ROLLOVER IN MB FOR OUTPUT FILES
 job.file.rollover.ndjson=200

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -54,7 +54,7 @@ coverage.update.initial.delay=1
 ## ---------------------------------------------------------------------------- STUCK JOB
 ## -- run every hour
 stuck.job.cron.schedule=0 0 * * * ?
-stuck.job.cancel.threshold=72
+stuck.job.cancel.threshold=36
 
 ## ---------------------------------------------------------------------------- ROLLOVER IN MB FOR OUTPUT FILES
 job.file.rollover.ndjson=200


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2725](https://jira.cms.gov/browse/AB2D-2725) - Description

### What Does This PR Do?

Changes the expiration date for files from 24 to 72 hours in the code and in documentation.

### Impacted External Components

Changed it in the ab2d-private- production documentation

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure