### PR TITLE
remove junit and change ordering of arguments to assertions

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -13,7 +13,6 @@ import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.eventlogger.events.*;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,8 +35,7 @@ import java.util.List;
 import static gov.cms.ab2d.api.controller.BulkDataAccessAPIIntegrationTests.PATIENT_EXPORT_PATH;
 import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -180,7 +178,7 @@ public class AdminAPIMaintenanceModeTests {
                         .header("Accept-Encoding", "gzip, deflate, br"))
                         .andExpect(status().is(200));
 
-        Assert.assertFalse(Files.exists(Paths.get(destinationStr + File.separator + testFile)));
+        assertFalse(Files.exists(Paths.get(destinationStr + File.separator + testFile)));
 
         // Cleanup
         propertiesDTOs.clear();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -8,7 +8,6 @@ import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -27,6 +26,8 @@ import java.util.Map;
 
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -90,18 +91,18 @@ public class AdminAPIPropertiesTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+        assertEquals(200, mvcResult.getResponse().getStatus());
 
         String result = mvcResult.getResponse().getContentAsString();
         ObjectMapper mapper = new ObjectMapper();
         List<PropertiesDTO> propertiesDTOs = mapper.readValue(result, new TypeReference<>() {} );
 
-        Assert.assertEquals(10, propertiesDTOs.size());
+        assertEquals(10, propertiesDTOs.size());
         for(PropertiesDTO propertiesDTO : propertiesDTOs) {
             Object value = propertyMap.get(propertiesDTO.getKey());
 
-            Assert.assertNotNull(value);
-            Assert.assertEquals(value.toString(), propertiesDTO.getValue());
+            assertNotNull(value);
+            assertEquals(value.toString(), propertiesDTO.getValue());
         }
     }
 
@@ -144,17 +145,17 @@ public class AdminAPIPropertiesTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(200, mvcResult.getResponse().getStatus());
+        assertEquals(200, mvcResult.getResponse().getStatus());
 
         String result = mvcResult.getResponse().getContentAsString();
         List<PropertiesDTO> propertiesDTOsRetrieved = mapper.readValue(result, new TypeReference<>() {} );
 
-        Assert.assertEquals(4, propertiesDTOsRetrieved.size());
+        assertEquals(4, propertiesDTOsRetrieved.size());
         for(PropertiesDTO propertiesDTO : propertiesDTOsRetrieved) {
             Object value = propertyMap.get(propertiesDTO.getKey());
 
-            Assert.assertNotNull(value);
-            Assert.assertEquals(value.toString(), propertiesDTO.getValue());
+            assertNotNull(value);
+            assertEquals(value.toString(), propertiesDTO.getValue());
         }
 
         // Cleanup

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
@@ -15,7 +15,6 @@ import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,6 +31,8 @@ import java.util.List;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -108,18 +109,18 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(201, mvcResult.getResponse().getStatus());
+        assertEquals(201, mvcResult.getResponse().getStatus());
 
         String result = mvcResult.getResponse().getContentAsString();
         UserDTO createdUserDTO = mapper.readValue(result, UserDTO.class);
-        Assert.assertEquals(createdUserDTO.getEmail(), userDTO.getEmail());
-        Assert.assertEquals(createdUserDTO.getUsername(), userDTO.getUsername());
-        Assert.assertEquals(createdUserDTO.getFirstName(), userDTO.getFirstName());
-        Assert.assertEquals(createdUserDTO.getLastName(), userDTO.getLastName());
-        Assert.assertEquals(createdUserDTO.getEnabled(), userDTO.getEnabled());
-        Assert.assertEquals(createdUserDTO.getContract().getContractNumber(), userDTO.getContract().getContractNumber());
-        Assert.assertEquals(createdUserDTO.getContract().getContractName(), userDTO.getContract().getContractName());
-        Assert.assertEquals(createdUserDTO.getRole(), userDTO.getRole());
+        assertEquals(createdUserDTO.getEmail(), userDTO.getEmail());
+        assertEquals(createdUserDTO.getUsername(), userDTO.getUsername());
+        assertEquals(createdUserDTO.getFirstName(), userDTO.getFirstName());
+        assertEquals(createdUserDTO.getLastName(), userDTO.getLastName());
+        assertEquals(createdUserDTO.getEnabled(), userDTO.getEnabled());
+        assertEquals(createdUserDTO.getContract().getContractNumber(), userDTO.getContract().getContractNumber());
+        assertEquals(createdUserDTO.getContract().getContractName(), userDTO.getContract().getContractName());
+        assertEquals(createdUserDTO.getRole(), userDTO.getRole());
     }
 
     @Test
@@ -142,18 +143,18 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(201, mvcResult.getResponse().getStatus());
+        assertEquals(201, mvcResult.getResponse().getStatus());
 
         String result = mvcResult.getResponse().getContentAsString();
         UserDTO createdUserDTO = mapper.readValue(result, UserDTO.class);
-        Assert.assertEquals(createdUserDTO.getEmail(), userDTO.getEmail());
-        Assert.assertEquals(createdUserDTO.getUsername(), userDTO.getUsername());
-        Assert.assertEquals(createdUserDTO.getFirstName(), userDTO.getFirstName());
-        Assert.assertEquals(createdUserDTO.getLastName(), userDTO.getLastName());
-        Assert.assertEquals(createdUserDTO.getEnabled(), userDTO.getEnabled());
-        Assert.assertEquals(createdUserDTO.getContract().getContractNumber(), userDTO.getContract().getContractNumber());
-        Assert.assertEquals(createdUserDTO.getContract().getContractName(), userDTO.getContract().getContractName());
-        Assert.assertEquals(createdUserDTO.getRole(), userDTO.getRole());
+        assertEquals(createdUserDTO.getEmail(), userDTO.getEmail());
+        assertEquals(createdUserDTO.getUsername(), userDTO.getUsername());
+        assertEquals(createdUserDTO.getFirstName(), userDTO.getFirstName());
+        assertEquals(createdUserDTO.getLastName(), userDTO.getLastName());
+        assertEquals(createdUserDTO.getEnabled(), userDTO.getEnabled());
+        assertEquals(createdUserDTO.getContract().getContractNumber(), userDTO.getContract().getContractNumber());
+        assertEquals(createdUserDTO.getContract().getContractName(), userDTO.getContract().getContractName());
+        assertEquals(createdUserDTO.getRole(), userDTO.getRole());
     }
 
     @Test
@@ -231,13 +232,13 @@ public class AdminAPIUserTests {
         String updateResult = updateMvcResult.getResponse().getContentAsString();
         UserDTO updatedUserDTO = mapper.readValue(updateResult, UserDTO.class);
 
-        Assert.assertEquals(updatedUserDTO.getEmail(), createdUserDTO.getEmail());
-        Assert.assertEquals(updatedUserDTO.getUsername(), createdUserDTO.getUsername());
-        Assert.assertEquals(updatedUserDTO.getFirstName(), createdUserDTO.getFirstName());
-        Assert.assertEquals(updatedUserDTO.getLastName(), createdUserDTO.getLastName());
-        Assert.assertEquals(updatedUserDTO.getEnabled(), createdUserDTO.getEnabled());
-        Assert.assertEquals(updatedUserDTO.getContract().getContractNumber(), createdUserDTO.getContract().getContractNumber());
-        Assert.assertEquals(updatedUserDTO.getRole(), createdUserDTO.getRole());
+        assertEquals(updatedUserDTO.getEmail(), createdUserDTO.getEmail());
+        assertEquals(updatedUserDTO.getUsername(), createdUserDTO.getUsername());
+        assertEquals(updatedUserDTO.getFirstName(), createdUserDTO.getFirstName());
+        assertEquals(updatedUserDTO.getLastName(), createdUserDTO.getLastName());
+        assertEquals(updatedUserDTO.getEnabled(), createdUserDTO.getEnabled());
+        assertEquals(updatedUserDTO.getContract().getContractNumber(), createdUserDTO.getContract().getContractNumber());
+        assertEquals(updatedUserDTO.getRole(), createdUserDTO.getRole());
     }
 
     @Test
@@ -283,7 +284,7 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 202);
+        assertEquals(mvcResult.getResponse().getStatus(), 202);
 
         String header = mvcResult.getResponse().getHeader("Content-Location");
 
@@ -291,7 +292,7 @@ public class AdminAPIUserTests {
         dataSetup.queueForCleanup(job);
         User jobUser = job.getUser();
         dataSetup.queueForCleanup(jobUser);
-        Assert.assertEquals(jobUser.getUsername(), userDTO.getUsername());
+        assertEquals(jobUser.getUsername(), userDTO.getUsername());
     }
 
     @Test
@@ -311,7 +312,7 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 202);
+        assertEquals(mvcResult.getResponse().getStatus(), 202);
 
         String header = mvcResult.getResponse().getHeader("Content-Location");
 
@@ -319,7 +320,7 @@ public class AdminAPIUserTests {
         User jobUser = job.getUser();
         dataSetup.queueForCleanup(jobUser);
         dataSetup.queueForCleanup(job);
-        Assert.assertEquals(jobUser.getUsername(), userDTO.getUsername());
+        assertEquals(jobUser.getUsername(), userDTO.getUsername());
     }
 
     @Test
@@ -333,14 +334,14 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(mvcResult.getResponse().getStatus(), 200);
 
         ObjectMapper mapper = new ObjectMapper();
 
         String updateResult = mvcResult.getResponse().getContentAsString();
         UserDTO updatedUserDTO = mapper.readValue(updateResult, UserDTO.class);
 
-        Assert.assertEquals(updatedUserDTO.getEnabled(), true);
+        assertEquals(updatedUserDTO.getEnabled(), true);
     }
 
     @Test
@@ -363,14 +364,14 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(mvcResult.getResponse().getStatus(), 200);
 
         ObjectMapper mapper = new ObjectMapper();
 
         String updateResult = mvcResult.getResponse().getContentAsString();
         UserDTO updatedUserDTO = mapper.readValue(updateResult, UserDTO.class);
 
-        Assert.assertEquals(updatedUserDTO.getEnabled(), false);
+        assertEquals(updatedUserDTO.getEnabled(), false);
     }
 
     @Test
@@ -393,22 +394,22 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(mvcResult.getResponse().getStatus(), 200);
 
         ObjectMapper mapper = new ObjectMapper();
 
         String getResult = mvcResult.getResponse().getContentAsString();
         UserDTO userDTO = mapper.readValue(getResult, UserDTO.class);
 
-        Assert.assertEquals(userDTO.getEmail(), TEST_USER);
-        Assert.assertEquals(userDTO.getUsername(), ENABLE_DISABLE_USER);
-        Assert.assertEquals(userDTO.getFirstName(), "test");
-        Assert.assertEquals(userDTO.getLastName(), "user");
-        Assert.assertEquals(userDTO.getEnabled(), true);
+        assertEquals(userDTO.getEmail(), TEST_USER);
+        assertEquals(userDTO.getUsername(), ENABLE_DISABLE_USER);
+        assertEquals(userDTO.getFirstName(), "test");
+        assertEquals(userDTO.getLastName(), "user");
+        assertEquals(userDTO.getEnabled(), true);
         ContractDTO contractDTO = userDTO.getContract();
-        Assert.assertEquals(contractDTO.getContractNumber(), "Z0000");
-        Assert.assertEquals("Test Contract Z0000", contractDTO.getContractName());
-        Assert.assertNotNull(contractDTO.getAttestedOn());
+        assertEquals(contractDTO.getContractNumber(), "Z0000");
+        assertEquals("Test Contract Z0000", contractDTO.getContractName());
+        assertNotNull(contractDTO.getAttestedOn());
     }
 
     @Test
@@ -419,7 +420,7 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        Assert.assertEquals(mvcResult.getResponse().getStatus(), 404);
+        assertEquals(mvcResult.getResponse().getStatus(), 404);
     }
 
     private void setupUser(boolean enabled) {

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -16,7 +16,6 @@ import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,10 +48,7 @@ import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
 import static gov.cms.ab2d.eventlogger.events.ErrorEvent.ErrorType.FILE_ALREADY_DELETED;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -119,7 +115,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testBasicPatientExport() throws Exception {
+    void testBasicPatientExport() throws Exception {
         ResultActions resultActions = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token));
@@ -156,17 +152,16 @@ public class BulkDataAccessAPIIntegrationTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH);
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH, job.getRequestUrl());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
-    public void testBasicPatientExportWithHttps() throws Exception {
+    void testBasicPatientExportWithHttps() throws Exception {
         ResultActions resultActions = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token)
@@ -180,13 +175,12 @@ public class BulkDataAccessAPIIntegrationTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "https://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH);
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("https://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH, job.getRequestUrl());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
@@ -260,7 +254,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportDuplicateSubmissionWithDifferentUser() throws Exception {
+    void testPatientExportDuplicateSubmissionWithDifferentUser() throws Exception {
         createMaxJobs();
 
         List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
@@ -286,7 +280,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithParameters() throws Exception {
+    void testPatientExportWithParameters() throws Exception {
         final String typeParams =
                 "?_type=ExplanationOfBenefit&_outputFormat=application/fhir+ndjson&since=20191015";
         ResultActions resultActions =
@@ -302,17 +296,16 @@ public class BulkDataAccessAPIIntegrationTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + typeParams);
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("http://localhost" + API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + typeParams, job.getRequestUrl());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
-    public void testPatientExportWithInvalidType() throws Exception {
+    void testPatientExportWithInvalidType() throws Exception {
         final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefit";
         this.mockMvc.perform(get(API_PREFIX +  FHIR_PREFIX + "/" + PATIENT_EXPORT_PATH + typeParams)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -344,7 +337,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithInvalidOutputFormat() throws Exception {
+    void testPatientExportWithInvalidOutputFormat() throws Exception {
         final String typeParams = "?_outputFormat=Invalid";
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/" + PATIENT_EXPORT_PATH + typeParams)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -376,7 +369,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithZipOutputFormat() throws Exception {
+    void testPatientExportWithZipOutputFormat() throws Exception {
         final String typeParams = "?_outputFormat=application/zip";
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/" + PATIENT_EXPORT_PATH + typeParams)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -390,7 +383,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testDeleteJob() throws Exception {
+    void testDeleteJob() throws Exception {
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -416,7 +409,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testDeleteNonExistentJob() throws Exception {
+    void testDeleteNonExistentJob() throws Exception {
         this.mockMvc.perform(delete(API_PREFIX + FHIR_PREFIX + "/Job/NonExistentJob/$status")
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().is(404))
@@ -444,11 +437,10 @@ public class BulkDataAccessAPIIntegrationTests {
                 loggerEventRepository.load(ErrorEvent.class),
                 loggerEventRepository.load(FileEvent.class),
                 loggerEventRepository.load(JobStatusChangeEvent.class)));
-
     }
 
     @Test
-    public void testDeleteJobsInInvalidState() throws Exception {
+    void testDeleteJobsInInvalidState() throws Exception {
         this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token)
@@ -496,12 +488,14 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWhileSubmitted() throws Exception {
+    void testGetStatusWhileSubmitted() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         this.mockMvc.perform(get(statusUrl).contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -524,7 +518,10 @@ public class BulkDataAccessAPIIntegrationTests {
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
+
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setProgress(30);
@@ -547,14 +544,16 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWhileFinishedHttps() throws Exception {
+    void testGetStatusWhileFinishedHttps() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .header("Authorization", "Bearer " + token)
                         .header("X-Forwarded-Proto", "https")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -606,13 +605,15 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWhileFinished() throws Exception {
+    void testGetStatusWhileFinished() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .header("Authorization", "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -683,12 +684,12 @@ public class BulkDataAccessAPIIntegrationTests {
         ApiRequestEvent requestEvent = (ApiRequestEvent) apiRequestEvents.get(0);
         ApiRequestEvent requestEvent2 = (ApiRequestEvent) apiRequestEvents.get(1);
         if (requestEvent.getUrl().contains("export")) {
-            assertEquals(null, requestEvent.getJobId());
+            assertNull(requestEvent.getJobId());
         } else {
             assertEquals(job.getJobUuid(), requestEvent.getJobId());
         }
         if (requestEvent2.getUrl().contains("export")) {
-            assertEquals(null, requestEvent2.getJobId());
+            assertNull(requestEvent2.getJobId());
         } else {
             assertEquals(job.getJobUuid(), requestEvent2.getJobId());
         }
@@ -719,13 +720,15 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWhileFailed() throws Exception {
+    void testGetStatusWhileFailed() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.FAILED);
@@ -757,7 +760,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWithJobNotFound() throws Exception {
+    void testGetStatusWithJobNotFound() throws Exception {
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -782,7 +785,7 @@ public class BulkDataAccessAPIIntegrationTests {
      }
 
     @Test
-    public void testGetStatusWithSpaceUrl() throws Exception {
+    void testGetStatusWithSpaceUrl() throws Exception {
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .header("Authorization", "Bearer " + token)
                 .contentType(MediaType.APPLICATION_JSON))
@@ -807,7 +810,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWithBadUrl() throws Exception {
+    void testGetStatusWithBadUrl() throws Exception {
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -828,13 +831,15 @@ public class BulkDataAccessAPIIntegrationTests {
 
 
     @Test
-    public void testDownloadFile() throws Exception {
+    void testDownloadFile() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         String testFile = "test.ndjson";
 
@@ -871,17 +876,19 @@ public class BulkDataAccessAPIIntegrationTests {
         String arrValue2 = JsonPath.read(downloadedFile, "$.array[1]");
         assertEquals("val2", arrValue2);
 
-        Assert.assertTrue(!Files.exists(Paths.get(destinationStr + File.separator + testFile)));
+        assertFalse(Files.exists(Paths.get(destinationStr + File.separator + testFile)));
     }
 
     @Test
-    public void testDownloadMissingFileGenericError() throws Exception {
+    void testDownloadMissingFileGenericError() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -928,13 +935,15 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testDownloadBadParameterFile() throws Exception {
+    void testDownloadBadParameterFile() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -966,13 +975,15 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testDownloadFileAlreadyDownloaded() throws Exception {
+    void testDownloadFileAlreadyDownloaded() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -1011,13 +1022,15 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testDownloadFileExpired() throws Exception {
+    void testDownloadFileExpired() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + PATIENT_EXPORT_PATH + "?_type=ExplanationOfBenefit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
+
         String statusUrl = mvcResult.getResponse().getHeader("Content-Location");
+        assertNotNull(statusUrl);
 
         Job job = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
         job.setStatus(JobStatus.SUCCESSFUL);
@@ -1048,7 +1061,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testBasicPatientExportWithContractWithHttps() throws Exception {
+    void testBasicPatientExportWithContractWithHttps() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         ResultActions resultActions = this.mockMvc.perform(
@@ -1060,21 +1073,21 @@ public class BulkDataAccessAPIIntegrationTests {
 
         String statusUrl =
                 "https://localhost" + API_PREFIX + FHIR_PREFIX + "/Job/" + job.getJobUuid() + "/$status";
+        assertNotNull(statusUrl);
 
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "https://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export");
-        assertEquals(job.getResourceTypes(), null);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("https://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export", job.getRequestUrl());
+        assertNull(job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
-    public void testBasicPatientExportWithContract() throws Exception {
+    void testBasicPatientExportWithContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         ResultActions resultActions = this.mockMvc.perform(
@@ -1089,17 +1102,17 @@ public class BulkDataAccessAPIIntegrationTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export");
-        assertEquals(job.getResourceTypes(), null);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export",
+                job.getRequestUrl());
+        assertNull(job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
-    public void testPatientExportWithParametersWithContract() throws Exception {
+    void testPatientExportWithParametersWithContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         final String typeParams =
@@ -1117,17 +1130,17 @@ public class BulkDataAccessAPIIntegrationTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        assertEquals(job.getStatus(), JobStatus.SUBMITTED);
-        assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        assertEquals(job.getProgress(), Integer.valueOf(0));
-        assertEquals(job.getRequestUrl(),
-                "http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams);
-        assertEquals(job.getResourceTypes(), EOB);
-        assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(JobStatus.SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams,
+                job.getRequestUrl());
+        assertEquals(EOB, job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
     }
 
     @Test
-    public void testPatientExportWithInvalidTypeWithContract() throws Exception {
+    void testPatientExportWithInvalidTypeWithContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         final String typeParams = "?_type=PatientInvalid,ExplanationOfBenefit";
@@ -1143,7 +1156,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithInvalidOutputFormatWithContract() throws Exception {
+    void testPatientExportWithInvalidOutputFormatWithContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         final String typeParams = "?_outputFormat=Invalid";
@@ -1169,7 +1182,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithContractDuplicateSubmission() throws Exception {
+    void testPatientExportWithContractDuplicateSubmission() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         createMaxJobsWithContract(contract);
@@ -1183,7 +1196,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithContractDuplicateSubmissionInProgress() throws Exception {
+    void testPatientExportWithContractDuplicateSubmissionInProgress() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         createMaxJobsWithContract(contract);
@@ -1203,7 +1216,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithContractDuplicateSubmissionCancelled() throws Exception {
+    void testPatientExportWithContractDuplicateSubmissionCancelled() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         createMaxJobsWithContract(contract);
@@ -1225,7 +1238,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithContractDuplicateSubmissionDifferentContract() throws Exception {
+    void testPatientExportWithContractDuplicateSubmissionDifferentContract() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
 
@@ -1237,7 +1250,9 @@ public class BulkDataAccessAPIIntegrationTests {
         }
 
         Contract contract1 = dataSetup.setupContract("Test1");
+
         User user = userRepository.findByUsername(TEST_USER);
+        assertNotNull(user);
         user.setContract(contract1);
         userRepository.saveAndFlush(user);
         Contract contractNew = dataSetup.setupContract("New Contract");
@@ -1249,7 +1264,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportWithContractDuplicateSubmissionDifferentUser() throws Exception {
+    void testPatientExportWithContractDuplicateSubmissionDifferentUser() throws Exception {
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         createMaxJobsWithContract(contract);
@@ -1276,7 +1291,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testCapabilityStatement() throws Exception {
+    void testCapabilityStatement() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + FHIR_PREFIX + "/metadata").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token)).andReturn();
@@ -1285,10 +1300,11 @@ public class BulkDataAccessAPIIntegrationTests {
 
         assertEquals(body, new JsonMapper()
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-                .writeValueAsString(new CapabilityStatement()));    }
+                .writeValueAsString(new CapabilityStatement()));
+    }
 
     @Test
-    public void tlsTest() throws Exception {
+    void tlsTest() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get("https://localhost:8443/" + API_PREFIX + FHIR_PREFIX + "/metadata").contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token)).andReturn();
@@ -1297,5 +1313,6 @@ public class BulkDataAccessAPIIntegrationTests {
 
         assertEquals(body, new JsonMapper()
                 .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-                .writeValueAsString(new CapabilityStatement()));    }
+                .writeValueAsString(new CapabilityStatement()));
+    }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -10,7 +10,6 @@ import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.eventlogger.events.*;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,8 +29,7 @@ import static gov.cms.ab2d.common.model.JobStatus.SUBMITTED;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.*;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -73,7 +71,7 @@ public class BulkDataAccessAPIUnusualDataTests {
     }
 
     @Test
-    public void testPatientExportWithNoAttestation() throws Exception {
+    void testPatientExportWithNoAttestation() throws Exception {
         // Valid contract number for sponsor, but no attestation
         String token = testUtil.setupContractWithNoAttestation(List.of(SPONSOR_ROLE));
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
@@ -91,8 +89,8 @@ public class BulkDataAccessAPIUnusualDataTests {
 
         List<LoggableEvent> errorEvents = loggerEventRepository.load(ErrorEvent.class);
         ErrorEvent errorEvent = (ErrorEvent) errorEvents.get(0);
-        assertEquals(errorEvent.getErrorType(), ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT);
 
+        assertEquals(ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT, errorEvent.getErrorType());
         assertTrue(UtilMethods.allEmpty(
                 loggerEventRepository.load(ReloadEvent.class),
                 loggerEventRepository.load(ContractBeneSearchEvent.class),
@@ -118,13 +116,13 @@ public class BulkDataAccessAPIUnusualDataTests {
         resultActions.andExpect(status().isAccepted())
                 .andExpect(header().string("Content-Location", statusUrl));
 
-        Assert.assertEquals(job.getStatus(), SUBMITTED);
-        Assert.assertEquals(job.getStatusMessage(), INITIAL_JOB_STATUS_MESSAGE);
-        Assert.assertEquals(job.getProgress(), Integer.valueOf(0));
-        Assert.assertEquals(job.getRequestUrl(),
-                "http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export");
-        Assert.assertNull(job.getResourceTypes());
-        Assert.assertEquals(job.getUser(), userRepository.findByUsername(TEST_USER));
+        assertEquals(SUBMITTED, job.getStatus());
+        assertEquals(INITIAL_JOB_STATUS_MESSAGE, job.getStatusMessage());
+        assertEquals(Integer.valueOf(0), job.getProgress());
+        assertEquals("http://localhost" + API_PREFIX + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export",
+                job.getRequestUrl());
+        assertNull(job.getResourceTypes());
+        assertEquals(userRepository.findByUsername(TEST_USER), job.getUser());
 
     }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_USER;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,6 +68,7 @@ public class InvalidTokenTest {
     @Test
     public void testInvalidToken() throws Exception {
         User user = userRepository.findByUsername(TEST_USER);
+        assertNotNull(user);
         user.setEnabled(false);
         userRepository.save(user);
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TestUtil.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TestUtil.java
@@ -81,14 +81,6 @@ public class TestUtil {
         return buildTokenStr();
     }
 
-    public String setupBadSponsorUserData(List<String> userRoles) throws JwtVerificationException {
-        dataSetup.setupUserBadSponsorData(userRoles);
-
-        setupMock();
-
-        return buildTokenStr();
-    }
-
     public String setupContractWithNoAttestation(List<String> userRoles) throws JwtVerificationException {
         dataSetup.setupContractWithNoAttestation(userRoles);
 
@@ -118,7 +110,7 @@ public class TestUtil {
         String destinationStr = destination.toString();
         Files.createDirectories(destination);
         InputStream testFileStream = this.getClass().getResourceAsStream("/" + testFile);
-        String testFileStr = IOUtils.toString(testFileStream, "UTF-8");
+        String testFileStr = IOUtils.toString(testFileStream, StandardCharsets.UTF_8);
         try (PrintWriter out = new PrintWriter(destinationStr + File.separator + testFile)) {
             out.println(testFileStr);
         }

--- a/bfd/src/test/java/gov/cms/ab2d/bfd/client/BFDClientConfigurationTest.java
+++ b/bfd/src/test/java/gov/cms/ab2d/bfd/client/BFDClientConfigurationTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.bfd.client;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.KeyStore;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = SpringBootApp.class, properties = "bfd.keystore.location=/tmp/bb.keystore")
@@ -35,6 +36,6 @@ public class BFDClientConfigurationTest {
     // Ensure that the keystore is loaded properly when we set the property for it to be a file on the filesystem
     @Test
     public void keystoreFile() {
-        Assert.assertNotNull(keyStore);
+        assertNotNull(keyStore);
     }
 }

--- a/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
+++ b/bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientTest.java
@@ -40,18 +40,15 @@ import java.util.MissingResourceException;
 import java.util.concurrent.TimeUnit;
 
 import static gov.cms.ab2d.bfd.client.BFDMockServerConfigurationUtil.MOCK_SERVER_PORT;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-
+/**
+ * Credits: most of the code in this class has been adopted from https://github.com/CMSgov/dpc-app
+ */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = SpringBootApp.class)
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = {BFDMockServerConfigurationUtil.PropertyOverrider.class}, classes = { BlueButtonClientTest.TestConfig.class })
-/**
- * Credits: most of the code in this class has been adopted from https://github.com/CMSgov/dpc-app
- */
 public class BlueButtonClientTest {
     // A random example patient (Jane Doe)
     private static final String TEST_PATIENT_ID = "20140000008325";
@@ -210,7 +207,7 @@ public class BlueButtonClientTest {
 
         var rootCause = ExceptionUtils.getRootCause(exception);
         assertTrue(rootCause instanceof SocketTimeoutException);
-        assertThat(rootCause.getMessage(), equalTo("Read timed out"));
+        assertEquals("Read timed out", rootCause.getMessage());
 
     }
 
@@ -287,7 +284,7 @@ public class BlueButtonClientTest {
     public void testPersonIdsHICN() {
         org.hl7.fhir.dstu3.model.Bundle response = bbc.requestPatientByHICN("11111");
         assertNotNull(response);
-        assertEquals(response.getEntry().size(), 3);
+        assertEquals(3, response.getEntry().size());
         org.hl7.fhir.dstu3.model.Patient p1 = (org.hl7.fhir.dstu3.model.Patient) response.getEntry().get(0).getResource();
         org.hl7.fhir.dstu3.model.Patient p2 = (org.hl7.fhir.dstu3.model.Patient) response.getEntry().get(0).getResource();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
@@ -301,7 +298,7 @@ public class BlueButtonClientTest {
     public void testPersonIdsMBI() {
         org.hl7.fhir.dstu3.model.Bundle response = bbc.requestPatientByMBI("11111");
         assertNotNull(response);
-        assertEquals(response.getEntry().size(), 3);
+        assertEquals(3, response.getEntry().size());
         org.hl7.fhir.dstu3.model.Patient p1 = (org.hl7.fhir.dstu3.model.Patient) response.getEntry().get(0).getResource();
         org.hl7.fhir.dstu3.model.Patient p2 = (org.hl7.fhir.dstu3.model.Patient) response.getEntry().get(0).getResource();
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
@@ -342,8 +339,8 @@ public class BlueButtonClientTest {
         org.hl7.fhir.dstu3.model.CapabilityStatement capabilityStatement = bbc.capabilityStatement();
 
         assertNotNull(capabilityStatement, "There should be a non null capability statement");
-        assertEquals(capabilityStatement.getFhirVersion(), "3.0.1");
-        assertEquals(capabilityStatement.getStatus(), org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE);
+        assertEquals("3.0.1", capabilityStatement.getFhirVersion());
+        assertEquals(org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus.ACTIVE, capabilityStatement.getStatus());
     }
 
     /**

--- a/common/src/test/java/gov/cms/ab2d/common/model/CoverageSearchTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CoverageSearchTest.java
@@ -28,23 +28,10 @@ class CoverageSearchTest {
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @Autowired
-    private ContractRepository contractRepo;
-
-    @Autowired
     private CoverageSearchRepository coverageSearchRepository;
 
     @Autowired
-    private CoverageSearchEventRepository coverageSearchEventRepo;
-
-    @Autowired
-    private CoveragePeriodRepository coveragePeriodRepo;
-
-    @Autowired
     private DataSetup dataSetup;
-
-    private Contract contract1;
-    private Contract contract2;
-
 
     @AfterEach
     void cleanup() {
@@ -55,8 +42,8 @@ class CoverageSearchTest {
     void testSearches() {
         try {
 
-            contract1 = dataSetup.setupContract("c123");
-            contract2 = dataSetup.setupContract("c456");
+            Contract contract1 = dataSetup.setupContract("c123");
+            Contract contract2 = dataSetup.setupContract("c456");
 
             CoveragePeriod period1 = dataSetup.createCoveragePeriod(contract1, 10, 2020);
             CoveragePeriod period2 = dataSetup.createCoveragePeriod(contract2, 10, 2020);

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -9,11 +9,9 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.util.Sets;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
@@ -53,7 +51,6 @@ import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 import static gov.cms.ab2d.e2etest.APIClient.PATIENT_EXPORT_PATH;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.*;
 
 // Unit tests here can be run from the IDE and will use LOCAL as the default, they can also be run from the TestLauncher
@@ -62,10 +59,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(TestRunnerParameterResolver.class)
 @Slf4j
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class TestRunner {
+class TestRunner {
 
-    private Logger apiLogger = LoggerFactory.getLogger("gov.cms.ab2d.api");
-    private Logger workerLogger = LoggerFactory.getLogger("gov.cms.ab2d.worker");
+    private static final Logger apiLogger = LoggerFactory.getLogger("gov.cms.ab2d.api");
+    private static final Logger workerLogger = LoggerFactory.getLogger("gov.cms.ab2d.worker");
 
     public static final String MBI_ID = "http://hl7.org/fhir/sid/us-mbi";
 
@@ -91,9 +88,9 @@ public class TestRunner {
 
     private Map<String, String> yamlMap;
 
-    private Environment environment;
+    private final Environment environment;
 
-    private OffsetDateTime earliest = OffsetDateTime.parse(SINCE_EARLIEST_DATE, ISO_DATE_TIME);
+    private static final OffsetDateTime earliest = OffsetDateTime.parse(SINCE_EARLIEST_DATE, ISO_DATE_TIME);
 
     private final Set<String> acceptableIdStrings = Set.of("carrier", "dme", "hha", "hospice", "inpatient", "outpatient", "snf");
 
@@ -244,7 +241,7 @@ public class TestRunner {
         HttpResponse<String> statusResponse = null;
         long start = System.currentTimeMillis();
         int status = 0;
-        Set<Integer> statusesBetween0And100 = Sets.newHashSet();
+        Set<Integer> statusesBetween0And100 = new HashSet<>();
         while(status != 200 && status != 500) {
             Thread.sleep(DELAY * 1000 + 2000);
 
@@ -271,10 +268,10 @@ public class TestRunner {
             }
         }
 
-        if(statusesBetween0And100.size() < 2) {
+//        if (statusesBetween0And100.size() < 2) {
             // Currently failing, add back when jobs take longer
             //Assert.fail("Did not receive more than 1 distinct progress values between 0 and 100");
-        }
+//        }
 
         if (status == 200 || status == 500) {
             return statusResponse;
@@ -287,25 +284,25 @@ public class TestRunner {
     private Pair<String, JSONArray> verifyJsonFromStatusResponse(HttpResponse<String> statusResponse, String jobUuid, String contractNumber) throws JSONException {
         final JSONObject json = new JSONObject(statusResponse.body());
         Boolean requiresAccessToken = json.getBoolean("requiresAccessToken");
-        Assert.assertEquals(true, requiresAccessToken);
+        assertEquals(true, requiresAccessToken);
         String request = json.getString("request");
         String stem = AB2D_API_URL + (contractNumber == null ? "Patient/" : "Group/" + contractNumber + "/") + "$export?_outputFormat=";
-        Assert.assertTrue(request.startsWith(stem));
+        assertTrue(request.startsWith(stem));
         JSONArray errors = json.getJSONArray("error");
 
         if(errors.length() > 0) {
             System.out.println(errors);
         }
 
-        Assert.assertEquals(0, errors.length());
+        assertEquals(0, errors.length());
 
         JSONArray output = json.getJSONArray("output");
         JSONObject outputObject = output.getJSONObject(0);
         String url = outputObject.getString("url");
         String filestem = AB2D_API_URL + "Job/" + jobUuid + "/file/" + testContract + "_0001.";
-        Assert.assertTrue(url.equals(filestem + "ndjson") || (url.equals(filestem + "zip")));
+        assertTrue(url.equals(filestem + "ndjson") || (url.equals(filestem + "zip")));
         String type = outputObject.getString("type");
-        Assert.assertEquals(type, "ExplanationOfBenefit");
+        assertEquals("ExplanationOfBenefit", type);
 
         JSONArray extension = outputObject.getJSONArray("extension");
 
@@ -323,9 +320,9 @@ public class TestRunner {
 
             JSONObject jsonObject = new JSONObject(str);
 
-            Assert.assertTrue(validFields(jsonObject));
-            Assert.assertEquals("ExplanationOfBenefit", jsonObject.getString("resourceType"));
-            Assert.assertEquals(0, jsonObject.getInt("precedence"));
+            assertTrue(validFields(jsonObject));
+            assertEquals("ExplanationOfBenefit", jsonObject.getString("resourceType"));
+            assertEquals(0, jsonObject.getInt("precedence"));
             String idString = jsonObject.getString("id");
 
             boolean found = false;
@@ -337,7 +334,7 @@ public class TestRunner {
             }
 
             if (!found) {
-                Assert.fail("No acceptable ID string was found, received " + idString);
+                fail("No acceptable ID string was found, received " + idString);
             }
 
             // Check that beneficiary id is included and follows expected format
@@ -362,43 +359,43 @@ public class TestRunner {
     private void checkDownloadExtensions(String fileContent, JSONArray extension) throws JSONException {
         JSONObject checkSumObject = extension.getJSONObject(0);
         String checkSumUrl = checkSumObject.getString("url");
-        Assert.assertEquals("https://ab2d.cms.gov/checksum", checkSumUrl);
+        assertEquals("https://ab2d.cms.gov/checksum", checkSumUrl);
         String checkSum = checkSumObject.getString("valueString");
         byte[] sha256ByteArr = DigestUtils.sha256(fileContent);
         String sha256Str = Hex.encodeHexString(sha256ByteArr);
-        Assert.assertEquals("sha256:" + sha256Str, checkSum);
-        Assert.assertEquals(checkSum.length(), 71);
+        assertEquals("sha256:" + sha256Str, checkSum);
+        assertEquals(71, checkSum.length());
 
         JSONObject lengthObject = extension.getJSONObject(1);
         String lengthUrl = lengthObject.getString("url");
 
-        Assert.assertEquals("https://ab2d.cms.gov/file_length", lengthUrl);
+        assertEquals("https://ab2d.cms.gov/file_length", lengthUrl);
         long length = lengthObject.getLong("valueDecimal");
-        Assert.assertEquals(length, fileContent.getBytes().length);
+        assertEquals(length, fileContent.getBytes().length);
     }
 
     private void checkStandardEOBFields(JSONObject jsonObject) throws JSONException {
         final JSONObject typeJson = jsonObject.getJSONObject("type");
-        Assert.assertNotNull(typeJson);
+        assertNotNull(typeJson);
         final JSONArray codingJson = typeJson.getJSONArray("coding");
-        Assert.assertNotNull(codingJson);
-        Assert.assertTrue(codingJson.length() >= 3);
+        assertNotNull(codingJson);
+        assertTrue(codingJson.length() >= 3);
         final JSONArray identifierJson = jsonObject.getJSONArray("identifier");
-        Assert.assertNotNull(identifierJson);
-        Assert.assertEquals(2, identifierJson.length());
+        assertNotNull(identifierJson);
+        assertEquals(2, identifierJson.length());
         final JSONArray diagnosisJson = jsonObject.getJSONArray("diagnosis");
-        Assert.assertNotNull(diagnosisJson);
+        assertNotNull(diagnosisJson);
         final JSONArray itemJson = jsonObject.getJSONArray("item");
-        Assert.assertNotNull(itemJson);
+        assertNotNull(itemJson);
     }
 
     private void checkBeneficiaryId(JSONObject jsonObject) throws JSONException {
         final JSONObject patientJson = jsonObject.getJSONObject("patient");
         String referenceString = patientJson.getString("reference");
-        Assert.assertTrue(StringUtils.isNotBlank(referenceString));
-        Assert.assertTrue(referenceString.startsWith("Patient"));
+        assertTrue(StringUtils.isNotBlank(referenceString));
+        assertTrue(referenceString.startsWith("Patient"));
         String patientId = referenceString.substring(referenceString.indexOf('-') + 1);
-        Assert.assertTrue(StringUtils.isNotBlank(patientId));
+        assertTrue(StringUtils.isNotBlank(patientId));
     }
 
     private void checkMetadata(OffsetDateTime since, JSONObject jsonObject) throws JSONException {
@@ -406,32 +403,32 @@ public class TestRunner {
         final String lastUpdated = metaJson.getString("lastUpdated");
         Instant lastUpdatedInstant = Instant.parse(lastUpdated);
         if (since != null) {
-            Assert.assertTrue(lastUpdatedInstant.isAfter(since.toInstant()));
+            assertTrue(lastUpdatedInstant.isAfter(since.toInstant()));
         }
     }
 
     private void checkEOBExtensions(JSONObject jsonObject) throws JSONException {
 
         final JSONArray extensions = jsonObject.getJSONArray("extension");
-        Assert.assertNotNull(extensions);
-        Assert.assertEquals(1, extensions.length());
+        assertNotNull(extensions);
+        assertEquals(1, extensions.length());
 
         // Assume first extension is MBI object
         JSONObject idObj = extensions.getJSONObject(0);
-        Assert.assertNotNull(idObj);
+        assertNotNull(idObj);
 
         // Unwrap identifier
         JSONObject valueIdentifier = idObj.getJSONObject("valueIdentifier");
-        Assert.assertNotNull(valueIdentifier);
+        assertNotNull(valueIdentifier);
 
         // Test that we gave correct label to identifier
         String system = valueIdentifier.getString("system");
-        Assert.assertFalse(StringUtils.isBlank(system));
-        Assert.assertEquals(MBI_ID, system);
+        assertFalse(StringUtils.isBlank(system));
+        assertEquals(MBI_ID, system);
 
         // Check that mbi is present and not empty
         String mbi = valueIdentifier.getString("value");
-        Assert.assertFalse(StringUtils.isBlank(mbi));
+        assertFalse(StringUtils.isBlank(mbi));
 
         JSONArray extensionsArray = valueIdentifier.getJSONArray("extension");
         assertEquals(1, extensionsArray.length());
@@ -481,9 +478,9 @@ public class TestRunner {
     private void downloadFile(Pair<String, JSONArray> downloadDetails, OffsetDateTime since) throws IOException, InterruptedException, JSONException {
         HttpResponse<InputStream> downloadResponse = apiClient.fileDownloadRequest(downloadDetails.getFirst());
 
-        Assert.assertEquals(200, downloadResponse.statusCode());
+        assertEquals(200, downloadResponse.statusCode());
         String contentEncoding = downloadResponse.headers().map().get("content-encoding").iterator().next();
-        Assert.assertEquals("gzip", contentEncoding);
+        assertEquals("gzip", contentEncoding);
 
         String downloadString;
         try(GZIPInputStream gzipInputStream = new GZIPInputStream(downloadResponse.body())) {
@@ -520,17 +517,17 @@ public class TestRunner {
                                                          String contractNumber) throws JSONException, IOException, InterruptedException {
         HttpResponse<String> statusResponse = apiClient.statusRequest(contentLocationList.iterator().next());
 
-        Assert.assertEquals(202, statusResponse.statusCode());
+        assertEquals(202, statusResponse.statusCode());
         List<String> retryAfterList = statusResponse.headers().map().get("retry-after");
-        Assert.assertEquals(retryAfterList.iterator().next(), String.valueOf(DELAY));
+        assertEquals(retryAfterList.iterator().next(), String.valueOf(DELAY));
         List<String> xProgressList = statusResponse.headers().map().get("x-progress");
-        Assert.assertThat(xProgressList.iterator().next(), matchesPattern("\\d+\\% complete"));
+        assertTrue(xProgressList.iterator().next().matches("\\d+\\% complete"));
 
         HttpResponse<String> retryStatusResponse = apiClient.statusRequest(contentLocationList.iterator().next());
 
-        Assert.assertEquals(429, retryStatusResponse.statusCode());
+        assertEquals(429, retryStatusResponse.statusCode());
         List<String> retryAfterListRepeat = retryStatusResponse.headers().map().get("retry-after");
-        Assert.assertEquals(retryAfterListRepeat.iterator().next(), String.valueOf(DELAY));
+        assertEquals(retryAfterListRepeat.iterator().next(), String.valueOf(DELAY));
 
         HttpResponse<String> statusResponseAgain = pollForStatusResponse(contentLocationList.iterator().next());
 
@@ -540,71 +537,72 @@ public class TestRunner {
             // No values returned if 500
             return null;
         }
-        Assert.assertEquals(200, statusResponseAgain.statusCode());
+        assertEquals(200, statusResponseAgain.statusCode());
 
         return verifyJsonFromStatusResponse(statusResponseAgain, jobUuid, isContract ? contractNumber : null);
     }
 
     @Test
     @Order(1)
-    public void runSystemWideExport() throws IOException, InterruptedException, JSONException {
+    void runSystemWideExport() throws IOException, InterruptedException, JSONException {
         System.out.println("Starting test 1");
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null);
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         Pair<String, JSONArray> downloadDetails = performStatusRequests(contentLocationList, false, testContract);
+        assertNotNull(downloadDetails);
         downloadFile(downloadDetails, null);
     }
 
     @Test
     @Order(2)
-    public void runSystemWideExportSince() throws IOException, InterruptedException, JSONException {
+    void runSystemWideExportSince() throws IOException, InterruptedException, JSONException {
         System.out.println("Starting test 2");
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, earliest);
         log.info("run system wide export since {}", exportResponse);
         System.out.println(earliest);
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         Pair<String, JSONArray> downloadDetails = performStatusRequests(contentLocationList, false, testContract);
-        if (downloadDetails != null) {
-            downloadFile(downloadDetails, earliest);
-        }
+        assertNotNull(downloadDetails);
+        downloadFile(downloadDetails, earliest);
     }
 
     @Test
     @Order(3)
-    public void runErrorSince() throws IOException, InterruptedException {
+    void runErrorSince() throws IOException, InterruptedException {
         System.out.println("Starting test 3");
         OffsetDateTime timeBeforeEarliest = earliest.minus(1, ChronoUnit.MINUTES);
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, timeBeforeEarliest);
-        Assert.assertEquals(400, exportResponse.statusCode());
+        assertEquals(400, exportResponse.statusCode());
 
         OffsetDateTime timeAfterNow = OffsetDateTime.now().plus(1, ChronoUnit.MINUTES);
         HttpResponse<String> exportResponse2 = apiClient.exportRequest(FHIR_TYPE, timeBeforeEarliest);
-        Assert.assertEquals(400, exportResponse2.statusCode());
+        assertEquals(400, exportResponse2.statusCode());
     }
 
     @Test
     @Order(4)
-    public void runSystemWideZipExport() throws IOException, InterruptedException, JSONException {
+    void runSystemWideZipExport() throws IOException, InterruptedException, JSONException {
         System.out.println("Starting test 4");
         HttpResponse<String> exportResponse = apiClient.exportRequest(ZIPFORMAT, null);
         log.info("run system wide zip export {}", exportResponse);
-        Assert.assertEquals(400, exportResponse.statusCode());
+        assertEquals(400, exportResponse.statusCode());
     }
 
     @Test
     @Order(5)
-    public void runContractNumberExport() throws IOException, InterruptedException, JSONException {
+    void runContractNumberExport() throws IOException, InterruptedException, JSONException {
         System.out.println("Starting test 5");
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(testContract, FHIR_TYPE, null);
         log.info("run contract number export {}", exportResponse);
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         Pair<String, JSONArray> downloadDetails = performStatusRequests(contentLocationList, true, testContract);
+        assertNotNull(downloadDetails);
         downloadFile(downloadDetails, null);
     }
 
@@ -614,30 +612,30 @@ public class TestRunner {
         System.out.println("Starting test 6");
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(testContract, ZIPFORMAT, null);
         log.info("run contract number zip export {}", exportResponse);
-        Assert.assertEquals(400, exportResponse.statusCode());
+        assertEquals(400, exportResponse.statusCode());
     }
 
     @Test
     @Order(7)
-    public void testDelete() throws IOException, InterruptedException {
+    void testDelete() throws IOException, InterruptedException {
         System.out.println("Starting test 7");
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null);
 
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         String jobUUid = JobUtil.getJobUuid(contentLocationList.iterator().next());
 
         HttpResponse<String> deleteResponse = apiClient.cancelJobRequest(jobUUid);
-        Assert.assertEquals(202, deleteResponse.statusCode());
+        assertEquals(202, deleteResponse.statusCode());
     }
 
     @Test
     @Order(8)
-    public void testUserCannotDownloadOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+    void testUserCannotDownloadOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
         System.out.println("Starting test 8");
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(testContract, FHIR_TYPE, null);
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         Pair<String, JSONArray> downloadDetails = performStatusRequests(contentLocationList, true, testContract);
@@ -645,16 +643,16 @@ public class TestRunner {
         APIClient secondUserAPIClient = createSecondUserClient();
 
         HttpResponse<InputStream> downloadResponse = secondUserAPIClient.fileDownloadRequest(downloadDetails.getFirst());
-        Assert.assertEquals(downloadResponse.statusCode(), 403);
+        assertEquals(403, downloadResponse.statusCode());
     }
 
     @Test
     @Order(9)
-    public void testUserCannotDeleteOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+    void testUserCannotDeleteOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
         System.out.println("Starting test 9");
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null);
 
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         String jobUUid = JobUtil.getJobUuid(contentLocationList.iterator().next());
@@ -662,31 +660,31 @@ public class TestRunner {
         APIClient secondUserAPIClient = createSecondUserClient();
 
         HttpResponse<String> deleteResponse = secondUserAPIClient.cancelJobRequest(jobUUid);
-        Assert.assertEquals(deleteResponse.statusCode(), 403);
+        assertEquals(403, deleteResponse.statusCode());
 
         // Cleanup
         HttpResponse<String> secondDeleteResponse = apiClient.cancelJobRequest(jobUUid);
-        Assert.assertEquals(202, secondDeleteResponse.statusCode());
+        assertEquals(202, secondDeleteResponse.statusCode());
     }
 
     @Test
     @Order(10)
-    public void testUserCannotCheckStatusOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+    void testUserCannotCheckStatusOtherUsersJob() throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
         System.out.println("Starting test 10");
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null);
 
-        Assert.assertEquals(202, exportResponse.statusCode());
+        assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
         APIClient secondUserAPIClient = createSecondUserClient();
 
         HttpResponse<String> statusResponse = secondUserAPIClient.statusRequest(contentLocationList.iterator().next());
-        Assert.assertEquals(statusResponse.statusCode(), 403);
+        assertEquals(403, statusResponse.statusCode());
 
         // Cleanup
         String jobUUid = JobUtil.getJobUuid(contentLocationList.iterator().next());
         HttpResponse<String> secondDeleteResponse = apiClient.cancelJobRequest(jobUUid);
-        Assert.assertEquals(202, secondDeleteResponse.statusCode());
+        assertEquals(202, secondDeleteResponse.statusCode());
     }
 
     private APIClient createSecondUserClient() throws InterruptedException, JSONException, IOException, KeyManagementException, NoSuchAlgorithmException {
@@ -700,7 +698,7 @@ public class TestRunner {
 
     @Test
     @Order(11)
-    public void testUserCannotMakeRequestWithoutToken() throws IOException, InterruptedException {
+    void testUserCannotMakeRequestWithoutToken() throws IOException, InterruptedException {
         System.out.println("Starting test 11");
         HttpRequest exportRequest = HttpRequest.newBuilder()
                 .uri(URI.create(AB2D_API_URL + PATIENT_EXPORT_PATH))
@@ -711,12 +709,12 @@ public class TestRunner {
 
         HttpResponse<String> response = apiClient.getHttpClient().send(exportRequest, HttpResponse.BodyHandlers.ofString());
 
-        Assert.assertEquals(401, response.statusCode());
+        assertEquals(401, response.statusCode());
     }
 
     @Test
     @Order(12)
-    public void testUserCannotMakeRequestWithSelfSignedToken() throws IOException, InterruptedException, JSONException {
+    void testUserCannotMakeRequestWithSelfSignedToken() throws IOException, InterruptedException, JSONException {
         System.out.println("Starting test 12");
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
@@ -748,13 +746,13 @@ public class TestRunner {
 
         HttpResponse<String> response = apiClient.getHttpClient().send(exportRequest, HttpResponse.BodyHandlers.ofString());
 
-        Assert.assertEquals(403, response.statusCode());
+        assertEquals(403, response.statusCode());
     }
 
     @Test
     @Order(13)
-    public void testUserCannotMakeRequestWithNullClaims() throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 12");
+    void testUserCannotMakeRequestWithNullClaims() throws IOException, InterruptedException, JSONException {
+        System.out.println("Starting test 13");
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
         Instant now = Instant.now();
@@ -778,26 +776,26 @@ public class TestRunner {
 
         HttpResponse<String> response = apiClient.getHttpClient().send(exportRequest, HttpResponse.BodyHandlers.ofString());
 
-        Assert.assertEquals(403, response.statusCode());
+        assertEquals(403, response.statusCode());
     }
 
     @Test
     @Order(14)
-    public void testBadQueryParameterResource() throws IOException, InterruptedException {
-        System.out.println("Starting test 13");
+    void testBadQueryParameterResource() throws IOException, InterruptedException {
+        System.out.println("Starting test 14");
         var params = new HashMap<>(){{
             put("_type", "BadParam");
         }};
         HttpResponse<String> exportResponse = apiClient.exportRequest(params);
 
         log.info("bad query parameter resource {}", exportResponse);
-        Assert.assertEquals(400, exportResponse.statusCode());
+        assertEquals(400, exportResponse.statusCode());
     }
 
     @Test
     @Order(15)
-    public void testBadQueryParameterOutputFormat() throws IOException, InterruptedException {
-        System.out.println("Starting test 14");
+    void testBadQueryParameterOutputFormat() throws IOException, InterruptedException {
+        System.out.println("Starting test 15");
         var params = new HashMap<>(){{
             put("_outputFormat", "BadParam");
         }};
@@ -805,15 +803,15 @@ public class TestRunner {
 
         log.info("bad query output format {}", exportResponse);
 
-        Assert.assertEquals(400, exportResponse.statusCode());
+        assertEquals(400, exportResponse.statusCode());
     }
 
     @Test
     @Order(16)
-    public void testHealthEndPoint() throws IOException, InterruptedException {
-        System.out.println("Starting test 15");
+    void testHealthEndPoint() throws IOException, InterruptedException {
+        System.out.println("Starting test 16");
         HttpResponse<String> healthCheckResponse = apiClient.healthCheck();
 
-        Assert.assertEquals(200, healthCheckResponse.statusCode());
+        assertEquals(200, healthCheckResponse.statusCode());
     }
 }

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -268,11 +268,6 @@ class TestRunner {
             }
         }
 
-//        if (statusesBetween0And100.size() < 2) {
-            // Currently failing, add back when jobs take longer
-            //Assert.fail("Did not receive more than 1 distinct progress values between 0 and 100");
-//        }
-
         if (status == 200 || status == 500) {
             return statusResponse;
         } else {

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/utils/UtilMethods.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/utils/UtilMethods.java
@@ -49,8 +49,8 @@ public final class UtilMethods {
         return Hex.encodeHexString(DigestUtils.sha256(stream));
     }
 
-    public static <T> boolean allEmpty(List<T>...events) {
-        for (List<T> e : events) {
+    public static boolean allEmpty(List<?>... events) {
+        for (List<?> e : events) {
             if (e != null && !e.isEmpty()) {
                 return false;
             }

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
@@ -6,8 +6,6 @@ import gov.cms.ab2d.eventlogger.events.ErrorEvent;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -41,12 +39,10 @@ class LogManagerTest {
         logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
         ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
                 "File Deleted");
-        doAnswer(new Answer() {
-            public Object answer(InvocationOnMock invocation) {
-                Object[] args = invocation.getArguments();
-                ((ErrorEvent)args[0]).setAwsId("aws1111");
-                return null; // void method, so return null
-            }
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
         }).when(kinesisEventLogger).log(event, true);
 
         logManager.log(event);
@@ -85,12 +81,10 @@ class LogManagerTest {
         ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
                 "File Deleted");
         logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
-        doAnswer(new Answer() {
-            public Object answer(InvocationOnMock invocation) {
-                Object[] args = invocation.getArguments();
-                ((ErrorEvent)args[0]).setAwsId("aws1111");
-                return null; // void method, so return null
-            }
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
         }).when(kinesisEventLogger).log(event);
         logManager.log(LogManager.LogType.KINESIS, event);
         assertEquals("aws1111", event.getAwsId());

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
@@ -87,7 +87,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
 
         ApiRequestEvent event = (ApiRequestEvent) events.get(0);
-        assertEquals(event.getAwsId(), "ABC");
+        assertEquals("ABC", event.getAwsId());
 
         jsce.setId(event.getId());
         assertEquals(event, jsce);
@@ -133,7 +133,7 @@ public class AllMapperEventTest {
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getUser());
         assertEquals("job123", event.getJobId());
-        assertTrue(jsce.equals(event));
+        assertEquals(event, jsce);
         assertEquals("Description", event.getDescription());
         assertEquals("Not Found", event.getResponseString());
         assertEquals(404, event.getResponseCode());
@@ -164,7 +164,7 @@ public class AllMapperEventTest {
         ContractBeneSearchEvent event = (ContractBeneSearchEvent) events.get(0);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
-        assertTrue(cbse.equals(event));
+        assertEquals(event, cbse);
         assertEquals(event.getId(), cbse.getId());
         assertEquals("laila", event.getUser());
         assertEquals("jobIdVal", event.getJobId());
@@ -197,7 +197,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = loggerEventRepository.load();
         assertEquals(events.size(), events2.size());
         ErrorEvent event = (ErrorEvent) events.get(0);
-        assertTrue(jsce.equals(event));
+        assertEquals(event, jsce);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -234,7 +234,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = loggerEventRepository.load();
         assertEquals(events.size(), events2.size());
         FileEvent event = (FileEvent) events.get(0);
-        assertTrue(jsce.equals(event));
+        assertEquals(event, jsce);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -271,7 +271,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = loggerEventRepository.load();
         assertEquals(events.size(), events2.size());
         JobStatusChangeEvent event = (JobStatusChangeEvent) events.get(0);
-        assertTrue(jsce.equals(event));
+        assertEquals(event, jsce);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
@@ -305,7 +305,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
         assertEquals(1, events.size());
         ReloadEvent event = (ReloadEvent) events.get(0);
-        assertTrue(cbse.equals(event));
+        assertEquals(event, cbse);
         assertEquals("dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), cbse.getId());

--- a/filter/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerTest.java
+++ b/filter/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerTest.java
@@ -40,8 +40,8 @@ class ExplanationOfBenefitTrimmerTest {
         assertNull(eobCarrier.getPatientTarget().getId());
         assertFalse(eobCarrier.getPatientTarget().getActive());
         assertNull(eobCarrier.getPatientTarget().getBirthDate());
-        assertEquals(sdf.format(eobCarrier.getBillablePeriod().getStart()), "1999-10-27");
-        assertEquals(sdf.format(eobCarrier.getBillablePeriod().getEnd()), "1999-10-27");
+        assertEquals("1999-10-27", sdf.format(eobCarrier.getBillablePeriod().getStart()));
+        assertEquals("1999-10-27", sdf.format(eobCarrier.getBillablePeriod().getEnd()));
         assertNull(eobCarrier.getCreated());
         assertTrue(StringUtils.isBlank(eobCarrier.getEnterer().getReference()));
         assertTrue(eobCarrier.getEntererTarget().getName().isEmpty());
@@ -65,7 +65,7 @@ class ExplanationOfBenefitTrimmerTest {
         assertNull(eobCarrier.getOriginalPrescriptionTarget().getId());
         assertNull(eobCarrier.getPayee().getId());
         assertTrue(isNullOrEmpty(eobCarrier.getInformation()));
-        assertEquals(eobCarrier.getPrecedence(), 0);
+        assertEquals(0, eobCarrier.getPrecedence());
         assertNull(eobCarrier.getInsurance().getId());
         assertNull(eobCarrier.getAccident().getId());
         assertNull(eobCarrier.getEmploymentImpacted().getId());

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
@@ -21,9 +21,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -12,10 +12,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherTest.java
@@ -18,10 +18,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")

--- a/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
@@ -5,7 +5,6 @@ import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.MockBfdServiceUtils;
 import gov.cms.ab2d.worker.SpringBootApp;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,6 +21,7 @@ import java.io.IOException;
 
 import static gov.cms.ab2d.common.util.Constants.MAINTENANCE_MODE;
 import static gov.cms.ab2d.worker.bfdhealthcheck.BFDMockServerConfigurationUtil.MOCK_SERVER_PORT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @ContextConfiguration(initializers = BFDMockServerConfigurationUtil.PropertyOverrider.class)
@@ -57,14 +57,14 @@ public class BFDHealthCheckTest {
         MockBfdServiceUtils.createMockServerMetaExpectation(TEST_DIR + "meta-unknown-status.xml", MOCK_SERVER_PORT);
 
         Properties maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("false", maintenanceProperties.getValue());
+        assertEquals("false", maintenanceProperties.getValue());
 
         for(int i = 0; i < consecutiveFailuresToTakeDown; i++) {
             bfdHealthCheck.checkBFDHealth();
         }
 
         maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("true", maintenanceProperties.getValue());
+        assertEquals("true", maintenanceProperties.getValue());
 
         // Cleanup
         MockBfdServiceUtils.reset(MOCK_SERVER_PORT);
@@ -88,14 +88,14 @@ public class BFDHealthCheckTest {
         MockBfdServiceUtils.createMockServerMetaExpectation(TEST_DIR + "meta.xml", MOCK_SERVER_PORT);
 
         Properties maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("true", maintenanceProperties.getValue());
+        assertEquals("true", maintenanceProperties.getValue());
 
         for (int i = 0; i < consecutiveSuccessesToBringUp; i++) {
             bfdHealthCheck.checkBFDHealth();
         }
 
         maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("false", maintenanceProperties.getValue());
+        assertEquals("false", maintenanceProperties.getValue());
     }
 
     @Test
@@ -120,14 +120,14 @@ public class BFDHealthCheckTest {
         bfdHealthCheck.checkBFDHealth();
 
         Properties maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("false", maintenanceProperties.getValue());
+        assertEquals("false", maintenanceProperties.getValue());
 
         for(int i = 0; i < consecutiveFailuresToTakeDown - 1; i++) {
             bfdHealthCheck.checkBFDHealth();
         }
 
         maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("true", maintenanceProperties.getValue());
+        assertEquals("true", maintenanceProperties.getValue());
 
         // Cleanup
         MockBfdServiceUtils.reset(MOCK_SERVER_PORT);
@@ -147,7 +147,7 @@ public class BFDHealthCheckTest {
         }
 
         Properties maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("true", maintenanceProperties.getValue());
+        assertEquals("true", maintenanceProperties.getValue());
 
         MockBfdServiceUtils.reset(MOCK_SERVER_PORT);
         MockBfdServiceUtils.createMockServerMetaExpectation(TEST_DIR + "meta.xml", MOCK_SERVER_PORT);
@@ -157,7 +157,7 @@ public class BFDHealthCheckTest {
         }
 
         maintenanceProperties = propertiesService.getPropertiesByKey(MAINTENANCE_MODE);
-        Assert.assertEquals("false", maintenanceProperties.getValue());
+        assertEquals("false", maintenanceProperties.getValue());
     }
 
     @AfterAll

--- a/worker/src/test/java/gov/cms/ab2d/worker/properties/PropertiesChangeDetectionTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/properties/PropertiesChangeDetectionTest.java
@@ -4,7 +4,6 @@ import gov.cms.ab2d.common.model.Properties;
 import gov.cms.ab2d.common.repository.PropertiesRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.worker.config.AutoScalingService;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +13,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static gov.cms.ab2d.common.util.Constants.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Testcontainers
@@ -36,9 +36,9 @@ public class PropertiesChangeDetectionTest {
 
     @Test
     public void testChangeInProperties() {
-        Assert.assertEquals(autoScalingService.getCorePoolSize(), 10);
-        Assert.assertEquals(autoScalingService.getMaxPoolSize(), 150);
-        Assert.assertEquals(autoScalingService.getScaleToMaxTime(), 900.0, 0);
+        assertEquals(autoScalingService.getCorePoolSize(), 10);
+        assertEquals(autoScalingService.getMaxPoolSize(), 150);
+        assertEquals(autoScalingService.getScaleToMaxTime(), 900.0, 0);
 
         Properties propertiesCorePoolSize = propertiesRepository.findByKey(PCP_CORE_POOL_SIZE).get();
         propertiesCorePoolSize.setValue("8");
@@ -54,18 +54,18 @@ public class PropertiesChangeDetectionTest {
 
         propertiesChangeDetection.detectChanges();
 
-        Assert.assertEquals(autoScalingService.getCorePoolSize(), 8);
-        Assert.assertEquals(autoScalingService.getMaxPoolSize(), 300);
-        Assert.assertEquals(autoScalingService.getScaleToMaxTime(), 1500.0, 0);
+        assertEquals(autoScalingService.getCorePoolSize(), 8);
+        assertEquals(autoScalingService.getMaxPoolSize(), 300);
+        assertEquals(autoScalingService.getScaleToMaxTime(), 1500.0, 0);
 
         Object valuePCPCorePoolSize = configurableEnvironment.getPropertySources().get("application").getProperty(PCP_CORE_POOL_SIZE);
-        Assert.assertEquals(valuePCPCorePoolSize, "8");
+        assertEquals(valuePCPCorePoolSize, "8");
 
         Object valuePCPMaxPoolSize = configurableEnvironment.getPropertySources().get("application").getProperty(PCP_MAX_POOL_SIZE);
-        Assert.assertEquals(valuePCPMaxPoolSize, "300");
+        assertEquals(valuePCPMaxPoolSize, "300");
 
         Object valuePCPScaleToMaxTime = configurableEnvironment.getPropertySources().get("application").getProperty(PCP_SCALE_TO_MAX_TIME);
-        Assert.assertEquals(valuePCPScaleToMaxTime, "1500");
+        assertEquals(valuePCPScaleToMaxTime, "1500");
 
         // Cleanup
         propertiesCorePoolSize.setValue("10");

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/FileServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.service;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -11,9 +10,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileServiceIntegrationTest {
 
@@ -31,19 +29,19 @@ public class FileServiceIntegrationTest {
     void testCreateDirectory() throws IOException {
         Files.deleteIfExists(tmpEfsMountDir.toPath());
         final Path directory = cut.createDirectory(tmpEfsMountDir.toPath());
-        Assertions.assertTrue(directory.toFile().isDirectory());
+        assertTrue(directory.toFile().isDirectory());
     }
 
     @Test
     void testCreateDirectoryWhenDirectoryAlreadyExist_ThrowsException() throws IOException {
         Files.deleteIfExists(tmpEfsMountDir.toPath());
         final Path directory = cut.createDirectory(tmpEfsMountDir.toPath());
-        Assertions.assertTrue(directory.toFile().isDirectory());
+        assertTrue(directory.toFile().isDirectory());
 
         var exceptionThrown = assertThrows(RuntimeException.class,
                 () -> cut.createDirectory(tmpEfsMountDir.toPath()));
 
-        assertThat(exceptionThrown.getMessage(), startsWith("Could not create output directory"));
+        assertTrue(exceptionThrown.getMessage().startsWith("Could not create output directory"));
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorTest.java
@@ -18,8 +18,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,7 +37,7 @@ class CancelStuckJobsProcessorTest {
     @Captor
     private ArgumentCaptor<Job> captor;
 
-    private List<Job> jobs = new ArrayList<>();
+    private final List<Job> jobs = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
@@ -55,7 +54,7 @@ class CancelStuckJobsProcessorTest {
         cut.process();
 
         verify(mockJobRepo).save(captor.capture());
-        assertThat(captor.getValue().getStatus(), is(JobStatus.CANCELLED));
+        assertEquals(JobStatus.CANCELLED, captor.getValue().getStatus());
     }
 
     @Test
@@ -69,9 +68,9 @@ class CancelStuckJobsProcessorTest {
 
         final List<Job> capturedJobs = captor.getAllValues();
 
-        assertThat(capturedJobs.size(), is(3));
+        assertEquals(3, capturedJobs.size());
         capturedJobs.forEach( job -> {
-                assertThat(job.getStatus(), is(JobStatus.CANCELLED));
+                assertEquals(JobStatus.CANCELLED, job.getStatus());
         });
 
     }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2954](https://jira.cms.gov/browse/AB2D-2954) - Remove JUnit4 
 
### What Does This PR Do?

Update unit tests to use JUnit5 only and fix incorrect argument orderings which cause misleading failure messages.

### What Should Reviewers Watch For?

Accidental modification of the semantics of a test.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure