### PR TITLE
change admin api to start jobs by contract number not username

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
@@ -92,20 +92,20 @@ public class AdminAPI {
     }
 
     @ResponseStatus(value = HttpStatus.OK)
-    @PutMapping("/user/{username}/enable")
-    public ResponseEntity<UserDTO> enableUser(@PathVariable @NotBlank String username) {
-        return new ResponseEntity<>(userService.enableUser(username), null, HttpStatus.OK);
+    @PutMapping("/user/{contractNumber}/enable")
+    public ResponseEntity<UserDTO> enableUser(@PathVariable @NotBlank String contractNumber) {
+        return new ResponseEntity<>(userService.enableUser(contractNumber), null, HttpStatus.OK);
     }
 
     @ResponseStatus(value = HttpStatus.OK)
-    @PutMapping("/user/{username}/disable")
-    public ResponseEntity<UserDTO> disableUser(@PathVariable @NotBlank String username) {
-        return new ResponseEntity<>(userService.disableUser(username), null, HttpStatus.OK);
+    @PutMapping("/user/{contractNumber}/disable")
+    public ResponseEntity<UserDTO> disableUser(@PathVariable @NotBlank String contractNumber) {
+        return new ResponseEntity<>(userService.disableUser(contractNumber), null, HttpStatus.OK);
     }
 
     @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping("/user/{username}")
-    public ResponseEntity<UserDTO> getUser(@PathVariable @NotBlank String username) {
-        return new ResponseEntity<>(userService.getUser(username), null, HttpStatus.OK);
+    @GetMapping("/user/{contractNumber}")
+    public ResponseEntity<UserDTO> getUser(@PathVariable @NotBlank String contractNumber) {
+        return new ResponseEntity<>(userService.getUser(contractNumber), null, HttpStatus.OK);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
@@ -80,25 +80,13 @@ public class AdminAPI {
         return new ResponseEntity<>(propertiesService.updateProperties(propertiesDTOs), null, HttpStatus.OK);
     }
 
-    @PostMapping("/user/{username}/job")
-    public ResponseEntity<Void> createJobOnBehalfOfUser(@PathVariable @NotBlank String username,
-        HttpServletRequest request,
-        @RequestParam(required = false, name = "_type", defaultValue = EOB) String resourceTypes,
-        @RequestParam(required = false, name = "_outputFormat") String outputFormat,
-        @RequestParam(required = false, name = "_since") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime since) {
-        userService.setupUserImpersonation(username, request);
-
-        return bulkDataAccessAPI.exportAllPatients(request, resourceTypes, outputFormat, since);
-    }
-
-    @PostMapping("/user/{username}/job/{contractNumber}")
-    public ResponseEntity<Void> createJobByContractOnBehalfOfUser(@PathVariable @NotBlank String username,
-                                                        @PathVariable @NotBlank String contractNumber,
+    @PostMapping("/job/{contractNumber}")
+    public ResponseEntity<Void> createJobByContractOnBehalfOfUser(@PathVariable @NotBlank String contractNumber,
                                                         HttpServletRequest request,
                                                         @RequestParam(required = false, name = "_type", defaultValue = EOB) String resourceTypes,
                                                         @RequestParam(required = false, name = "_outputFormat") String outputFormat,
                                                         @RequestParam(required = false, name = "_since") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime since) {
-        userService.setupUserImpersonation(username, request);
+        userService.setupUserImpersonation(contractNumber, request);
 
         return bulkDataAccessAPI.exportPatientsWithContract(request, contractNumber, resourceTypes, outputFormat, since);
     }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
@@ -45,6 +45,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AdminAPIUserTests {
 
     public static final String TEST_USER = "test@test.com";
+    private static final String USER_URL = "/user";
+    private static final String ENABLE_DISABLE_USER = "enableDisableUser";
+    private static final String ENABLE_DISABLE_CONTRACT = "Z0000";
 
     @Autowired
     private MockMvc mockMvc;
@@ -72,9 +75,7 @@ public class AdminAPIUserTests {
 
     private String token;
 
-    private static final String USER_URL = "/user";
 
-    private static final String ENABLE_DISABLE_USER = "enableDisableUser";
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
@@ -269,7 +270,7 @@ public class AdminAPIUserTests {
 
     @Test
     public void testCreateUsersJobByContractOnAdminBehalf() throws Exception {
-        setupUser("regularUser", "Z0000", true);
+        setupUser("regularUser", true);
 
         MvcResult mvcResult = this.mockMvc.perform(
                 post(API_PREFIX + ADMIN_PREFIX + "/job/Z0000")
@@ -291,22 +292,22 @@ public class AdminAPIUserTests {
     @Test
     public void enableUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(ENABLE_DISABLE_USER,"Z0000",false);
+        setupUser(ENABLE_DISABLE_USER, false);
 
         MvcResult mvcResult = this.mockMvc.perform(
-                put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER + "/enable")
+                put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_CONTRACT + "/enable")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(200, mvcResult.getResponse().getStatus());
 
         ObjectMapper mapper = new ObjectMapper();
 
         String updateResult = mvcResult.getResponse().getContentAsString();
         UserDTO updatedUserDTO = mapper.readValue(updateResult, UserDTO.class);
 
-        assertEquals(updatedUserDTO.getEnabled(), true);
+        assertEquals(true, updatedUserDTO.getEnabled());
     }
 
     @Test
@@ -321,22 +322,22 @@ public class AdminAPIUserTests {
     @Test
     public void disableUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(ENABLE_DISABLE_USER,"Z0000",true);
+        setupUser(ENABLE_DISABLE_USER, true);
 
         MvcResult mvcResult = this.mockMvc.perform(
-                put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER + "/disable")
+                put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_CONTRACT + "/disable")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(200, mvcResult.getResponse().getStatus());
 
         ObjectMapper mapper = new ObjectMapper();
 
         String updateResult = mvcResult.getResponse().getContentAsString();
         UserDTO updatedUserDTO = mapper.readValue(updateResult, UserDTO.class);
 
-        assertEquals(updatedUserDTO.getEnabled(), false);
+        assertEquals(false, updatedUserDTO.getEnabled());
     }
 
     @Test
@@ -351,28 +352,28 @@ public class AdminAPIUserTests {
     @Test
     public void getUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(ENABLE_DISABLE_USER, "Z0000",true);
+        setupUser(ENABLE_DISABLE_USER, true);
 
         MvcResult mvcResult = this.mockMvc.perform(
-                get(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER)
+                get(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_CONTRACT)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        assertEquals(mvcResult.getResponse().getStatus(), 200);
+        assertEquals(200, mvcResult.getResponse().getStatus());
 
         ObjectMapper mapper = new ObjectMapper();
 
         String getResult = mvcResult.getResponse().getContentAsString();
         UserDTO userDTO = mapper.readValue(getResult, UserDTO.class);
 
-        assertEquals(userDTO.getEmail(), TEST_USER);
-        assertEquals(userDTO.getUsername(), ENABLE_DISABLE_USER);
-        assertEquals(userDTO.getFirstName(), "test");
-        assertEquals(userDTO.getLastName(), "user");
-        assertEquals(userDTO.getEnabled(), true);
+        assertEquals(TEST_USER, userDTO.getEmail());
+        assertEquals(ENABLE_DISABLE_USER, userDTO.getUsername());
+        assertEquals("test", userDTO.getFirstName());
+        assertEquals("user", userDTO.getLastName());
+        assertEquals(true, userDTO.getEnabled());
         ContractDTO contractDTO = userDTO.getContract();
-        assertEquals(contractDTO.getContractNumber(), "Z0000");
+        assertEquals(ENABLE_DISABLE_CONTRACT, contractDTO.getContractNumber());
         assertEquals("Test Contract Z0000", contractDTO.getContractName());
         assertNotNull(contractDTO.getAttestedOn());
     }
@@ -385,11 +386,11 @@ public class AdminAPIUserTests {
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        assertEquals(mvcResult.getResponse().getStatus(), 404);
+        assertEquals(404, mvcResult.getResponse().getStatus());
     }
 
-    private void setupUser(String username, String contractNumber, boolean enabled) {
-        Contract contract = dataSetup.setupContract(contractNumber);
+    private void setupUser(String username, boolean enabled) {
+        Contract contract = dataSetup.setupContract(ENABLE_DISABLE_CONTRACT);
         User user = new User();
         user.setUsername(username);
         user.setEmail(TEST_USER);

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIUserTests.java
@@ -96,7 +96,7 @@ public class AdminAPIUserTests {
         userDTO.setEnabled(true);
         userDTO.setFirstName("Test");
         userDTO.setLastName("User");
-        userDTO.setContract(buildContractDTO());
+        userDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         userDTO.setRole(ADMIN_ROLE);
         Role role = roleService.findRoleByName(ADMIN_ROLE);
         userDTO.setRole(role.getName());
@@ -131,7 +131,7 @@ public class AdminAPIUserTests {
         userDTO.setEnabled(true);
         userDTO.setFirstName("Test");
         userDTO.setLastName("User");
-        userDTO.setContract(buildContractDTO());
+        userDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         Role role = roleService.findRoleByName(ATTESTOR_ROLE);
         userDTO.setRole(role.getName());
 
@@ -165,7 +165,7 @@ public class AdminAPIUserTests {
         userDTO.setEnabled(true);
         userDTO.setFirstName("Test");
         userDTO.setLastName("User");
-        userDTO.setContract(buildContractDTO());
+        userDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         userDTO.setRole(ADMIN_ROLE);
         Role role = roleService.findRoleByName(ADMIN_ROLE);
         userDTO.setRole(role.getName());
@@ -201,7 +201,7 @@ public class AdminAPIUserTests {
         userDTO.setEnabled(true);
         userDTO.setFirstName("Test");
         userDTO.setLastName("User");
-        userDTO.setContract(buildContractDTO());
+        userDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         userDTO.setRole(ADMIN_ROLE);
 
         ObjectMapper mapper = new ObjectMapper();
@@ -261,58 +261,23 @@ public class AdminAPIUserTests {
         userDTO.setEnabled(true);
         userDTO.setFirstName("Test");
         userDTO.setLastName("User");
-        userDTO.setContract(buildContractDTO());
+        userDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         userDTO.setRole(SPONSOR_ROLE);
 
         return userDTO;
     }
 
     @Test
-    public void testCreateUsersJobOnAdminBehalf() throws Exception {
-        UserDTO userDTO = createUser();
-
-        ObjectMapper mapper = new ObjectMapper();
-
-        this.mockMvc.perform(
-                post(API_PREFIX + ADMIN_PREFIX + USER_URL)
-                        .contentType(MediaType.APPLICATION_JSON).content(mapper.writeValueAsString(userDTO))
-                        .header("Authorization", "Bearer " + token));
-
-        MvcResult mvcResult = this.mockMvc.perform(
-                post(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + userDTO.getUsername() + "/job")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + token))
-                .andReturn();
-
-        assertEquals(mvcResult.getResponse().getStatus(), 202);
-
-        String header = mvcResult.getResponse().getHeader("Content-Location");
-
-        Job job = jobRepository.findByJobUuid(header.substring(header.indexOf("/Job/") + 5, header.indexOf("/$status")));
-        dataSetup.queueForCleanup(job);
-        User jobUser = job.getUser();
-        dataSetup.queueForCleanup(jobUser);
-        assertEquals(jobUser.getUsername(), userDTO.getUsername());
-    }
-
-    @Test
     public void testCreateUsersJobByContractOnAdminBehalf() throws Exception {
-        UserDTO userDTO = createUser();
-
-        ObjectMapper mapper = new ObjectMapper();
-
-        this.mockMvc.perform(
-                post(API_PREFIX + ADMIN_PREFIX + USER_URL)
-                        .contentType(MediaType.APPLICATION_JSON).content(mapper.writeValueAsString(userDTO))
-                        .header("Authorization", "Bearer " + token));
+        setupUser("regularUser", "Z0000", true);
 
         MvcResult mvcResult = this.mockMvc.perform(
-                post(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + userDTO.getUsername() + "/job/ABC123")
+                post(API_PREFIX + ADMIN_PREFIX + "/job/Z0000")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + token))
                 .andReturn();
 
-        assertEquals(mvcResult.getResponse().getStatus(), 202);
+        assertEquals(202, mvcResult.getResponse().getStatus());
 
         String header = mvcResult.getResponse().getHeader("Content-Location");
 
@@ -320,13 +285,13 @@ public class AdminAPIUserTests {
         User jobUser = job.getUser();
         dataSetup.queueForCleanup(jobUser);
         dataSetup.queueForCleanup(job);
-        assertEquals(jobUser.getUsername(), userDTO.getUsername());
+        assertEquals("regularUser", jobUser.getUsername());
     }
 
     @Test
     public void enableUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(false);
+        setupUser(ENABLE_DISABLE_USER,"Z0000",false);
 
         MvcResult mvcResult = this.mockMvc.perform(
                 put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER + "/enable")
@@ -356,7 +321,7 @@ public class AdminAPIUserTests {
     @Test
     public void disableUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(true);
+        setupUser(ENABLE_DISABLE_USER,"Z0000",true);
 
         MvcResult mvcResult = this.mockMvc.perform(
                 put(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER + "/disable")
@@ -386,7 +351,7 @@ public class AdminAPIUserTests {
     @Test
     public void getUser() throws Exception {
         // Ensure user is in right state first
-        setupUser(true);
+        setupUser(ENABLE_DISABLE_USER, "Z0000",true);
 
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX + ADMIN_PREFIX + USER_URL + "/" + ENABLE_DISABLE_USER)
@@ -423,10 +388,10 @@ public class AdminAPIUserTests {
         assertEquals(mvcResult.getResponse().getStatus(), 404);
     }
 
-    private void setupUser(boolean enabled) {
-        Contract contract = dataSetup.setupContract("Z0000");
+    private void setupUser(String username, String contractNumber, boolean enabled) {
+        Contract contract = dataSetup.setupContract(contractNumber);
         User user = new User();
-        user.setUsername(ENABLE_DISABLE_USER);
+        user.setUsername(username);
         user.setEmail(TEST_USER);
         user.setFirstName("test");
         user.setLastName("user");
@@ -437,7 +402,7 @@ public class AdminAPIUserTests {
         dataSetup.queueForCleanup(savedUser);
     }
 
-    private ContractDTO buildContractDTO() {
+    private ContractDTO buildContractDTO(String contractNumber) {
 
         ContractDTO contractDTO = new ContractDTO();
         contractDTO.setContractNumber(VALID_CONTRACT_NUMBER);

--- a/common/src/main/java/gov/cms/ab2d/common/repository/UserRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/UserRepository.java
@@ -2,12 +2,19 @@ package gov.cms.ab2d.common.repository;
 
 import gov.cms.ab2d.common.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Nullable
     User findByUsername(@Nullable String username);
+
+    @Query("SELECT u FROM User u WHERE u.contract.contractNumber = :contractNumber")
+    Optional<User> findByContract(@NonNull String contractNumber);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/UserRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,5 +16,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByUsername(@Nullable String username);
 
     @Query("SELECT u FROM User u WHERE u.contract.contractNumber = :contractNumber")
-    Optional<User> findByContract(@NonNull String contractNumber);
+    List<User> findByContract(@NonNull String contractNumber);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/UserService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/UserService.java
@@ -23,9 +23,9 @@ public interface UserService {
 
     List<GrantedAuthority> getGrantedAuth(User user);
 
-    UserDTO enableUser(String username);
+    UserDTO enableUser(String contractNumber);
 
-    UserDTO disableUser(String username);
+    UserDTO disableUser(String contractNumber);
 
-    UserDTO getUser(String username);
+    UserDTO getUser(String contractNumber);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Transactional
 @Service
@@ -75,10 +76,20 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void setupUserImpersonation(String username, HttpServletRequest request) {
-        User user = getUserByUsername(username);
-        log.info("Admin user is impersonating user {}", username);
+    public void setupUserImpersonation(String contractNumber, HttpServletRequest request) {
+        User user = getUserByContract(contractNumber);
+        log.info("Admin user is impersonating user {}", user.getUsername());
         setupUserAndRolesInSecurityContext(user, request);
+    }
+
+    private User getUserByContract(String contractNumber) {
+        Optional<User> user = userRepository.findByContract(contractNumber);
+
+        return user.orElseThrow(() -> {
+            String userNotPresentMsg = "User is not present in our database";
+            log.error(userNotPresentMsg);
+            throw new ResourceNotFoundException(userNotPresentMsg);
+        });
     }
 
     @Override

--- a/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
@@ -189,9 +189,9 @@ class UserServiceTest {
         UserDTO createdUser = userService.createUser(user);
         dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
-        String username = createdUser.getUsername();
+        String contractNumber = createdUser.getContract().getContractNumber();
 
-        userService.setupUserImpersonation(username, httpServletRequest);
+        userService.setupUserImpersonation(contractNumber, httpServletRequest);
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         assertEquals("test@test.com", authentication.getPrincipal());

--- a/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/UserServiceTest.java
@@ -216,7 +216,7 @@ class UserServiceTest {
         userService.createUser(user);
         dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
-        UserDTO updatedUser = userService.enableUser(user.getUsername());
+        UserDTO updatedUser = userService.enableUser(user.getContract().getContractNumber());
         assertEquals(true, updatedUser.getEnabled());
     }
 
@@ -226,7 +226,7 @@ class UserServiceTest {
         userService.createUser(user);
         dataSetup.queueForCleanup(userService.getUserByUsername("test@test.com"));
 
-        UserDTO updatedUser = userService.disableUser(user.getUsername());
+        UserDTO updatedUser = userService.disableUser(user.getContract().getContractNumber());
         assertEquals(false, updatedUser.getEnabled());
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3032](https://jira.cms.gov/browse/AB2D-3032) - Admin API Endpoints
 
### What Does This PR Do?

Change the Admin endpoints to stop using okta client ids and start using only contract numbers for starting jobs.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure