### PR TITLE
remove filter for eob.status field

### DIFF
--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -438,11 +438,11 @@ class TestRunner {
     }
 
     private boolean validFields(JSONObject jsonObject) {
-        Set<String> allowedFields = Set.of("identifier", "item", "meta", "patient", "billablePeriod", "diagnosis",
+        Set<String> allowedFields = Set.of("identifier", "status", "item", "meta", "patient", "billablePeriod", "diagnosis",
                 "provider", "id", "type", "precedence", "resourceType", "organization", "facility", "careTeam",
                 "procedure", "extension");
 
-        Set<String> disallowedFields = Set.of("status", "patientTarget", "created", "enterer",
+        Set<String> disallowedFields = Set.of("patientTarget", "created", "enterer",
             "entererTarget", "insurer", "insurerTarget", "providerTarget", "organizationTarget", "referral",
             "referralTarget", "facilityTarget", "claim", "claimTarget", "claimResponse", "claimResponseTarget",
             "outcome", "disposition", "related", "prescription", "prescriptionTarget", "originalPrescription",

--- a/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR3.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR3.java
@@ -47,7 +47,6 @@ public class ExplanationOfBenefitTrimmerR3 {
 
            Inherited - Identifier, resourceType, type
          */
-        benefit.setStatus(null);
         benefit.setExtension(null);
         benefit.setPatientTarget(null);
         benefit.setCreated(null);

--- a/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
+++ b/filter/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
@@ -49,7 +49,6 @@ public class ExplanationOfBenefitTrimmerR4 {
            Inherited - Identifier, resourceType, type (min cardinality from 0 to 1)
          */
 
-        benefit.setStatus(null);
         // We don't know what ends up here so needs to be removed
         clearOutList(benefit.getExtension());
         // This was Information and now it's SupportingInfo


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2963](https://jira.cms.gov/browse/AB2D-2963) - Report EOB.status on Claims
 
### What Does This PR Do?

Stops filtering the `eob.status` field. This field is the only field that a PDP can use to detect whether a claim is the latest version ('active') is a stale version ('cancelled') or has been altogether cancelled ('cancelled').

### What Should Reviewers Watch For?

Wait for comment with approval from CMS.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure