### PR TITLE
limit ADMIN role access to FHIR resources

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilterAfter(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeRequests()
             .antMatchers(API_PREFIX + ADMIN_PREFIX + "/**").hasAuthority(ADMIN_ROLE)
-            .antMatchers(API_PREFIX + FHIR_PREFIX + "/**").hasAnyAuthority(SPONSOR_ROLE, ADMIN_ROLE)
+            .antMatchers(API_PREFIX + FHIR_PREFIX + "/**").hasAnyAuthority(SPONSOR_ROLE)
             .anyRequest().authenticated();
     }
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -65,13 +65,13 @@ public class RoleTests {
 
     // This will test the API using a role that should not be able to access sponsor URLs
     @Test
-    public void testAdminRoleAccessingSponsorApi() throws Exception {
+    public void testAdminRoleAccessingSponsorApiIsDisabled() throws Exception {
         token = testUtil.setupToken(List.of(ADMIN_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX + FHIR_PREFIX + "/Patient/$export")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
-                .andExpect(status().is(202));
+                .andExpect(status().is(403));
     }
 
     // This will test the API using a role that should not be able to access sponsor URLs


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3033](https://jira.cms.gov/browse/AB2D-3033) - Limit ADMIN role access to the api
 
### What Does This PR Do?

Disallow the ADMIN user downloading data from any FHIR endpoints in our api. If we are going to give the ADMIN user the ability to start any job, for security, we should prevent the ADMIN user from being able to download the results of that job.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure