### PR TITLE
Bug/ab2d 2941 Fix EFS Not Using TLS

### DIFF
--- a/Deploy/bash/deploy-application.sh
+++ b/Deploy/bash/deploy-application.sh
@@ -1103,15 +1103,6 @@ else
   exit 1
 fi
 
-# Get latest stable version of stunnel
-# - note that you need the latest, since older versions become unavailable
-# shellcheck disable=SC1003
-STUNNEL_LATEST_VERSION=$(curl -s 'https://www.stunnel.org/downloads.html' |
-  sed 's/</\'$'\n''</g' | sed -n '/>Latest Version$/,$ p' |
-  grep -E -m1 -o 'downloads/stunnel-.+\.tar\.gz' |
-  cut -d">" -f 2 |
-  sed 's/\.tar\.gz//')
-
 # Run automation for API and worker
 
 terraform apply \
@@ -1148,7 +1139,6 @@ terraform apply \
   --var "ab2d_hpms_api_params=${AB2D_HPMS_API_PARAMS}" \
   --var "ab2d_hpms_auth_key_id=${AB2D_HPMS_AUTH_KEY_ID}" \
   --var "ab2d_hpms_auth_key_secret=${AB2D_HPMS_AUTH_KEY_SECRET}" \
-  --var "stunnel_latest_version=${STUNNEL_LATEST_VERSION}" \
   --var "gold_image_name=${GOLD_IMAGE_NAME}" \
   --var "ec2_desired_instance_count_api=${EC2_DESIRED_INSTANCE_COUNT_API}" \
   --var "ec2_minimum_instance_count_api=${EC2_MINIMUM_INSTANCE_COUNT_API}" \
@@ -1182,7 +1172,6 @@ terraform apply \
   --var "new_relic_app_name=$NEW_RELIC_APP_NAME" \
   --var "new_relic_license_key=$NEW_RELIC_LICENSE_KEY" \
   --var "vpn_private_ip_address_cidr_range=${VPN_PRIVATE_IP_ADDRESS_CIDR_RANGE}" \
-  --var "stunnel_latest_version=${STUNNEL_LATEST_VERSION}" \
   --var "gold_image_name=${GOLD_IMAGE_NAME}" \
   --var "ec2_desired_instance_count_worker=${EC2_DESIRED_INSTANCE_COUNT_WORKER}" \
   --var "ec2_minimum_instance_count_worker=${EC2_MINIMUM_INSTANCE_COUNT_WORKER}" \

--- a/Deploy/bash/deploy-worker-module.sh
+++ b/Deploy/bash/deploy-worker-module.sh
@@ -389,17 +389,6 @@ else
 fi
 
 #
-# Get latest stable version of stunnel
-# - note that you need the latest, since older versions become unavailable
-#
-
-STUNNEL_LATEST_VERSION=$(curl -s 'https://www.stunnel.org/downloads.html' |
-  sed 's/</\'$'\n''</g' | sed -n '/>Latest Version$/,$ p' |
-  egrep -m1 -o 'downloads/stunnel-.+\.tar\.gz' |
-  cut -d">" -f 2 |
-  sed 's/\.tar\.gz//')
-
-#
 # Build worker and push to ECR repo
 #
 
@@ -585,7 +574,6 @@ terraform apply \
   --var "region=${REGION}" \
   --var "ssh_key_name=${SSH_KEY_NAME}" \
   --var "ssh_username=${SSH_USERNAME}" \
-  --var "stunnel_latest_version=${STUNNEL_LATEST_VERSION}" \
   --var "vpn_private_ip_address_cidr_range=${VPN_PRIVATE_IP_ADDRESS_CIDR_RANGE}" \
   --var "worker_desired_instances=${WORKER_DESIRED_INSTANCES}" \
   --var "worker_min_instances=${WORKER_MIN_INSTANCES}" \

--- a/Deploy/bash/update-gold-disk.sh
+++ b/Deploy/bash/update-gold-disk.sh
@@ -216,11 +216,11 @@ fi
 # Create AMI for controller, api, and worker nodes
 #
 
-# Set 1 hour of polling at 1 minute intervals
+# Set 75 minutes of polling at 1 minute intervals
 # - this was necessary to prevent a timeout error
 
-export AWS_MAX_ATTEMPTS=60
-export AWS_POLL_DELAY_SECONDS=60
+export AWS_MAX_ATTEMPTS=75
+export AWS_POLL_DELAY_SECONDS=75
 
 # Build the AMI
 

--- a/Deploy/packer/app/app.json
+++ b/Deploy/packer/app/app.json
@@ -15,7 +15,7 @@
       "access_key": "{{ user `aws_access_key_id`}}",
       "secret_key": "{{ user `aws_secret_access_key`}}",
       "token": "{{ user `aws_session_token`}}",
-      "iam_instance_profile": "Ab2dInstanceV2Profile",
+      "iam_instance_profile": "{{ user `iam_instance_profile`}}",
       "region": "{{ user `region`}}",
       "instance_type": "{{user `ec2_instance_type`}}",
       "subnet_id": "{{user `subnet_public_1_id`}}",

--- a/Deploy/terraform/environments/ab2d-dev/main.tf
+++ b/Deploy/terraform/environments/ab2d-dev/main.tf
@@ -198,7 +198,6 @@ module "api" {
   ab2d_hpms_api_params              = var.ab2d_hpms_api_params
   ab2d_hpms_auth_key_id             = var.ab2d_hpms_auth_key_id
   ab2d_hpms_auth_key_secret         = var.ab2d_hpms_auth_key_secret
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_api                    = var.cpm_backup_api
 }
 
@@ -256,7 +255,6 @@ module "worker" {
   claims_skip_billable_period_check = var.claims_skip_billable_period_check
   ab2d_opt_out_job_schedule         = var.ab2d_opt_out_job_schedule
   ab2d_s3_optout_bucket             = var.ab2d_s3_optout_bucket
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_worker                 = var.cpm_backup_worker
 }
 

--- a/Deploy/terraform/environments/ab2d-dev/variables.tf
+++ b/Deploy/terraform/environments/ab2d-dev/variables.tf
@@ -487,15 +487,6 @@ variable "ab2d_okta_jwt_issuer" {
 }
 
 #
-# EFS
-#
-
-variable "stunnel_latest_version" {
-  default     = ""
-  description = "Please pass this on command line and not as a value here"
-}
-
-#
 # Target group
 #
 

--- a/Deploy/terraform/environments/ab2d-east-impl/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-impl/main.tf
@@ -198,7 +198,6 @@ module "api" {
   ab2d_hpms_api_params              = var.ab2d_hpms_api_params
   ab2d_hpms_auth_key_id             = var.ab2d_hpms_auth_key_id
   ab2d_hpms_auth_key_secret         = var.ab2d_hpms_auth_key_secret
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_api                    = var.cpm_backup_api
 }
 
@@ -256,7 +255,6 @@ module "worker" {
   claims_skip_billable_period_check = var.claims_skip_billable_period_check
   ab2d_opt_out_job_schedule         = var.ab2d_opt_out_job_schedule
   ab2d_s3_optout_bucket             = var.ab2d_s3_optout_bucket
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_worker                 = var.cpm_backup_worker
 }
 

--- a/Deploy/terraform/environments/ab2d-east-impl/variables.tf
+++ b/Deploy/terraform/environments/ab2d-east-impl/variables.tf
@@ -487,15 +487,6 @@ variable "ab2d_okta_jwt_issuer" {
 }
 
 #
-# EFS
-#
-
-variable "stunnel_latest_version" {
-  default     = ""
-  description = "Please pass this on command line and not as a value here"
-}
-
-#
 # Target group
 #
 

--- a/Deploy/terraform/environments/ab2d-east-prod-test/worker/input.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod-test/worker/input.tf
@@ -30,7 +30,6 @@ variable "percent_capacity_increase" {}
 variable "region" {}
 variable "ssh_key_name" {}
 variable "ssh_username" {}
-variable "stunnel_latest_version" {}
 variable "vpn_private_ip_address_cidr_range" {}
 variable "worker_desired_instances" {}
 variable "worker_min_instances" {}

--- a/Deploy/terraform/environments/ab2d-east-prod-test/worker/worker.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod-test/worker/worker.tf
@@ -71,7 +71,6 @@ module "worker" {
   region                            = var.region
   ssh_key_name                      = var.env
   ssh_username                      = var.ssh_username
-  stunnel_latest_version            = var.stunnel_latest_version
   vpc_id                            = data.terraform_remote_state.core.outputs.vpc_id
   vpn_private_ip_address_cidr_range = var.vpn_private_ip_address_cidr_range
   worker_desired_instances          = var.worker_desired_instances

--- a/Deploy/terraform/environments/ab2d-east-prod/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod/main.tf
@@ -200,7 +200,6 @@ module "api" {
   ab2d_hpms_api_params              = var.ab2d_hpms_api_params
   ab2d_hpms_auth_key_id             = var.ab2d_hpms_auth_key_id
   ab2d_hpms_auth_key_secret         = var.ab2d_hpms_auth_key_secret
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_api                    = var.cpm_backup_api
 }
 
@@ -258,7 +257,6 @@ module "worker" {
   claims_skip_billable_period_check = var.claims_skip_billable_period_check
   ab2d_opt_out_job_schedule         = var.ab2d_opt_out_job_schedule
   ab2d_s3_optout_bucket             = var.ab2d_s3_optout_bucket
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_worker                 = var.cpm_backup_worker
 }
 

--- a/Deploy/terraform/environments/ab2d-east-prod/variables.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod/variables.tf
@@ -487,15 +487,6 @@ variable "ab2d_okta_jwt_issuer" {
 }
 
 #
-# EFS
-#
-
-variable "stunnel_latest_version" {
-  default     = ""
-  description = "Please pass this on command line and not as a value here"
-}
-
-#
 # Target group
 #
 

--- a/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
+++ b/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
@@ -198,7 +198,6 @@ module "api" {
   ab2d_hpms_api_params              = var.ab2d_hpms_api_params
   ab2d_hpms_auth_key_id             = var.ab2d_hpms_auth_key_id
   ab2d_hpms_auth_key_secret         = var.ab2d_hpms_auth_key_secret
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_api                    = var.cpm_backup_api
 }
 
@@ -256,7 +255,6 @@ module "worker" {
   claims_skip_billable_period_check = var.claims_skip_billable_period_check
   ab2d_opt_out_job_schedule         = var.ab2d_opt_out_job_schedule
   ab2d_s3_optout_bucket             = var.ab2d_s3_optout_bucket
-  stunnel_latest_version            = var.stunnel_latest_version
   cpm_backup_worker                 = var.cpm_backup_worker
 }
 

--- a/Deploy/terraform/environments/ab2d-sbx-sandbox/variables.tf
+++ b/Deploy/terraform/environments/ab2d-sbx-sandbox/variables.tf
@@ -487,15 +487,6 @@ variable "ab2d_okta_jwt_issuer" {
 }
 
 #
-# EFS
-#
-
-variable "stunnel_latest_version" {
-  default     = ""
-  description = "Please pass this on command line and not as a value here"
-}
-
-#
 # Target group
 #
 

--- a/Deploy/terraform/modules/api/main.tf
+++ b/Deploy/terraform/modules/api/main.tf
@@ -307,7 +307,7 @@ resource "aws_launch_configuration" "launch_config" {
   iam_instance_profile = var.iam_instance_profile
   key_name = var.ssh_key_name
   security_groups = [aws_security_group.api.id]  
-  user_data = templatefile("${path.module}/userdata.tpl",{ env = "${lower(var.env)}", cluster_name = "${lower(var.env)}-api", efs_id = var.efs_id, stunnel_latest_version = var.stunnel_latest_version })
+  user_data = templatefile("${path.module}/userdata.tpl",{ env = "${lower(var.env)}", cluster_name = "${lower(var.env)}-api", efs_id = var.efs_id })
   lifecycle { create_before_destroy = true }
 }
 

--- a/Deploy/terraform/modules/api/userdata.tpl
+++ b/Deploy/terraform/modules/api/userdata.tpl
@@ -8,51 +8,6 @@ echo "$(hostname -s).${env}" > /tmp/hostname
 sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
-#
-# Setup EFS realted items
-#
-
-# Build amazon-efs-utils as an RPM package
-
-sudo yum -y install git
-sudo yum -y install rpm-build
-cd /tmp
-git clone https://github.com/aws/efs-utils
-cd efs-utils
-# Change FIPS mode to yes
-sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
-sudo make rpm
-
-# Install amazon-efs-utils as an RPM package
-# - note that '--nogpgcheck' is now required for installing locally built rpm
-
-sudo yum -y install ./build/amazon-efs-utils*rpm --nogpgcheck
-
-#
-# Upgrade stunnel for using EFS mount helper with TLS
-# - by default, it enforces certificate hostname checking
-#
-
-sudo yum install gcc openssl-devel tcp_wrappers-devel -y
-cd /tmp
-curl -o "${stunnel_latest_version}.tar.gz" "https://www.stunnel.org/downloads/${stunnel_latest_version}.tar.gz"
-tar xvfz "${stunnel_latest_version}.tar.gz"
-cd "${stunnel_latest_version}"
-sudo ./configure
-sudo make
-sudo rm -f /bin/stunnel
-sudo make install
-if [[ -f /bin/stunnel ]]; then sudo mv /bin/stunnel /root; fi
-sudo ln -s /usr/local/bin/stunnel /bin/stunnel
-
-# Configure running container instances to use an Amazon EFS file system
-#
-# Mounting Your Amazon EFS File System Automatically
-# https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html
-
-sudo mkdir /mnt/efs
-sudo cp /etc/fstab /etc/fstab.bak
-
 #####
 # -----------
 # Without TLS

--- a/Deploy/terraform/modules/api/userdata.tpl
+++ b/Deploy/terraform/modules/api/userdata.tpl
@@ -9,7 +9,7 @@ sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
 #
-# Setup EFS realted items 
+# Setup EFS realted items
 #
 
 # Build amazon-efs-utils as an RPM package
@@ -19,6 +19,8 @@ sudo yum -y install rpm-build
 cd /tmp
 git clone https://github.com/aws/efs-utils
 cd efs-utils
+# Change FIPS mode to yes
+sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
 sudo make rpm
 
 # Install amazon-efs-utils as an RPM package
@@ -55,19 +57,19 @@ sudo cp /etc/fstab /etc/fstab.bak
 # -----------
 # Without TLS
 # -----------
-echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
-sudo mount -a
+# echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
+# sudo mount -a
 #
 # --------
 # With TLS
 # --------
 # Mount with IAM authorization to an Amazon EC2 instance that has an instance profile
-# echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
-# sudo mount -a
+echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
 #####
 
 #
-# Setup ECS realted items 
+# Setup ECS realted items
 #
 
 # ECS config file

--- a/Deploy/terraform/modules/api/variables.tf
+++ b/Deploy/terraform/modules/api/variables.tf
@@ -79,8 +79,6 @@ variable "ab2d_keystore_password" {}
 
 variable "ab2d_okta_jwt_issuer" {}
 
-variable "stunnel_latest_version" {}
-
 variable "cpm_backup_api" {}
 
 variable "ab2d_hpms_url" {}

--- a/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
@@ -39,7 +39,6 @@ variable "percent_capacity_increase" {}
 variable "region" {}
 variable "ssh_key_name" {}
 variable "ssh_username" {}
-variable "stunnel_latest_version" {}
 variable "vpc_id" {}
 variable "vpn_private_ip_address_cidr_range" {}
 variable "worker_desired_instances" {}

--- a/Deploy/terraform/modules/terraservices_pattern/worker/userdata.tpl
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/userdata.tpl
@@ -9,9 +9,9 @@ sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
 #
-# Setup EFS realted items 
+# Setup EFS realted items
 #
- 
+
 # Build amazon-efs-utils as an RPM package
 
 sudo yum -y install git
@@ -19,6 +19,8 @@ sudo yum -y install rpm-build
 cd /tmp
 git clone https://github.com/aws/efs-utils
 cd efs-utils
+# Change FIPS mode to yes
+sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
 sudo make rpm
 
 # Install amazon-efs-utils as an RPM package
@@ -56,15 +58,15 @@ sudo cp /etc/fstab /etc/fstab.bak
 # -----------
 # TO DO: Ensure stunnel is being used with the custom AMI
 # -----------
-echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
-sudo mount -a
+# echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
+# sudo mount -a
 #
 # --------
 # Note that the following method can't be used since it is specific to Amazon's ECS specific AMI)
 # --------
 # Mount with IAM authorization to an Amazon EC2 instance that has an instance profile
-# echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
-# sudo mount -a
+echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
 #####
 
 # Place BFD keystore in shared EFS directory (if doesn't already exist)
@@ -87,7 +89,7 @@ else
   export RUBY_BIN="/home/ec2-user/.rbenv/versions/2.6.5/bin"
   sudo "$RUBY_BIN/bundle" exec "$RUBY_BIN/rake" \
     get_file_from_s3_and_decrypt["./${bfd_keystore_file_name}","${env}-automation"]
-  
+
   # Create a "bfd-keystore" directory under EFS (if doesn't exist)
   sudo mkdir -p "/mnt/efs/bfd-keystore/${env}"
 
@@ -97,9 +99,9 @@ else
 fi
 
 #
-# Setup ECS realted items 
+# Setup ECS realted items
 #
- 
+
 # ECS config file
 # https://github.com/aws/amazon-ecs-agent
 

--- a/Deploy/terraform/modules/terraservices_pattern/worker/userdata.tpl
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/userdata.tpl
@@ -8,61 +8,15 @@ echo "$(hostname -s).${env}" > /tmp/hostname
 sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
-#
-# Setup EFS realted items
-#
-
-# Build amazon-efs-utils as an RPM package
-
-sudo yum -y install git
-sudo yum -y install rpm-build
-cd /tmp
-git clone https://github.com/aws/efs-utils
-cd efs-utils
-# Change FIPS mode to yes
-sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
-sudo make rpm
-
-# Install amazon-efs-utils as an RPM package
-# - note that '--nogpgcheck' is now required for installing locally built rpm
-
-sudo yum -y install ./build/amazon-efs-utils*rpm --nogpgcheck
-
-#
-# Upgrade stunnel for using EFS mount helper with TLS
-# - by default, it enforces certificate hostname checking
-#
-
-sudo yum install gcc openssl-devel tcp_wrappers-devel -y
-cd /tmp
-curl -o "${stunnel_latest_version}.tar.gz" "https://www.stunnel.org/downloads/${stunnel_latest_version}.tar.gz"
-tar xvfz "${stunnel_latest_version}.tar.gz"
-cd "${stunnel_latest_version}"
-sudo ./configure
-sudo make
-sudo rm -f /bin/stunnel
-sudo make install
-if [[ -f /bin/stunnel ]]; then sudo mv /bin/stunnel /root; fi
-sudo ln -s /usr/local/bin/stunnel /bin/stunnel
-
-# Configure running container instances to use an Amazon EFS file system
-#
-# Mounting Your Amazon EFS File System Automatically
-# https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html
-
-sudo mkdir /mnt/efs
-sudo cp /etc/fstab /etc/fstab.bak
-
-# TO DO: This will be handled differently when we move to fargate
 #####
 # -----------
-# TO DO: Ensure stunnel is being used with the custom AMI
+# Without TLS
 # -----------
 # echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
 # sudo mount -a
 #
 # --------
-# Note that the following method can't be used since it is specific to Amazon's ECS specific AMI)
+# With TLS
 # --------
 # Mount with IAM authorization to an Amazon EC2 instance that has an instance profile
 echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab

--- a/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
@@ -181,7 +181,7 @@ resource "aws_launch_configuration" "launch_config" {
   iam_instance_profile = var.iam_instance_profile
   key_name = var.ssh_key_name
   security_groups = [aws_security_group.worker.id]
-  user_data = templatefile("${path.module}/userdata.tpl",{ env = lower(var.env), cluster_name = "${lower(var.env)}-worker", efs_id = var.efs_id, stunnel_latest_version = var.stunnel_latest_version, bfd_keystore_file_name = var.bfd_keystore_file_name })
+  user_data = templatefile("${path.module}/userdata.tpl",{ env = lower(var.env), cluster_name = "${lower(var.env)}-worker", efs_id = var.efs_id, bfd_keystore_file_name = var.bfd_keystore_file_name })
   lifecycle { create_before_destroy = true }
 }
 

--- a/Deploy/terraform/modules/worker/main.tf
+++ b/Deploy/terraform/modules/worker/main.tf
@@ -186,7 +186,7 @@ resource "aws_launch_configuration" "launch_config" {
   iam_instance_profile = var.iam_instance_profile
   key_name = var.ssh_key_name
   security_groups = [aws_security_group.worker.id]
-  user_data = templatefile("${path.module}/userdata.tpl",{ env = "${lower(var.env)}", cluster_name = "${lower(var.env)}-worker", efs_id = var.efs_id, stunnel_latest_version = var.stunnel_latest_version, bfd_keystore_file_name = var.bfd_keystore_file_name })
+  user_data = templatefile("${path.module}/userdata.tpl",{ env = "${lower(var.env)}", cluster_name = "${lower(var.env)}-worker", efs_id = var.efs_id, bfd_keystore_file_name = var.bfd_keystore_file_name })
   lifecycle { create_before_destroy = true }
 }
 

--- a/Deploy/terraform/modules/worker/userdata.tpl
+++ b/Deploy/terraform/modules/worker/userdata.tpl
@@ -8,51 +8,6 @@ echo "$(hostname -s).${env}" > /tmp/hostname
 sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
-#
-# Setup EFS realted items
-#
-
-# Build amazon-efs-utils as an RPM package
-
-sudo yum -y install git
-sudo yum -y install rpm-build
-cd /tmp
-git clone https://github.com/aws/efs-utils
-cd efs-utils
-# Change FIPS mode to yes
-sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
-sudo make rpm
-
-# Install amazon-efs-utils as an RPM package
-# - note that '--nogpgcheck' is now required for installing locally built rpm
-
-sudo yum -y install ./build/amazon-efs-utils*rpm --nogpgcheck
-
-#
-# Upgrade stunnel for using EFS mount helper with TLS
-# - by default, it enforces certificate hostname checking
-#
-
-sudo yum install gcc openssl-devel tcp_wrappers-devel -y
-cd /tmp
-curl -o "${stunnel_latest_version}.tar.gz" "https://www.stunnel.org/downloads/${stunnel_latest_version}.tar.gz"
-tar xvfz "${stunnel_latest_version}.tar.gz"
-cd "${stunnel_latest_version}"
-sudo ./configure
-sudo make
-sudo rm -f /bin/stunnel
-sudo make install
-if [[ -f /bin/stunnel ]]; then sudo mv /bin/stunnel /root; fi
-sudo ln -s /usr/local/bin/stunnel /bin/stunnel
-
-# Configure running container instances to use an Amazon EFS file system
-#
-# Mounting Your Amazon EFS File System Automatically
-# https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html
-
-sudo mkdir /mnt/efs
-sudo cp /etc/fstab /etc/fstab.bak
-
 #####
 # -----------
 # Without TLS

--- a/Deploy/terraform/modules/worker/userdata.tpl
+++ b/Deploy/terraform/modules/worker/userdata.tpl
@@ -9,9 +9,9 @@ sudo mv /tmp/hostname /etc/hostname
 sudo hostname "$(hostname -s).${env}"
 
 #
-# Setup EFS realted items 
+# Setup EFS realted items
 #
- 
+
 # Build amazon-efs-utils as an RPM package
 
 sudo yum -y install git
@@ -19,6 +19,8 @@ sudo yum -y install rpm-build
 cd /tmp
 git clone https://github.com/aws/efs-utils
 cd efs-utils
+# Change FIPS mode to yes
+sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
 sudo make rpm
 
 # Install amazon-efs-utils as an RPM package
@@ -55,15 +57,15 @@ sudo cp /etc/fstab /etc/fstab.bak
 # -----------
 # Without TLS
 # -----------
-echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
-sudo mount -a
+# echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
+# sudo mount -a
 #
 # --------
 # With TLS
 # --------
 # Mount with IAM authorization to an Amazon EC2 instance that has an instance profile
-# echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
-# sudo mount -a
+echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
 #####
 
 # Place BFD keystore in shared EFS directory (if doesn't already exist)
@@ -90,7 +92,7 @@ else
   export RUBY_BIN="/home/ec2-user/.rbenv/versions/2.6.5/bin"
   sudo "$RUBY_BIN/bundle" exec "$RUBY_BIN/rake" \
     get_file_from_s3_and_decrypt["./${bfd_keystore_file_name}","${env}-automation"]
-  
+
   # Create a "bfd-keystore" directory under EFS (if doesn't exist)
   sudo mkdir -p "/mnt/efs/bfd-keystore/${env}"
 
@@ -100,9 +102,9 @@ else
 fi
 
 #
-# Setup ECS realted items 
+# Setup ECS realted items
 #
- 
+
 # ECS config file
 # https://github.com/aws/amazon-ecs-agent
 

--- a/Deploy/terraform/modules/worker/variables.tf
+++ b/Deploy/terraform/modules/worker/variables.tf
@@ -80,5 +80,4 @@ variable "claims_skip_billable_period_check" {}
 variable "ab2d_opt_out_job_schedule" {}
 variable "ab2d_s3_optout_bucket" {}
 
-variable "stunnel_latest_version" {}
 variable "cpm_backup_worker" {}


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2941](https://jira.cms.gov/browse/AB2D-2941) - Fix EFS mounts Not Using TLS
 
### What Does This PR Do?
This PR Fixes an issue with running Stunnel in FIPS mode, therefore allowing TLS connection to EFS Mounts in AWS. Specifically, this PR removes Stunnel configuration from Terraform and moves it into Packer.

Semantically this means that instead of configuring the TLS connection to EFS after creating a VM we are baking it into the VM image.

### What Should Reviewers Watch For?
The new Packer config that saves time on deployments (approx 11 mins) 

### Usage/Deployment Instructions
 Standard Deployment (already deployed in all envs)

### Impacted External Components
EFS Mounts (Now over TLS)

### Database Changes
N/A
### Limitations
Must be run on a FIPS Compliant kernel or Gold AMI

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?
N/A - Devops Changes
### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure