### PR TITLE
Feature/ab2d 3143 missing environment on alerts

### DIFF
--- a/Deploy/terraform/environments/ab2d-dev/main.tf
+++ b/Deploy/terraform/environments/ab2d-dev/main.tf
@@ -141,7 +141,7 @@ module "efs" {
 module "api" {
   source                            = "../../modules/api"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-dev"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id

--- a/Deploy/terraform/environments/ab2d-dev/main.tf
+++ b/Deploy/terraform/environments/ab2d-dev/main.tf
@@ -206,7 +206,7 @@ module "api" {
 module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-dev"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/environments/ab2d-east-impl/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-impl/main.tf
@@ -206,7 +206,7 @@ module "api" {
 module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-east-impl"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/environments/ab2d-east-impl/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-impl/main.tf
@@ -141,7 +141,7 @@ module "efs" {
 module "api" {
   source                            = "../../modules/api"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-east-impl"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id

--- a/Deploy/terraform/environments/ab2d-east-prod-test/worker/worker.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod-test/worker/worker.tf
@@ -56,7 +56,7 @@ module "worker" {
   efs_id                            = data.terraform_remote_state.core.outputs.efs_id
   efs_security_group_id             = data.terraform_remote_state.core.outputs.efs_sg_id
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-east-prod-test"
   gold_disk_name                    = var.gold_image_name
   hicn_hash_iter                    = var.hicn_hash_iter
   hicn_hash_pepper                  = var.hicn_hash_pepper

--- a/Deploy/terraform/environments/ab2d-east-prod/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod/main.tf
@@ -208,7 +208,8 @@ module "api" {
 module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-east-prod"
+//  bfd_insights                      = "true" enable when bfd insights is implemented
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/environments/ab2d-east-prod/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod/main.tf
@@ -143,7 +143,8 @@ module "efs" {
 module "api" {
   source                            = "../../modules/api"
   env                               = var.env
-  execution_env                     = "local" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-east-prod"
+//  bfd_insights                      = "true" enable when bfd insights is implemented
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id

--- a/Deploy/terraform/environments/ab2d-east-prod/main.tf
+++ b/Deploy/terraform/environments/ab2d-east-prod/main.tf
@@ -144,7 +144,7 @@ module "api" {
   source                            = "../../modules/api"
   env                               = var.env
   execution_env                     = "ab2d-east-prod"
-//  bfd_insights                      = "true" enable when bfd insights is implemented
+//  bfd_insights                      = "send_events" enable when bfd insights is implemented
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id
@@ -210,7 +210,7 @@ module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
   execution_env                     = "ab2d-east-prod"
-//  bfd_insights                      = "true" enable when bfd insights is implemented
+//  bfd_insights                      = "send_events" enable when bfd insights is implemented
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
+++ b/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
@@ -142,6 +142,7 @@ module "api" {
   source                            = "../../modules/api"
   env                               = var.env
   execution_env                     = "ab2d-sbx-sandbox" # set to 'local' to turn off BFD insights
+  bfd_insights                      = "true"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id

--- a/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
+++ b/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
@@ -142,7 +142,7 @@ module "api" {
   source                            = "../../modules/api"
   env                               = var.env
   execution_env                     = "ab2d-sbx-sandbox" # set to 'local' to turn off BFD insights
-  bfd_insights                      = "true"
+  bfd_insights                      = "send_events"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_sec_group_id           = data.aws_security_group.ab2d_deployment_controller_sg.id
@@ -208,7 +208,7 @@ module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
   execution_env                     = "ab2d-sbx-sandbox"
-  bfd_insights                      = "true"
+  bfd_insights                      = "send_events"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
+++ b/Deploy/terraform/environments/ab2d-sbx-sandbox/main.tf
@@ -207,7 +207,8 @@ module "api" {
 module "worker" {
   source                            = "../../modules/worker"
   env                               = var.env
-  execution_env                     = "ab2d-sbx-sandbox" # set to 'local' to turn off BFD insights
+  execution_env                     = "ab2d-sbx-sandbox"
+  bfd_insights                      = "true"
   vpc_id                            = var.vpc_id
   db_sec_group_id                   = data.aws_security_group.ab2d_database_sg.id
   controller_subnet_ids             = var.deployment_controller_subnet_ids

--- a/Deploy/terraform/modules/api/main.tf
+++ b/Deploy/terraform/modules/api/main.tf
@@ -180,10 +180,14 @@ resource "aws_ecs_task_definition" "api" {
 	  "name" : "AB2D_EFS_MOUNT",
 	  "value" : "/mnt/efs"
 	},
-        {
+    {
 	  "name" : "AB2D_EXECUTION_ENV",
 	  "value" : "${lower(var.execution_env)}"
 	},
+    {
+       "name" : "AB2D_BFD_INSIGHTS",
+       "value" : "${lower(var.bfd_insights)}"
+    },
         {
 	  "name" : "AB2D_DB_SSL_MODE",
 	  "value" : "require"

--- a/Deploy/terraform/modules/api/variables.tf
+++ b/Deploy/terraform/modules/api/variables.tf
@@ -1,6 +1,6 @@
 variable "env" {}
 variable "execution_env" { default = "local" }
-variable "bfd_insights" { default = "false" }
+variable "bfd_insights" { default = "none" }
 variable "aws_account_number" {}
 variable "vpc_id" {}
 variable "db_sec_group_id" {}

--- a/Deploy/terraform/modules/api/variables.tf
+++ b/Deploy/terraform/modules/api/variables.tf
@@ -1,5 +1,6 @@
 variable "env" {}
-variable "execution_env" {}
+variable "execution_env" { default = "local" }
+variable "bfd_insights" { default = "false" }
 variable "aws_account_number" {}
 variable "vpc_id" {}
 variable "db_sec_group_id" {}

--- a/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
@@ -3,6 +3,7 @@ variable "ami_id" {}
 variable "autoscale_group_wait" {}
 variable "aws_account_number" {}
 variable "beta" {}
+variable "bfd_insights" { default = "false" }
 variable "bfd_keystore_file_name" {} # Used in userdata.tpl
 variable "bfd_keystore_location" {}
 variable "bfd_keystore_password" {}
@@ -24,7 +25,7 @@ variable "efs_dns_name" {}
 variable "efs_id" {}
 variable "efs_security_group_id" {}
 variable "env" {}
-variable "execution_env" {}
+variable "execution_env" { default = "false" }
 variable "gold_disk_name" {}
 variable "hicn_hash_iter" {}
 variable "hicn_hash_pepper" {}

--- a/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/input.tf
@@ -3,7 +3,7 @@ variable "ami_id" {}
 variable "autoscale_group_wait" {}
 variable "aws_account_number" {}
 variable "beta" {}
-variable "bfd_insights" { default = "false" }
+variable "bfd_insights" { default = "none" }
 variable "bfd_keystore_file_name" {} # Used in userdata.tpl
 variable "bfd_keystore_location" {}
 variable "bfd_keystore_password" {}
@@ -25,7 +25,7 @@ variable "efs_dns_name" {}
 variable "efs_id" {}
 variable "efs_security_group_id" {}
 variable "env" {}
-variable "execution_env" { default = "false" }
+variable "execution_env" { default = "local" }
 variable "gold_disk_name" {}
 variable "hicn_hash_iter" {}
 variable "hicn_hash_pepper" {}

--- a/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
@@ -129,7 +129,10 @@ resource "aws_ecs_task_definition" "worker" {
           "value" : "${lower(var.execution_env)}"
         },
         {
-          "name" : "AB2D_DB_SSL_MODE",
+          "name" : "BFD
+        },
+	    {
+	      "name" : "AB2D_DB_SSL_MODE",
           "value" : "require"
         },
         {

--- a/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
+++ b/Deploy/terraform/modules/terraservices_pattern/worker/worker.tf
@@ -129,7 +129,8 @@ resource "aws_ecs_task_definition" "worker" {
           "value" : "${lower(var.execution_env)}"
         },
         {
-          "name" : "BFD
+          "name" : "AB2D_BFD_INSIGHTS",
+          "value": "${lower(var.bfd_insights)}"
         },
 	    {
 	      "name" : "AB2D_DB_SSL_MODE",

--- a/Deploy/terraform/modules/worker/main.tf
+++ b/Deploy/terraform/modules/worker/main.tf
@@ -122,10 +122,14 @@ resource "aws_ecs_task_definition" "worker" {
 	  "name" : "AB2D_EFS_MOUNT",
 	  "value" : "/mnt/efs"
 	},
-	{
+    {
 	  "name" : "AB2D_EXECUTION_ENV",
 	  "value" : "${lower(var.execution_env)}"
 	},
+    {
+       "name" : "AB2D_BFD_INSIGHTS",
+       "value" : "${lower(var.bfd_insights)}"
+    },
 	{
 	  "name" : "AB2D_DB_SSL_MODE",
 	  "value" : "require"

--- a/Deploy/terraform/modules/worker/variables.tf
+++ b/Deploy/terraform/modules/worker/variables.tf
@@ -1,6 +1,6 @@
 variable "env" {}
 variable "execution_env" { default = "local" }
-variable "bfd_insights" { default = "false" }
+variable "bfd_insights" { default = "none" }
 variable "aws_account_number" {}
 variable "vpc_id" {}
 variable "db_sec_group_id" {}

--- a/Deploy/terraform/modules/worker/variables.tf
+++ b/Deploy/terraform/modules/worker/variables.tf
@@ -1,5 +1,6 @@
 variable "env" {}
-variable "execution_env" {}
+variable "execution_env" { default = "local" }
+variable "bfd_insights" { default = "false" }
 variable "aws_account_number" {}
 variable "vpc_id" {}
 variable "db_sec_group_id" {}

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
@@ -22,12 +22,12 @@ public class KinesisEventLogger implements EventLogger {
     private final KinesisConfig config;
     private final AmazonKinesisFirehose client;
     private final String appEnv;
-    private final boolean kinesisEnabled;
+    private final KinesisMode kinesisEnabled;
     private final String streamId;
 
     public KinesisEventLogger(KinesisConfig config, AmazonKinesisFirehose client,
                               @Value("${execution.env}") String appEnv,
-                              @Value("${eventlogger.kinesis.enabled}") boolean kinesisEnabled,
+                              @Value("${eventlogger.kinesis.enabled}") KinesisMode kinesisEnabled,
                               @Value("${eventlogger.kinesis.stream.prefix:}") String streamId) {
         this.config = config;
         this.client = client;
@@ -45,12 +45,7 @@ public class KinesisEventLogger implements EventLogger {
         event.setEnvironment(appEnv);
 
         // If kinesis is disabled then return immediately
-        if (!kinesisEnabled) {
-            return;
-        }
-
-        // If the environment is a testing environment do not log
-        if (appEnv == null || appEnv.equalsIgnoreCase("local")) {
+        if (kinesisEnabled == KinesisMode.NONE) {
             return;
         }
 

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventProcessor.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventProcessor.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.kinesisfirehose.model.PutRecordRequest;
 import com.amazonaws.services.kinesisfirehose.model.PutRecordResult;
 import com.amazonaws.services.kinesisfirehose.model.Record;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.codehaus.jettison.json.JSONObject;
@@ -26,17 +27,12 @@ import java.util.stream.Collectors;
 
 import static gov.cms.ab2d.eventlogger.utils.UtilMethods.camelCaseToUnderscore;
 
+@AllArgsConstructor
 @Slf4j
 public class KinesisEventProcessor implements Callable<Void> {
+    private final LoggableEvent event;
     private final AmazonKinesisFirehose client;
     private final String streamId;
-    private final LoggableEvent event;
-
-    public KinesisEventProcessor(LoggableEvent event, AmazonKinesisFirehose client, String streamPrefix) {
-        this.client = client;
-        this.streamId = streamPrefix;
-        this.event = event;
-    }
 
     /**
      * Convert an event to a JSON string doing the following:

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisMode.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisMode.java
@@ -1,0 +1,6 @@
+package gov.cms.ab2d.eventlogger.eventloggers.kinesis;
+
+public enum KinesisMode {
+    NONE,
+    SEND_EVENTS
+}

--- a/eventlogger/src/main/resources/application.eventlogger.properties
+++ b/eventlogger/src/main/resources/application.eventlogger.properties
@@ -4,4 +4,4 @@ execution.env=${AB2D_EXECUTION_ENV:#{'local'}}
 slack.alert.webhooks=${AB2D_SLACK_ALERT_WEBHOOKS:#{''}}
 slack.trace.webhooks=${AB2D_SLACK_TRACE_WEBHOOKS:#{''}}
 
-eventlogger.kinesis.enabled=${AB2D_BFD_INSIGHTS:#{false}}
+eventlogger.kinesis.enabled=${AB2D_BFD_INSIGHTS:#{'NONE'}}

--- a/eventlogger/src/main/resources/application.eventlogger.properties
+++ b/eventlogger/src/main/resources/application.eventlogger.properties
@@ -4,3 +4,4 @@ execution.env=${AB2D_EXECUTION_ENV:#{'local'}}
 slack.alert.webhooks=${AB2D_SLACK_ALERT_WEBHOOKS:#{''}}
 slack.trace.webhooks=${AB2D_SLACK_TRACE_WEBHOOKS:#{''}}
 
+eventlogger.kinesis.enabled=${AB2D_BFD_INSIGHTS:#{false}}

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -39,6 +40,15 @@ class KinesisEventLoggerTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
+    @Value("${execution.env}")
+    private String appEnv;
+
+    @Value("${eventlogger.kinesis.enabled}")
+    private boolean kinesisEnabled;
+
+    @Value("${eventlogger.kinesis.stream.prefix:}")
+    private String streamId;
+
     @Autowired
     private KinesisConfig config;
 
@@ -49,7 +59,7 @@ class KinesisEventLoggerTest {
 
     @BeforeEach
     void init() {
-        logger = new KinesisEventLogger(config, firehose, "dev", "");
+        logger = new KinesisEventLogger(config, firehose, appEnv, kinesisEnabled, streamId);
         ReflectionTestUtils.setField(logger, "appEnv", "dev");
         doReturn(generateRandomResult()).when(firehose).putRecord(any());
     }

--- a/eventlogger/src/test/resources/application.properties
+++ b/eventlogger/src/test/resources/application.properties
@@ -17,7 +17,7 @@ logging.level.liquibase=ERROR
 
 execution.env=${AB2D_EXECUTION_ENV:#{'dev'}}
 # Default to true for testing
-eventlogger.kinesis.enabled=true
+eventlogger.kinesis.enabled=send_events
 
 slack.alert.webhooks=${AB2D_SLACK_ALERT_WEBHOOKS:#{''}}
 slack.trace.webhooks=${AB2D_SLACK_TRACE_WEBHOOKS:#{''}}

--- a/eventlogger/src/test/resources/application.properties
+++ b/eventlogger/src/test/resources/application.properties
@@ -16,6 +16,8 @@ efs.mount=${java.io.tmpdir}/jobdownloads/
 logging.level.liquibase=ERROR
 
 execution.env=${AB2D_EXECUTION_ENV:#{'dev'}}
+# Default to true for testing
+eventlogger.kinesis.enabled=true
 
 slack.alert.webhooks=${AB2D_SLACK_ALERT_WEBHOOKS:#{''}}
 slack.trace.webhooks=${AB2D_SLACK_TRACE_WEBHOOKS:#{''}}


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3143](https://jira.cms.gov/browse/AB2D-3143) - Missing AB2D Environment on Slack Alerts
 
### What Does This PR Do?

Get rid of overloading the AB2D_EXECUTION_ENV variable with both enabling/disabling Kinesis and stating the environment for alerting systems.

* Created new variable AB2D_BFD_INSIGHTS as a toggle for Kinesis event logging.
* Added AB2D_BFD_INSIGHTS to Terraform
* Changed AB2D_EXECUTION_ENV to actual environment name in Terraform
* Changed both variables to have default values (AB2D_EXECUTION_ENV defaults to "local" and AB2D_BFD_INSIGHTS defaults to "false")

### What Should Reviewers Watch For?

* An incomplete Terraform configuration
* Any cases where the value of the toggle could lead to attempting to stream events when it shouldn't be enabled.
* Whether the names of each environment are the expected values in Terraform

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure