### PR TITLE
add sql to remove all disabled users and manually added nonokta users

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -96,3 +96,5 @@ databaseChangeLog:
       file: db/changelog/v2021/add_fhir_version.sql
   - include:
       file: db/changelog/v2021/add_coverage_search_props.sql
+  - include:
+      file: db/changelog/v2021/remove_extra_users.sql

--- a/common/src/main/resources/db/changelog/v2021/remove_extra_users.sql
+++ b/common/src/main/resources/db/changelog/v2021/remove_extra_users.sql
@@ -1,0 +1,30 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+--changeset wnyffenegger:remove_extra_users failOnError:true
+
+DELETE FROM user_role
+WHERE user_account_id IN (
+    SELECT id FROM user_account WHERE enabled = false
+);
+
+DELETE FROM user_account
+WHERE enabled = false;
+
+DELETE FROM user_role
+WHERE user_account_id IN (
+        SELECT id FROM user_account WHERE username IN (
+            '832hfwef93hfkkf3hhhh', '9fhselhffhf93jhflshh', '39fhklsfzxmneu32feff',
+            'bvk329df23fhjfsdjkef', 'vdbewfjzjhfew93fh3hh', 'zvhjefio239fhiew2fff',
+            'vxcliwefnl239f03f2jf', 'vzdhwfehj3249fwejkfh', 'vznkweicln349fn32rjj',
+            'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl'
+        )
+);
+
+DELETE FROM user_account
+WHERE username IN (
+   '832hfwef93hfkkf3hhhh', '9fhselhffhf93jhflshh', '39fhklsfzxmneu32feff',
+   'bvk329df23fhjfsdjkef', 'vdbewfjzjhfew93fh3hh', 'zvhjefio239fhiew2fff',
+   'vxcliwefnl239f03f2jf', 'vzdhwfehj3249fwejkfh', 'vznkweicln349fn32rjj',
+   'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl'
+);

--- a/common/src/main/resources/db/changelog/v2021/remove_extra_users.sql
+++ b/common/src/main/resources/db/changelog/v2021/remove_extra_users.sql
@@ -17,7 +17,9 @@ WHERE user_account_id IN (
             '832hfwef93hfkkf3hhhh', '9fhselhffhf93jhflshh', '39fhklsfzxmneu32feff',
             'bvk329df23fhjfsdjkef', 'vdbewfjzjhfew93fh3hh', 'zvhjefio239fhiew2fff',
             'vxcliwefnl239f03f2jf', 'vzdhwfehj3249fwejkfh', 'vznkweicln349fn32rjj',
-            'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl'
+            'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl', '0oa2t7wfhvB2qSqPg297',
+            '0oa2t7wdgfB2qSRTg397', '0ca27wdgfKefjefTg534', '0ca27wcvnxkjjefTg334',
+            '0ca27w535jfejefTg124', '0ca902fhewffhhhwg144', '039fuewmn44fhhhwg144'
         )
 );
 
@@ -26,5 +28,7 @@ WHERE username IN (
    '832hfwef93hfkkf3hhhh', '9fhselhffhf93jhflshh', '39fhklsfzxmneu32feff',
    'bvk329df23fhjfsdjkef', 'vdbewfjzjhfew93fh3hh', 'zvhjefio239fhiew2fff',
    'vxcliwefnl239f03f2jf', 'vzdhwfehj3249fwejkfh', 'vznkweicln349fn32rjj',
-   'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl'
+   'xi43hl32sdfl3kfkljew', 'afwjil423fweohfwejkl', '0oa2t7wfhvB2qSqPg297',
+   '0oa2t7wdgfB2qSRTg397', '0ca27wdgfKefjefTg534', '0ca27wcvnxkjjefTg334',
+   '0ca27w535jfejefTg124', '0ca902fhewffhhhwg144', '039fuewmn44fhhhwg144'
 );


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-2508](https://jira.cms.gov/browse/AB2D-2508) - Remove non-okta user accounts
 
### What Does This PR Do?

Removes all users that are disabled. These users (in production and in sandbox) are not okta credentials. Any okta credential in the user_account table is currently enabled.

Removes all non-okta users manually created by liquibase for testing.

See add_multicontract_data.sql, all user accounts not beginning with a zero are not okta users.

Remove multi-contract okta users being tested in sandbox

### What Should Reviewers Watch For?

Any user_accounts that might inadvertently be deleted by the queries.

These queries have been tested as select statements in production.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure