### PR TITLE
ignore default slack webhook url

### DIFF
--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLogger.java
@@ -38,6 +38,13 @@ public class SlackLogger {
         this.slackTraceWebhooks = slackTraceWebhooks.stream().filter(StringUtils::isNotBlank)
                 .map(String::trim).collect(toList());
         this.appEnv = appEnv;
+
+        filterAlerts();
+    }
+
+    private void filterAlerts() {
+        slackAlertWebhooks.removeIf(url -> url.equalsIgnoreCase("na"));
+        slackTraceWebhooks.removeIf(url -> url.equalsIgnoreCase("na"));
     }
 
     /**

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class SlackLoggerTest {
+class SlackLoggerTest {
 
     private final Slack slack = mock(Slack.class);
 
@@ -79,5 +79,20 @@ public class SlackLoggerTest {
 
         assertFalse(slackLogger.logAlert("oops"));
         assertFalse(slackLogger.logTrace("oops"));
+    }
+
+    @DisplayName("SlackLogger ignores default url 'na'")
+    @Test
+    void slackLoggerIgnoresDefaultUrl() throws IOException {
+
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("NA", "Na", "nA", "\t\tNA", "   NA\n"),
+                List.of("NA", "Na", "nA", "\t\tNA", "   NA\n"), "testing");
+
+        when(slack.send(anyString(), any(Payload.class))).thenThrow(IOException.class);
+
+        assertTrue(slackLogger.logAlert("testing"));
+        assertTrue(slackLogger.logTrace("testing"));
+
+        verify(slack, times(0)).send(anyString(), any(Payload.class));
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3099](https://jira.cms.gov/browse/AB2D-3099) - Escape Slack Webhook
 
### What Does This PR Do?

Terraform is causing problems because it won't accept empty values for input so we need to set a default value that is ignored.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure