### PR TITLE
remove usage of since for enrollment calculation

### DIFF
--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -605,7 +605,7 @@ class CoverageDriverTest {
             job.setSince(OffsetDateTime.of(endMonth, endDay, AB2D_ZONE.getRules().getOffset(Instant.now())));
 
             boolean inProgressEndMonth = driver.isCoverageAvailable(job);
-            assertTrue(inProgressEndMonth, "eob searches should run when only month after since is successful");
+            assertFalse(inProgressEndMonth, "eob searches should run when only month after since is successful");
         } catch (InterruptedException | CoverageDriverException exception) {
             fail("could not check for available coverage", exception);
         }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
@@ -58,16 +58,9 @@ class CoverageDriverUnitTest {
         CoverageDriverException startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job));
         assertEquals("contract attestation time is after current time," +
                 " cannot find metadata for coverage periods in the future", startDateInFuture.getMessage());
-
-        contract.setAttestedOn(AB2D_EPOCH.toOffsetDateTime());
-        job.setSince(OffsetDateTime.now().plusHours(1));
-
-        startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job));
-        assertEquals("contract attestation time is after current time," +
-                " cannot find metadata for coverage periods in the future", startDateInFuture.getMessage());
     }
 
-    @DisplayName("Paging coverage ignores since date in future and does ")
+    @DisplayName("Paging coverage ignores since date in future and executes search")
     @Test
     void pageRequestWhenSinceDateAfterNow() {
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
@@ -56,15 +56,63 @@ class CoverageDriverUnitTest {
         job.setContract(contract);
 
         CoverageDriverException startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job));
-        assertEquals("contract attestation time or since date on job is after current time," +
+        assertEquals("contract attestation time is after current time," +
                 " cannot find metadata for coverage periods in the future", startDateInFuture.getMessage());
 
         contract.setAttestedOn(AB2D_EPOCH.toOffsetDateTime());
         job.setSince(OffsetDateTime.now().plusHours(1));
 
         startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job));
-        assertEquals("contract attestation time or since date on job is after current time," +
+        assertEquals("contract attestation time is after current time," +
                 " cannot find metadata for coverage periods in the future", startDateInFuture.getMessage());
+    }
+
+    @DisplayName("Paging coverage ignores since date in future and does ")
+    @Test
+    void pageRequestWhenSinceDateAfterNow() {
+
+        when(coverageService.getCoveragePeriod(any(Contract.class), anyInt(), anyInt())).thenAnswer((invocationOnMock) -> {
+            CoveragePeriod period = new CoveragePeriod();
+            period.setContract(invocationOnMock.getArgument(0));
+            period.setMonth(invocationOnMock.getArgument(1));
+            period.setYear(invocationOnMock.getArgument(2));
+
+            return period;
+        });
+
+        int pagingSize = (int) ReflectionTestUtils.getField(driver, "PAGING_SIZE");
+
+        when(coverageService.pageCoverage(any(CoveragePagingRequest.class))).thenAnswer((invocationMock) -> {
+            CoveragePagingRequest request = invocationMock.getArgument(0);
+
+            Optional<String> cursor = request.getCursor();
+
+            CoveragePagingRequest nextRequest = null;
+            if (cursor.isPresent()) {
+                int cursorValue = Integer.parseInt(cursor.get());
+                nextRequest = new CoveragePagingRequest(pagingSize, "" + (cursorValue + pagingSize), List.of());
+            } else {
+                nextRequest = new CoveragePagingRequest(pagingSize, "" + pagingSize, List.of());
+
+            }
+
+            return new CoveragePagingResult(List.of(), nextRequest);
+        });
+
+        Job job = new Job();
+        Contract contract = new Contract();
+        contract.setAttestedOn(OffsetDateTime.now().plusHours(1));
+        job.setContract(contract);
+
+        CoverageDriverException startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job));
+        assertEquals("contract attestation time is after current time," +
+                " cannot find metadata for coverage periods in the future", startDateInFuture.getMessage());
+
+        contract.setAttestedOn(AB2D_EPOCH.toOffsetDateTime());
+        job.setSince(OffsetDateTime.now().plusHours(1));
+
+        CoveragePagingResult result = driver.pageCoverage(job);
+        assertNotNull(result);
     }
 
     @DisplayName("Paging coverage fails when coverage periods are missing")


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2957](https://jira.cms.gov/browse/AB2D-2957) - Since Parameter Applied Incorrectly to Enrollment Data
 
### What Does This PR Do?

Fix bug introduced in CoverageDriver that was incorrectly applying the since parameter to enrollment data. The since parameter is only meant for usage with claims data. The since parameter filters by the time a claim was received/updated in BFD and not by the time that services were rendered.

### What Should Reviewers Watch For?

Any other usages of since that may have snuck into the CoverageProcessor or other coverage classes.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure