### PR TITLE
Bug fix, only compute delta when a previous search has elements.

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -180,7 +180,6 @@ public class CoverageServiceImpl implements CoverageService {
 
         int previousCount = 0;
         if (previousSearch.isPresent()) {
-            coverageDeltaRepository.trackDeltas(previousSearch.get(), current);
             previousCount = coverageServiceRepo.countBySearchEvent(previousSearch.get());
         }
 
@@ -188,6 +187,7 @@ public class CoverageServiceImpl implements CoverageService {
 
         int unchanged = 0;
         if (previousCount > 0) {
+            coverageDeltaRepository.trackDeltas(previousSearch.get(), current);
             unchanged = coverageServiceRepo.countIntersection(previousSearch.get(), current);
         }
 


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2976](https://jira.cms.gov/browse/AB2D-2976) - Description

***Related Tickets***
 
### What Does This PR Do?
Computes delta only if the previous search had actual data.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure