### PR TITLE
feature/ab2d-2970-eliminate-website-remnants-for-akamai-netstorage-deployment

### DIFF
--- a/Deploy/bash/create-or-update-website-akamai.sh
+++ b/Deploy/bash/create-or-update-website-akamai.sh
@@ -130,7 +130,8 @@ rsync \
   --partial \
   --archive \
   --verbose \
+  --delete \
   --force \
   --rsh="ssh -v -oStrictHostKeyChecking=no -oHostKeyAlgorithms=+ssh-dss -i ${NETSTORAGE_SSH_KEY}" \
-  _site/* \
-  "sshacs@${AKAMAI_RSYNC_DOMAIN}:/${AKAMAI_UPLOAD_DIRECTORY}/_site"
+  _site/ \
+  "sshacs@${AKAMAI_RSYNC_DOMAIN}:/${AKAMAI_UPLOAD_DIRECTORY}/_site/"


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2970](https://jira.cms.gov/browse/AB2D-2970) - Eliminate website remnants for akamai netstorage deployment

***Related Tickets***

N/A
 
### What Does This PR Do?

Eliminates remnants from previous static website when deploying a new website that eliminates directories or files that were present in the previous deployment.

### What Should Reviewers Watch For?

Note that the "*" wildcard had to be removed in order to allow both updates and deletions in the existing "_site" directory in Akamai NetStorage to work.

### Usage/Deployment Instructions

Note that this was tested by manually creating a "test" directory with a file in it using file manager of the website's upload directory in NetStorage. The website deployment script was run and the "test" directory was automatically removed.

### Impacted External Components

N/A

### Database Changes

N/A

### Limitations

N/A

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

N/A

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure