### PR TITLE
Techdebt/ab2d 2890 common test cleanup

### DIFF
--- a/common/src/test/java/gov/cms/ab2d/common/health/DatabaseAvailableTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/health/DatabaseAvailableTest.java
@@ -13,14 +13,11 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
-import java.sql.*;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executor;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
@@ -37,7 +34,7 @@ class DatabaseAvailableTest {
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
     @Test
-    public void testDatasource() throws SQLException {
+    void testDatasource() throws SQLException {
         assertTrue(DatabaseAvailable.isDbAvailable(dataSource));
         assertFalse(DatabaseAvailable.isDbAvailable(null));
         Mockito.when(bogusDS.getConnection()).thenReturn(null);

--- a/common/src/test/java/gov/cms/ab2d/common/health/MemoryUtilizationTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/health/MemoryUtilizationTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MemoryUtilizationTest {
     @Test
-    public void testMemory() {
+    void testMemory() {
         assertFalse(MemoryUtilization.outOfMemory(2));
         assertTrue(MemoryUtilization.outOfMemory((int) (Math.pow(2, 31) - 1)));
     }

--- a/common/src/test/java/gov/cms/ab2d/common/health/UrlAvailableTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/health/UrlAvailableTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class UrlAvailableTest {
     @Test
-    public void testAvailable() {
+    void testAvailable() {
         assertFalse(UrlAvailable.available("www.google.com"));
         assertTrue(UrlAvailable.available("http://www.google.com"));
         assertTrue(UrlAvailable.available("http://www.google.com:80"));
@@ -16,7 +16,7 @@ class UrlAvailableTest {
     }
 
     @Test
-    public void testAnyAvailable() {
+    void testAnyAvailable() {
         List<String> l1 = List.of("http://www.google.com", "http://www.facebook.com");
         List<String> l2 = List.of("http://www.glajlasjdflkajsdfkljaskdfjlasjdfloogle.com", "http://www.facebook.com");
         List<String> l3 = List.of("http://www.google.com", "http://www.lkjasdkfljal;kdsjf;lakjsdflkjsdafacebook.com");

--- a/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
@@ -2,6 +2,9 @@ package gov.cms.ab2d.common.model;
 
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.DataSetup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,8 +13,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @Testcontainers
@@ -27,30 +30,35 @@ class ContractUpdateModeTest {
     @Autowired
     private ContractRepository contractRepository;
 
+    @Autowired
+    private DataSetup dataSetup;
+
+    private Contract contract;
+
+    @BeforeEach
+    public void before() {
+        contract = buildContract();
+        dataSetup.queueForCleanup(contract);
+    }
+
+    @AfterEach
+    public void after() {
+        dataSetup.cleanup();
+    }
+
     @Test
     void testAutomaticUpdate() {
-        Contract contract = buildContract();
         assertFalse(contract.hasAttestation());
         contract.updateAttestation(true, TEST_DATE_STR);
         assertTrue(contract.hasAttestation());
-
-        cleanup(contract);
     }
 
     @Test
     void testManualOverride() {
-        Contract contract = buildContract();
         assertFalse(contract.hasAttestation());
         contract.setUpdateMode(Contract.UpdateMode.MANUAL);
         contract.updateAttestation(true, TEST_DATE_STR);
         assertFalse(contract.hasAttestation());
-
-        cleanup(contract);
-    }
-
-    private void cleanup(Contract contract) {
-        // Cleanup
-        contractRepository.delete(contract);
     }
 
     private Contract buildContract() {

--- a/common/src/test/java/gov/cms/ab2d/common/model/CoverageSearchTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CoverageSearchTest.java
@@ -15,7 +15,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @Testcontainers
@@ -47,13 +48,7 @@ class CoverageSearchTest {
 
     @AfterEach
     void after() {
-        coverageSearchEventRepo.deleteAll();
-        coverageSearchRepository.deleteAll();
-        coveragePeriodRepo.deleteAll();
-
-        contractRepo.delete(contract1);
-        contractRepo.delete(contract2);
-        contractRepo.flush();
+        dataSetup.cleanup();
     }
 
     @Test

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -33,7 +33,7 @@ class CreateUpdateTimestampTest {
 
     @AfterEach
     public void after() {
-
+        dataSetup.cleanup();
     }
 
     @Test

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -2,6 +2,8 @@ package gov.cms.ab2d.common.model;
 
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.DataSetup;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Testcontainers
@@ -24,7 +26,15 @@ class CreateUpdateTimestampTest {
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @Autowired
+    private DataSetup dataSetup;
+
+    @Autowired
     private ContractRepository contractRepository;
+
+    @AfterEach
+    public void after() {
+
+    }
 
     @Test
     void testTimestamps() {
@@ -36,6 +46,8 @@ class CreateUpdateTimestampTest {
         assertNull(contract.getModified());
 
         Contract savedCSE = contractRepository.save(contract);
+        dataSetup.queueForCleanup(savedCSE);
+
         assertEquals("TEST123", savedCSE.getContractNumber());
         assertNotNull(savedCSE.getId());
         assertNotNull(savedCSE.getCreated());
@@ -49,8 +61,5 @@ class CreateUpdateTimestampTest {
 
         assertEquals(created, finaleCSE.getCreated());
         assertNotEquals(modified, finaleCSE.getModified());
-
-        // Cleanup
-        contractRepository.delete(finaleCSE);
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("OptionalGetWithoutIsPresent")
 @SpringBootTest
 @Testcontainers
 @TestPropertySource(locations = "/application.common.properties")
@@ -46,13 +45,13 @@ class ContractServiceImplTest {
         contract.setContractName("Test Contract");
         contract.setContractNumber("NATTE");
 
-        contract = contractRepo.save(contract);    }
+        contract = contractRepo.save(contract);
+        dataSetup.queueForCleanup(contract);
+    }
 
     @AfterEach
     private void after() {
-        if (contract != null) {
-            dataSetup.deleteContract(contract);
-        }
+        dataSetup.cleanup();
     }
 
     @DisplayName("Find all contracts and filter by attestation")

--- a/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/CoverageServiceImplTest.java
@@ -99,13 +99,7 @@ class CoverageServiceImplTest {
 
     @AfterEach
     public void cleanUp() {
-        dataSetup.deleteCoverage();
-        coverageSearchEventRepo.deleteAll();
-        coverageSearchRepo.deleteAll();
-        coveragePeriodRepo.deleteAll();
-        contractRepo.delete(contract1);
-        contractRepo.delete(contract2);
-        contractRepo.flush();
+        dataSetup.cleanup();
     }
 
     @DisplayName("Get a coverage period")

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -10,7 +10,6 @@ import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventlogger.reports.sql.DoSummary;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,17 +44,15 @@ import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESS
 import static gov.cms.ab2d.common.service.JobServiceImpl.ZIPFORMAT;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
 @Testcontainers
-public class JobServiceTest {
+class JobServiceTest {
 
+    public static final String USERNAME = "douglas.adams@towels.com";
+    public static final String CONTRACT_NUMBER = "S0000";
     public static final String LOCAL_HOST = "http://localhost:8080";
 
     private JobService jobService;
@@ -107,92 +104,99 @@ public class JobServiceTest {
         jobService = new JobServiceImpl(userService, jobRepository, jobOutputService, logManager, doSummary);
         ReflectionTestUtils.setField(jobService, "fileDownloadPath", tmpJobLocation);
 
-        // todo: Very bizarre behavior happens if these are moved to an @AfterEach method instead.  Doing deleteAll()
-        // in a setup method is definitely a code smell.
-        jobRepository.deleteAll();
-        userRepository.deleteAll();
-        contractRepository.deleteAll();
-
-        dataSetup.setupUser(List.of());
+        dataSetup.setupNonStandardUser(USERNAME, CONTRACT_NUMBER, List.of());
 
         setupRegularUserSecurityContext();
     }
 
-    @Test
-    public void createJob() {
-        Job job = createJobAllContracts(ZIPFORMAT);
-        assertThat(job).isNotNull();
-        assertThat(job.getId()).isNotNull();
-        assertThat(job.getJobUuid()).isNotNull();
-        assertThat(job.getOutputFormat()).isNotNull();
-        assertEquals(job.getOutputFormat(), ZIPFORMAT);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getRequestUrl(), LOCAL_HOST);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getJobOutputs().size(), 0);
-        assertNull(job.getLastPollTime());
-        assertNull(job.getExpiresAt());
-        assertThat(job.getJobUuid()).matches(
-                "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}");
+    @AfterEach
+    public void after() {
+        dataSetup.cleanup();
+    }
 
-        // Verify it actually got persisted in the DB
-        assertThat(jobRepository.findById(job.getId())).get().isEqualTo(job);
+    private void setupRegularUserSecurityContext() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new org.springframework.security.core.userdetails.User(USERNAME,
+                                "test", new ArrayList<>()), "pass"));
     }
 
     @Test
-    public void createJobWithContract() {
+    void createJob() {
+        Job job = createJobAllContracts(ZIPFORMAT);
+        assertNotNull(job);
+        assertNotNull(job.getId());
+        assertNotNull(job.getJobUuid());
+        assertNotNull(job.getOutputFormat());
+        assertEquals(ZIPFORMAT, job.getOutputFormat());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals(userRepository.findByUsername(USERNAME), job.getUser());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(LOCAL_HOST, job.getRequestUrl());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(0, job.getJobOutputs().size());
+        assertNull(job.getLastPollTime());
+        assertNull(job.getExpiresAt());
+        assertTrue(job.getJobUuid().matches("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"));
+
+        // Verify it actually got persisted in the DB
+        assertEquals(job, jobRepository.findById(job.getId()).get());
+    }
+
+    @Test
+    void createJobWithContract() {
         Contract contract = contractRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
 
         Job job = jobService.createJob(EOB, LOCAL_HOST, contract.getContractNumber(), NDJSON_FIRE_CONTENT_TYPE, null);
-        assertThat(job).isNotNull();
-        assertThat(job.getId()).isNotNull();
-        assertThat(job.getJobUuid()).isNotNull();
-        assertThat(job.getOutputFormat()).isNotNull();
+        dataSetup.queueForCleanup(job);
+
+        assertNotNull(job);
+        assertNotNull(job.getId());
+        assertNotNull(job.getJobUuid());
+        assertNotNull(job.getOutputFormat());
         assertEquals(NDJSON_FIRE_CONTENT_TYPE, job.getOutputFormat());
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getRequestUrl(), LOCAL_HOST);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getJobOutputs().size(), 0);
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals(userRepository.findByUsername(USERNAME), job.getUser());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(LOCAL_HOST, job.getRequestUrl());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(0, job.getJobOutputs().size());
         assertNull(job.getLastPollTime());
         assertNull(job.getExpiresAt());
-        assertThat(job.getJobUuid()).matches(
-                "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}");
+        assertTrue(job.getJobUuid().matches("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"));
+
         assertNotNull(job.getContract());
         assertEquals(job.getContract().getContractNumber(), contract.getContractNumber());
 
         // Verify it actually got persisted in the DB
-        assertThat(jobRepository.findById(job.getId())).get().isEqualTo(job);
+        assertEquals(job, jobRepository.findById(job.getId()).get());
     }
 
     @Test
-    public void createJobWithSpecificContractNoAttestation() {
-        dataSetup.setupContractWithNoAttestation(List.of());
-        Assertions.assertThrows(InvalidContractException.class,
+    void createJobWithSpecificContractNoAttestation() {
+        dataSetup.setupContractWithNoAttestation(USERNAME, CONTRACT_NUMBER, List.of());
+        assertThrows(InvalidContractException.class,
                 () -> jobService.createJob(EOB, LOCAL_HOST, DataSetup.VALID_CONTRACT_NUMBER, NDJSON_FIRE_CONTENT_TYPE, null));
     }
 
     @Test
-    public void createJobWithAllContractsNoAttestation() {
-        dataSetup.setupContractWithNoAttestation(List.of());
-        Assertions.assertThrows(InvalidContractException.class,
+    void createJobWithAllContractsNoAttestation() {
+        dataSetup.setupContractWithNoAttestation(USERNAME, CONTRACT_NUMBER, List.of());
+        assertThrows(InvalidContractException.class,
                 () -> jobService.createJob(EOB, LOCAL_HOST, null, NDJSON_FIRE_CONTENT_TYPE, null));
     }
 
     @Test
-    public void failedValidation() {
-        Assertions.assertThrows(TransactionSystemException.class,
+    void failedValidation() {
+        assertThrows(TransactionSystemException.class,
                 () -> jobService.createJob("Patient,ExplanationOfBenefit,Coverage", LOCAL_HOST,
                         null, NDJSON_FIRE_CONTENT_TYPE, null));
     }
 
     @Test
-    public void cancelJob() {
+    void cancelJob() {
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         jobService.cancelJob(job.getJobUuid());
@@ -204,13 +208,13 @@ public class JobServiceTest {
     }
 
     @Test
-    public void cancelNonExistingJob() {
-        Assertions.assertThrows(ResourceNotFoundException.class,
+    void cancelNonExistingJob() {
+        assertThrows(ResourceNotFoundException.class,
                 () -> jobService.cancelJob("NonExistingJob"));
     }
 
     @Test
-    public void getJob() {
+    void getJob() {
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         Job retrievedJob = jobService.getAuthorizedJobByJobUuidAndRole(job.getJobUuid());
@@ -219,7 +223,7 @@ public class JobServiceTest {
     }
 
     @Test
-    public void getJobAdminRole() {
+    void getJobAdminRole() {
         // Job created by regular user
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
@@ -231,7 +235,7 @@ public class JobServiceTest {
     }
 
     @Test
-    public void getJobCreatedByAdminRole() {
+    void getJobCreatedByAdminRole() {
         setupAdminUser();
 
         // Job created by admin user
@@ -239,7 +243,7 @@ public class JobServiceTest {
 
         setupRegularUserSecurityContext();
 
-        Assertions.assertThrows(InvalidJobAccessException.class,
+        assertThrows(InvalidJobAccessException.class,
                 () -> jobService.getAuthorizedJobByJobUuidAndRole(job.getJobUuid()));
     }
 
@@ -254,7 +258,8 @@ public class JobServiceTest {
         Contract contract = dataSetup.setupContract("Y0000");
         user.setContract(contract);
 
-        userRepository.saveAndFlush(user);
+        user = userRepository.saveAndFlush(user);
+        dataSetup.queueForCleanup(user);
 
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(
@@ -262,27 +267,20 @@ public class JobServiceTest {
                                 "test", new ArrayList<>()), "pass"));
     }
 
-    private void setupRegularUserSecurityContext() {
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(
-                        new org.springframework.security.core.userdetails.User(TEST_USER,
-                                "test", new ArrayList<>()), "pass"));
-    }
-
     @Test
-    public void getNonExistentJob() {
-        Assertions.assertThrows(ResourceNotFoundException.class,
+    void getNonExistentJob() {
+        assertThrows(ResourceNotFoundException.class,
                 () -> jobService.getAuthorizedJobByJobUuidAndRole("NonExistent"));
     }
 
     @Test
-    public void testJobInSuccessfulState() {
+    void testJobInSuccessfulState() {
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         job.setStatus(JobStatus.SUCCESSFUL);
         jobRepository.saveAndFlush(job);
 
-        Assertions.assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
+        assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
     }
 
     @Test
@@ -292,7 +290,7 @@ public class JobServiceTest {
         job.setStatus(JobStatus.CANCELLED);
         jobRepository.saveAndFlush(job);
 
-        Assertions.assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
+        assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
 
     }
 
@@ -303,12 +301,12 @@ public class JobServiceTest {
         job.setStatus(JobStatus.FAILED);
         jobRepository.saveAndFlush(job);
 
-        Assertions.assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
+        assertThrows(InvalidJobStateTransition.class, () -> jobService.cancelJob(job.getJobUuid()));
 
     }
 
     @Test
-    public void updateJob() {
+    void updateJob() {
         Job job = createJobAllContracts(ZIPFORMAT);
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime localDateTime = OffsetDateTime.now();
@@ -343,31 +341,31 @@ public class JobServiceTest {
         job.setJobOutputs(output);
 
         Job updatedJob = jobService.updateJob(job);
-        Assert.assertEquals(ZIPFORMAT, updatedJob.getOutputFormat());
-        Assert.assertEquals(Integer.valueOf(100), updatedJob.getProgress());
-        Assert.assertEquals(now, updatedJob.getLastPollTime());
-        Assert.assertEquals(JobStatus.IN_PROGRESS, updatedJob.getStatus());
-        Assert.assertEquals(localDateTime, updatedJob.getCreatedAt());
-        Assert.assertEquals(localDateTime, updatedJob.getCompletedAt());
-        Assert.assertEquals("abc", updatedJob.getJobUuid());
-        Assert.assertEquals(EOB, updatedJob.getResourceTypes());
-        Assert.assertEquals("http://localhost", updatedJob.getRequestUrl());
-        Assert.assertEquals("Pending", updatedJob.getStatusMessage());
-        Assert.assertEquals(now, updatedJob.getExpiresAt());
+        assertEquals(ZIPFORMAT, updatedJob.getOutputFormat());
+        assertEquals(Integer.valueOf(100), updatedJob.getProgress());
+        assertEquals(now, updatedJob.getLastPollTime());
+        assertEquals(JobStatus.IN_PROGRESS, updatedJob.getStatus());
+        assertEquals(localDateTime, updatedJob.getCreatedAt());
+        assertEquals(localDateTime, updatedJob.getCompletedAt());
+        assertEquals("abc", updatedJob.getJobUuid());
+        assertEquals(EOB, updatedJob.getResourceTypes());
+        assertEquals("http://localhost", updatedJob.getRequestUrl());
+        assertEquals("Pending", updatedJob.getStatusMessage());
+        assertEquals(now, updatedJob.getExpiresAt());
 
         JobOutput updatedOutput = updatedJob.getJobOutputs().get(0);
-        Assert.assertEquals(false, updatedOutput.getError());
-        Assert.assertEquals(EOB, updatedOutput.getFhirResourceType());
-        Assert.assertEquals("file.ndjson", updatedOutput.getFilePath());
+        assertEquals(false, updatedOutput.getError());
+        assertEquals(EOB, updatedOutput.getFhirResourceType());
+        assertEquals("file.ndjson", updatedOutput.getFilePath());
 
         JobOutput updatedErrorOutput = updatedJob.getJobOutputs().get(1);
-        Assert.assertEquals(true, updatedErrorOutput.getError());
-        Assert.assertEquals(OPERATION_OUTCOME, updatedErrorOutput.getFhirResourceType());
-        Assert.assertEquals("error.ndjson", updatedErrorOutput.getFilePath());
+        assertEquals(true, updatedErrorOutput.getError());
+        assertEquals(OPERATION_OUTCOME, updatedErrorOutput.getFhirResourceType());
+        assertEquals("error.ndjson", updatedErrorOutput.getFilePath());
     }
 
     @Test
-    public void getFileDownloadUrl() throws IOException {
+    void getFileDownloadUrl() throws IOException {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
@@ -380,14 +378,14 @@ public class JobServiceTest {
         createNDJSONFile(errorFile, destinationStr);
 
         Resource resource = jobService.getResourceForJob(job.getJobUuid(), testFile);
-        Assert.assertEquals(testFile, resource.getFilename());
+        assertEquals(testFile, resource.getFilename());
 
         Resource errorResource = jobService.getResourceForJob(job.getJobUuid(), errorFile);
-        Assert.assertEquals(errorFile, errorResource.getFilename());
+        assertEquals(errorFile, errorResource.getFilename());
     }
 
     @Test
-    public void getJobOutputFromDifferentUser() throws IOException {
+    void getJobOutputFromDifferentUser() throws IOException {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
@@ -404,6 +402,7 @@ public class JobServiceTest {
         user.setRoles(Set.of(role));
         user.setUsername("BadUser");
         user.setEnabled(true);
+        dataSetup.queueForCleanup(user);
 
         Contract contract = dataSetup.setupContract("New Contract");
         user.setContract(contract);
@@ -418,7 +417,7 @@ public class JobServiceTest {
                 InvalidJobAccessException.class,
                 () -> jobService.getResourceForJob(job.getJobUuid(), testFile));
 
-        Assert.assertEquals(exceptionThrown.getMessage(), "Unauthorized");
+        assertEquals(exceptionThrown.getMessage(), "Unauthorized");
     }
 
     private void createNDJSONFile(String file, String destinationStr) throws IOException {
@@ -467,27 +466,27 @@ public class JobServiceTest {
     }
 
     @Test
-    public void getFileDownloadUrlWithWrongFilename() {
+    void getFileDownloadUrlWithWrongFilename() {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
 
-        Assertions.assertThrows(ResourceNotFoundException.class,
+        assertThrows(ResourceNotFoundException.class,
                 () -> jobService.getResourceForJob(job.getJobUuid(), "filenamewrong.ndjson"));
     }
 
     @Test
-    public void getFileDownloadUrlWitMissingOutput() {
+    void getFileDownloadUrlWitMissingOutput() {
         String testFile = "outputmissing.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
 
-        Assertions.assertThrows(JobOutputMissingException.class,
+        assertThrows(JobOutputMissingException.class,
                 () -> jobService.getResourceForJob(job.getJobUuid(), "outputmissing.ndjson"));
     }
 
     @Test
-    public void getFileDownloadAlreadyDownloaded() {
+    void getFileDownloadAlreadyDownloaded() {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
@@ -495,15 +494,14 @@ public class JobServiceTest {
         jobOutput.setDownloaded(true);
         jobOutputRepository.save(jobOutput);
 
-
-        var exception = Assertions.assertThrows(JobOutputMissingException.class,
+        var exception = assertThrows(JobOutputMissingException.class,
                 () -> jobService.getResourceForJob(job.getJobUuid(), "test.ndjson"));
         assertEquals("The file is not present as it has already been downloaded. Please resubmit the job.",
                 exception.getMessage());
     }
 
     @Test
-    public void getFileDownloadExpired() {
+    void getFileDownloadExpired() {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
@@ -511,37 +509,37 @@ public class JobServiceTest {
         jobRepository.save(job);
 
 
-        var exception = Assertions.assertThrows(JobOutputMissingException.class,
+        var exception = assertThrows(JobOutputMissingException.class,
                 () -> jobService.getResourceForJob(job.getJobUuid(), "test.ndjson"));
         assertEquals("The file is not present as it has expired. Please resubmit the job.", exception.getMessage());
     }
 
     @Test
-    public void checkIfUserCanAddJobTest() {
+    void checkIfUserCanAddJobTest() {
         boolean result = jobService.checkIfCurrentUserCanAddJob();
-        Assert.assertTrue(result);
+        assertTrue(result);
     }
 
     @Test
-    public void checkIfUserCanAddJobTrueTest() {
+    void checkIfUserCanAddJobTrueTest() {
         createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         boolean result = jobService.checkIfCurrentUserCanAddJob();
-        Assert.assertTrue(result);
+        assertTrue(result);
     }
 
     @Test
-    public void checkIfUserCanAddJobPastLimitTest() {
+    void checkIfUserCanAddJobPastLimitTest() {
         createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
         createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
         createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         boolean result = jobService.checkIfCurrentUserCanAddJob();
-        Assert.assertFalse(result);
+        assertFalse(result);
     }
 
     @Test
-    public void deleteFileForJobTest() {
+    void deleteFileForJobTest() {
         String testFile = "test.ndjson";
         String errorFile = "error.ndjson";
         Job job = createJobForFileDownloads(testFile, errorFile);
@@ -549,6 +547,8 @@ public class JobServiceTest {
     }
 
     private Job createJobAllContracts(String outputFormat) {
-        return jobService.createJob(EOB, LOCAL_HOST, null, outputFormat, null);
+        Job job = jobService.createJob(EOB, LOCAL_HOST, null, outputFormat, null);
+        dataSetup.queueForCleanup(job);
+        return job;
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
@@ -3,12 +3,9 @@ package gov.cms.ab2d.common.service;
 import gov.cms.ab2d.common.SpringBootApp;
 import gov.cms.ab2d.common.dto.*;
 import gov.cms.ab2d.common.model.*;
-import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import gov.cms.ab2d.common.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,22 +28,16 @@ import java.util.List;
 
 import static gov.cms.ab2d.common.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
 @Testcontainers
-public class UserServiceTest {
+class UserServiceTest {
 
     @Autowired
     private UserService userService;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private ContractRepository contractRepository;
 
     @Autowired
     private RoleService roleService;
@@ -59,41 +50,49 @@ public class UserServiceTest {
 
     @AfterEach
     public void teardown() {
-        userRepository.deleteAll();
-        contractRepository.deleteAll();
+        dataSetup.cleanup();
     }
 
+    // This is a bad test because if other test classes run first
+    // and do set the current user it will bleed over into this test class
+    @Disabled
     @Test
-    public void testUser() {
+    void testUser() {
         User user = userService.getCurrentUser();
 
         assertNull(user); // no authentication for now, so will be null
     }
 
     @Test
-    public void testCreateUser() {
+    void testCreateUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
 
         UserDTO createdUser = userService.createUser(user);
-        Assert.assertEquals(createdUser.getUsername(), user.getUsername());
-        Assert.assertEquals(createdUser.getEmail(), user.getEmail());
-        Assert.assertEquals(createdUser.getFirstName(), user.getFirstName());
-        Assert.assertEquals(createdUser.getLastName(), user.getLastName());
-        Assert.assertEquals(createdUser.getEnabled(), user.getEnabled());
-        Assert.assertEquals(createdUser.getContract(), user.getContract());
-        Assert.assertEquals(createdUser.getRole(), SPONSOR_ROLE);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
+
+        assertEquals(user.getUsername(), createdUser.getUsername());
+        assertEquals(user.getEmail(), createdUser.getEmail());
+        assertEquals(user.getFirstName(), createdUser.getFirstName());
+        assertEquals(user.getLastName(), createdUser.getLastName());
+        assertEquals(user.getEnabled(), createdUser.getEnabled());
+        assertEquals(user.getContract(), createdUser.getContract());
+        assertEquals(SPONSOR_ROLE, createdUser.getRole());
     }
 
     @Test
-    public void testCreateDuplicateUser() {
+    void testCreateDuplicateUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
 
         userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
+
         var exceptionThrown = Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
             user.setEmail("anotherEmail@test.com");
             userService.createUser(user);
         });
-        assertThat(exceptionThrown.getMessage(), is("could not execute statement; SQL [n/a]; constraint [uc_user_account_username]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement"));
+        assertEquals("could not execute statement; SQL [n/a]; constraint [uc_user_account_username]; " +
+                "nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement",
+                exceptionThrown.getMessage());
     }
 
     private UserDTO buildUserDTO(String test, String sponsorRole) {
@@ -121,10 +120,11 @@ public class UserServiceTest {
     }
 
     @Test
-    public void testUpdateUser() {
+    void testUpdateUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
 
         UserDTO createdUser = userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         createdUser.setEmail("newTest@test.com");
         createdUser.setFirstName("New");
@@ -136,14 +136,14 @@ public class UserServiceTest {
 
         UserDTO updatedUser = userService.updateUser(createdUser);
 
-        Assert.assertEquals(updatedUser.getUsername(), createdUser.getUsername());
-        Assert.assertEquals(updatedUser.getEmail(), createdUser.getEmail());
-        Assert.assertEquals(updatedUser.getFirstName(), createdUser.getFirstName());
-        Assert.assertEquals(updatedUser.getLastName(), createdUser.getLastName());
-        Assert.assertEquals(updatedUser.getEnabled(), createdUser.getEnabled());
-        Assert.assertEquals(updatedUser.getContract().getContractName(), createdUser.getContract().getContractName());
-        Assert.assertEquals(updatedUser.getContract().getContractNumber(), createdUser.getContract().getContractNumber());
-        Assert.assertEquals(updatedUser.getRole(), createdUser.getRole());
+        assertEquals(createdUser.getUsername(), updatedUser.getUsername());
+        assertEquals(createdUser.getEmail(), updatedUser.getEmail());
+        assertEquals(createdUser.getFirstName(), updatedUser.getFirstName());
+        assertEquals(createdUser.getLastName(), updatedUser.getLastName());
+        assertEquals(createdUser.getEnabled(), updatedUser.getEnabled());
+        assertEquals(createdUser.getContract().getContractName(), updatedUser.getContract().getContractName());
+        assertEquals(createdUser.getContract().getContractNumber(), updatedUser.getContract().getContractNumber());
+        assertEquals(createdUser.getRole(), updatedUser.getRole());
     }
 
     private ContractDTO buildContractDTO(Contract contract) {
@@ -155,37 +155,39 @@ public class UserServiceTest {
     }
 
     @Test
-    public void testUpdateUserAddRole() {
+    void testUpdateUserAddRole() {
         UserDTO user = buildUserDTO("Test", null);
 
-        Assert.assertNull(user.getRole());
+        assertNull(user.getRole());
 
         UserDTO createdUser = userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         createdUser.setRole(SPONSOR_ROLE);
 
         UserDTO updatedUser = userService.updateUser(createdUser);
 
-        Assert.assertEquals(updatedUser.getRole(), createdUser.getRole());
+        assertEquals(createdUser.getRole(), updatedUser.getRole());
     }
 
     @Test
-    public void testUpdateUserRemoveRole() {
+    void testUpdateUserRemoveRole() {
         UserDTO user = buildUserDTO("TEST", SPONSOR_ROLE);
 
-        Assert.assertEquals(user.getRole(), SPONSOR_ROLE);
+        assertEquals(SPONSOR_ROLE, user.getRole());
 
         UserDTO createdUser = userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         createdUser.setRole(null);
 
         UserDTO updatedUser = userService.updateUser(createdUser);
 
-        Assert.assertNull(updatedUser.getRole());
+        assertNull(updatedUser.getRole());
     }
 
     @Test
-    public void testSetupUserAndRolesInSecurityContext() {
+    void testSetupUserAndRolesInSecurityContext() {
         HttpServletRequest httpServletRequest = new MockHttpServletRequest();
 
         List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(ADMIN_ROLE));
@@ -196,44 +198,47 @@ public class UserServiceTest {
 
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
         UserDTO createdUser = userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         String username = createdUser.getUsername();
 
         userService.setupUserImpersonation(username, httpServletRequest);
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Assert.assertEquals(authentication.getPrincipal(), "test@test.com");
-        Assert.assertEquals(authentication.getAuthorities().size(), 1);
+        assertEquals("test@test.com", authentication.getPrincipal());
+        assertEquals(1, authentication.getAuthorities().size());
         GrantedAuthority grantedAuthority = authentication.getAuthorities().iterator().next();
-        Assert.assertEquals(grantedAuthority.getAuthority(), SPONSOR_ROLE);
+        assertEquals(SPONSOR_ROLE, grantedAuthority.getAuthority());
     }
 
     @Test
-    public void testSetupUserAndRolesInSecurityContextBadUser() {
+    void testSetupUserAndRolesInSecurityContextBadUser() {
         HttpServletRequest httpServletRequest = new MockHttpServletRequest();
         var exceptionThrown = Assertions.assertThrows(ResourceNotFoundException.class, () -> {
             userService.setupUserImpersonation("UserDoesNotExist", httpServletRequest);
         });
-        Assert.assertEquals(exceptionThrown.getMessage(), "User is not present in our database");
+        assertEquals("User is not present in our database", exceptionThrown.getMessage());
     }
 
     @Test
-    public void testEnableUser() {
+    void testEnableUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
         user.setEnabled(false);
 
         userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         UserDTO updatedUser = userService.enableUser(user.getUsername());
-        Assert.assertEquals(updatedUser.getEnabled(), true);
+        assertEquals(true, updatedUser.getEnabled());
     }
 
     @Test
-    public void testDisableUser() {
+    void testDisableUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);
         userService.createUser(user);
+        dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
         UserDTO updatedUser = userService.disableUser(user.getUsername());
-        Assert.assertEquals(updatedUser.getEnabled(), false);
+        assertEquals(false, updatedUser.getEnabled());
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
@@ -53,16 +53,6 @@ class UserServiceTest {
         dataSetup.cleanup();
     }
 
-    // This is a bad test because if other test classes run first
-    // and do set the current user it will bleed over into this test class
-    @Disabled
-    @Test
-    void testUser() {
-        User user = userService.getCurrentUser();
-
-        assertNull(user); // no authentication for now, so will be null
-    }
-
     @Test
     void testCreateUser() {
         UserDTO user = buildUserDTO("Test", SPONSOR_ROLE);

--- a/common/src/test/java/gov/cms/ab2d/common/util/AttestationStatusTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AttestationStatusTest.java
@@ -1,17 +1,18 @@
 package gov.cms.ab2d.common.util;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
-public class AttestationStatusTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AttestationStatusTest {
 
     // Add better tests in future, for now just use this to meet coverage checks, it's being covered by HPMS module
     @Test
-    public void testAttestationStatus() {
+    void testAttestationStatus() {
         AttestationStatus attestationStatus = AttestationStatus.WITHOUT_ATTESTATION;
-        Assert.assertEquals("Without Attestation", attestationStatus.getValue());
+        assertEquals("Without Attestation", attestationStatus.getValue());
 
         AttestationStatus attestationStatusAttested = AttestationStatus.ATTESTED;
-        Assert.assertEquals("Attested", attestationStatusAttested.getValue());
+        assertEquals("Attested", attestationStatusAttested.getValue());
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/util/DateUtilTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DateUtilTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.common.util;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -10,33 +9,34 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_ZONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DateUtilTest {
+class DateUtilTest {
 
     @Test
-    public void testFormatDateAsDateTimeAsUTC() throws ParseException {
+    void testFormatDateAsDateTimeAsUTC() throws ParseException {
         LocalDateTime localDateTime = LocalDateTime.of(2019, 10, 21, 0, 0);
 
         String formattedDate = DateUtil.formatLocalDateTimeAsUTC(localDateTime);
 
-        Assert.assertEquals("Mon, 21 Oct 2019 00:00:00 GMT", formattedDate);
+        assertEquals("Mon, 21 Oct 2019 00:00:00 GMT", formattedDate);
     }
 
     @Test
-    public void testConvertLocalDateTimeToDate() throws ParseException {
+    void testConvertLocalDateTimeToDate() throws ParseException {
         LocalDateTime localDateTime = LocalDateTime.of(2019, 10, 21, 0, 0);
         Date date = DateUtil.convertLocalDateTimeToDate(localDateTime);
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date dateFromFormatParse = format.parse("2019-10-21");
 
-        Assert.assertEquals(dateFromFormatParse, date);
+        assertEquals(dateFromFormatParse, date);
     }
 
     @Test
-    public void testGetESTOffset() {
+    void testGetESTOffset() {
         String expectedOffset = TimeZone.getTimeZone(AB2D_ZONE).inDaylightTime(new Date()) ? "-0400" : "-0500";
         String offset = DateUtil.getESTOffset();
-        Assert.assertEquals(expectedOffset, offset);
+        assertEquals(expectedOffset, offset);
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/util/FHIRUtilTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/FHIRUtilTest.java
@@ -5,22 +5,19 @@ import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
-public class FHIRUtilTest {
+class FHIRUtilTest {
 
     @Test
     void testGetErrorOutcome() {
         final String errText = "SOMETHING BROKE";
         final OperationOutcome oo = FHIRUtil.getErrorOutcome(errText);
         assertTrue(oo instanceof  OperationOutcome);
-        assertThat(oo.getResourceType(), is(ResourceType.OperationOutcome));
-        assertThat(oo.getIssue().size(), is(1));
-        assertThat(oo.getIssue().get(0).getDetails().getText(), is(errText));
+        assertEquals(ResourceType.OperationOutcome, oo.getResourceType());
+        assertEquals(1, oo.getIssue().size());
+        assertEquals(errText, oo.getIssue().get(0).getDetails().getText());
     }
 
     @Test
@@ -28,6 +25,6 @@ public class FHIRUtilTest {
         final String errText = "SOMETHING BROKE";
         final OperationOutcome oo = FHIRUtil.getErrorOutcome(errText);
         final String payload = FHIRUtil.outcomeToJSON(oo);
-        assertThat(payload, notNullValue());
+        assertNotNull(payload);
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2890](https://jira.cms.gov/browse/AB2D-2890) - Common Test Cleanup
 
### What Does This PR Do?

Creates a mechanism for registering and deleting domain model objects commonly added to the database for unit testing.

Many of these domain objects are placed into tables that cannot be wiped because they initially contain standard sets of information. So this mechanism only deletes objects created during tests.

The mechanism is added to the DataSetup class and requires all domain objects to be registered with the DataSetup class by each test class. Additionally, each test class must implement an AfterEach method that calls DataSetup.cleanup to complete deletion of those objects between tests.

### What Should Reviewers Watch For?

Any potential side effects that might cause issues in other modules like api and worker.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure