### PR TITLE
bug/ab2d-3407 ApiRequestEvent Organization Missing

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
@@ -34,7 +34,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.SINCE;
 import static gov.cms.ab2d.api.controller.common.ApiText.TYPE_PARAM;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 
 @AllArgsConstructor
@@ -77,7 +77,7 @@ public class AdminAPI {
     @ResponseStatus(value = HttpStatus.OK)
     @PutMapping("/properties")
     public ResponseEntity<List<PropertiesDTO>> updateProperties(@RequestBody List<PropertiesDTO> propertiesDTOs) {
-        eventLogger.log(new ReloadEvent(MDC.get(CLIENT), ReloadEvent.FileType.PROPERTIES, null,
+        eventLogger.log(new ReloadEvent(MDC.get(ORGANIZATION), ReloadEvent.FileType.PROPERTIES, null,
                 propertiesDTOs.size()));
         return new ResponseEntity<>(propertiesService.updateProperties(propertiesDTOs), null, HttpStatus.OK);
     }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 
 @ControllerAdvice
@@ -105,14 +105,14 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler({JobOutputMissingException.class})
     public ResponseEntity<JsonNode> handleJobOutputMissing(Exception e, HttpServletRequest request) throws IOException {
-        eventLogger.log(new ErrorEvent(MDC.get(CLIENT), UtilMethods.parseJobId(request.getRequestURI()),
+        eventLogger.log(new ErrorEvent(MDC.get(ORGANIZATION), UtilMethods.parseJobId(request.getRequestURI()),
                 ErrorEvent.ErrorType.FILE_ALREADY_DELETED, getRootCause(e)));
         return generateFHIRError(e, request);
     }
 
     @ExceptionHandler({InvalidContractException.class})
     public ResponseEntity<Void> handleInvalidContractErrors(Exception e, HttpServletRequest request) {
-        eventLogger.log(new ErrorEvent(MDC.get(CLIENT), null,
+        eventLogger.log(new ErrorEvent(MDC.get(ORGANIZATION), null,
                 ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT, getRootCause(e)));
         return generateError(e, request);
     }
@@ -134,14 +134,14 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<JsonNode> handleTooManyRequestsExceptions(final TooManyRequestsException e, HttpServletRequest request) throws IOException {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(RETRY_AFTER, Integer.toString(retryAfterDelay));
-        eventLogger.log(new ErrorEvent(MDC.get(CLIENT), UtilMethods.parseJobId(request.getRequestURI()),
+        eventLogger.log(new ErrorEvent(MDC.get(ORGANIZATION), UtilMethods.parseJobId(request.getRequestURI()),
                 ErrorEvent.ErrorType.TOO_MANY_STATUS_REQUESTS, "Too many requests performed in too short a time"));
         return generateFHIRError(e, httpHeaders, request);
     }
 
     private ResponseEntity<Void> generateError(Exception ex, HttpServletRequest request) {
         HttpStatus status = getErrorResponse(ex.getClass());
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), null, status,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
                 "API Error", getRootCause(ex), (String) request.getAttribute(REQUEST_ID)));
         return new ResponseEntity<>(null, null, status);
     }
@@ -157,7 +157,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         FhirVersion version = FhirVersion.fromUrl(request.getRequestURI());
         IBaseResource operationOutcome = version.getErrorOutcome(msg);
         String encoded = version.outcomePrettyToJSON(operationOutcome);
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), null,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null,
                 ErrorHandler.getErrorResponse(e.getClass()),
                 "FHIR Error", msg, (String) request.getAttribute(REQUEST_ID)));
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/HealthAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/HealthAPI.java
@@ -29,7 +29,7 @@ public class HealthAPI {
         if (healthCheck.healthy()) {
             return new ResponseEntity<>(HttpStatus.OK);
         } else {
-            eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), null, HttpStatus.INTERNAL_SERVER_ERROR, "API Health NOT Ok",
+            eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.INTERNAL_SERVER_ERROR, "API Health NOT Ok",
                     null, (String) request.getAttribute(REQUEST_ID)));
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
@@ -26,7 +26,7 @@ import static gov.cms.ab2d.common.service.JobService.ZIPFORMAT;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.ZIP_SUPPORT_ON;
 import static gov.cms.ab2d.common.util.Constants.JOB_LOG;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -107,7 +107,7 @@ public class ApiCommon {
         String statusURL = getUrl(API_PREFIX_V1 + FHIR_PREFIX + "/Job/" + job.getJobUuid() + "/$status", request);
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.add(CONTENT_LOCATION, statusURL);
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), job.getJobUuid(), HttpStatus.ACCEPTED, "Job Created",
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), job.getJobUuid(), HttpStatus.ACCEPTED, "Job Created",
                 "Job " + job.getJobUuid() + " was created", requestId));
         return new ResponseEntity<>(null, responseHeaders,
                 HttpStatus.ACCEPTED);

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -19,7 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.FILE_LOG;
 import static gov.cms.ab2d.common.util.Constants.JOB_LOG;
 import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
@@ -47,7 +47,7 @@ public class FileDownloadCommon {
         try (OutputStream out = response.getOutputStream(); FileInputStream in = new FileInputStream(downloadResource.getFile())) {
             IOUtils.copy(in, out);
 
-            eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), jobUuid, HttpStatus.OK, "File Download",
+            eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), jobUuid, HttpStatus.OK, "File Download",
                     "File " + filename + " was downloaded", (String) request.getAttribute(REQUEST_ID)));
 
             jobService.deleteFileForJob(downloadResource.getFile(), jobUuid);

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static gov.cms.ab2d.api.controller.common.ApiText.X_PROG;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.JOB_LOG;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
@@ -74,7 +74,7 @@ public class StatusCommon {
             case IN_PROGRESS:
                 responseHeaders.add(X_PROG, job.getProgress() + "% complete");
                 responseHeaders.add(RETRY_AFTER, Integer.toString(retryAfterDelay));
-                eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), job.getJobUuid(), HttpStatus.ACCEPTED,
+                eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), job.getJobUuid(), HttpStatus.ACCEPTED,
                         "Job in progress", job.getProgress() + "% complete",
                         (String) request.getAttribute(REQUEST_ID)));
                 return new ResponseEntity<>(null, responseHeaders, HttpStatus.ACCEPTED);
@@ -137,7 +137,7 @@ public class StatusCommon {
         responseHeaders.add(EXPIRES, DateTimeFormatter.RFC_1123_DATE_TIME.format(jobExpiresUTC));
         final JobCompletedResponse resp = getJobCompletedResonse(job, request, apiPrefix);
         log.info("Job status completed successfully");
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), job.getJobUuid(), HttpStatus.OK,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), job.getJobUuid(), HttpStatus.OK,
                 "Job completed", null, (String) request.getAttribute(REQUEST_ID)));
         return new ResponseEntity<>(resp, responseHeaders, HttpStatus.OK);
     }
@@ -150,7 +150,7 @@ public class StatusCommon {
 
         log.info("Job successfully cancelled");
 
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), jobUuid, HttpStatus.ACCEPTED,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), jobUuid, HttpStatus.ACCEPTED,
                 "Job cancelled", null, (String) request.getAttribute(REQUEST_ID)));
 
         return new ResponseEntity<>(null, null,

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityAPIV1.java
@@ -33,7 +33,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.CAP_RET;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
@@ -63,7 +63,7 @@ public class CapabilityAPIV1 {
 
         IParser parser = STU3.getJsonParser();
 
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), null, HttpStatus.OK,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.OK,
                 CAP_STMT, CAP_RET, (String) request.getAttribute(REQUEST_ID)));
 
         String server = common.getCurrentUrl(request).replace("/metadata", "");

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityAPIV2.java
@@ -31,7 +31,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.CAP_RET;
 import static gov.cms.ab2d.api.controller.common.ApiText.CAP_STMT;
 import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
-import static gov.cms.ab2d.common.util.Constants.CLIENT;
+import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
@@ -63,7 +63,7 @@ public class CapabilityAPIV2 {
 
         IParser parser = R4.getJsonParser();
 
-        eventLogger.log(new ApiResponseEvent(MDC.get(CLIENT), null, HttpStatus.OK,
+        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.OK,
                 CAP_STMT, CAP_RET, (String) request.getAttribute(REQUEST_ID)));
 
         String server = common.getCurrentUrl(request).replace("/metadata", "");

--- a/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
@@ -121,9 +121,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             throw new BadJWTTokenException(clientBlankMsg);
         }
 
-        // Save current client
-        MDC.put(CLIENT, client);
-
         // Attempt to get client object from repository (to check whether enabled and setup roles if enabled)
         PdpClient pdpClient;
         try {
@@ -138,6 +135,9 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             logApiRequestEvent(request, token, null, jobId);
             throw new UsernameNotFoundException("Client was not found");
         }
+
+        // Save organization
+        MDC.put(ORGANIZATION, pdpClient.getOrganization());
 
         // If client is disabled for any reason do not proceed
         if (!pdpClient.getEnabled()) {

--- a/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
@@ -103,64 +103,65 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String token = null;
-        String client = null;
+        String client;
+
         try {
             token = getToken(request);
             client = getClientId(token);
         } catch (Exception ex) {
-            logApiRequestEvent(request, token, client, jobId);
+            logApiRequestEvent(request, token, null, jobId);
             throw ex;
         }
 
-        logApiRequestEvent(request, token, client, jobId);
+        if (client.isEmpty()) {
+            logApiRequestEvent(request, token, null, jobId);
 
-        if (!client.isEmpty()) {
-            MDC.put(CLIENT, client);
-            PdpClient pdpClient = getClient(client);
-
-            pdpClientService.setupClientAndRolesInSecurityContext(pdpClient, request);
-        } else {
             String clientBlankMsg = "Client id was blank";
             log.error(clientBlankMsg);
             throw new BadJWTTokenException(clientBlankMsg);
         }
 
+        // Save current client
+        MDC.put(CLIENT, client);
+
+        // Attempt to get client object from repository (to check whether enabled and setup roles if enabled)
+        PdpClient pdpClient;
+        try {
+            pdpClient = pdpClientService.getClientById(client);
+        } catch (ResourceNotFoundException exception) {
+            logApiRequestEvent(request, token, null, jobId);
+            throw new UsernameNotFoundException("Client was not found");
+        }
+
+        // If client is null then continue throwing username not found
+        if (pdpClient == null) {
+            logApiRequestEvent(request, token, null, jobId);
+            throw new UsernameNotFoundException("Client was not found");
+        }
+
+        // If client is disabled for any reason do not proceed
+        if (!pdpClient.getEnabled()) {
+            log.error("Client {} is not enabled", pdpClient.getOrganization());
+            logApiRequestEvent(request, token, pdpClient.getOrganization(), jobId);
+            throw new ClientNotEnabledException("Client " + pdpClient.getOrganization() + " is not enabled");
+        }
+
+        // Otherwise setup roles and context
+        logApiRequestEvent(request, token, pdpClient.getOrganization(), jobId);
+        pdpClientService.setupClientAndRolesInSecurityContext(pdpClient, request);
+
         // go to the next filter in the filter chain
         chain.doFilter(request, response);
     }
 
-    private void logApiRequestEvent(HttpServletRequest request, String token, String username, String jobId) {
+    private void logApiRequestEvent(HttpServletRequest request, String token, String organization, String jobId) {
         String url = UtilMethods.getURL(request);
         String uniqueId = UUID.randomUUID().toString();
-        ApiRequestEvent requestEvent = new ApiRequestEvent(username, jobId, url, UtilMethods.getIpAddress(request),
+        ApiRequestEvent requestEvent = new ApiRequestEvent(organization, jobId, url, UtilMethods.getIpAddress(request),
                 token, uniqueId);
         eventLogger.log(requestEvent);
 
         request.setAttribute(REQUEST_ID, uniqueId);
-    }
-
-    /**
-     * Given a client id, look up the client in the database
-     *
-     * @param clientId - {@link PdpClient#getClientId()} of a client
-     * @return - an {@link PdpClient} object
-     */
-    private PdpClient getClient(String clientId) {
-        PdpClient pdpClient;
-        try {
-            pdpClient = pdpClientService.getClientById(clientId);
-        } catch (ResourceNotFoundException exception) {
-            throw new UsernameNotFoundException("Client was not found");
-        }
-        if (pdpClient == null) {
-            throw new UsernameNotFoundException("Client was not found");
-        }
-
-        if (!pdpClient.getEnabled()) {
-            log.error("Client {} is not enabled", pdpClient.getOrganization());
-            throw new ClientNotEnabledException("Client " + pdpClient.getOrganization() + " is not enabled");
-        }
-        return pdpClient;
     }
 
     /**

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -46,6 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AdminAPIPdpClientTests {
 
     public static final String TEST_CLIENT = "test@test.com";
+    public static final String TEST_ORG = "PDP-TEST";
     private static final String CLIENT_URL = "/client";
     private static final String ENABLE_DISABLE_CLIENT = "enableDisableClient";
     private static final String ENABLE_DISABLE_CONTRACT = "Z0000";
@@ -94,7 +95,7 @@ public class AdminAPIPdpClientTests {
     public void testCreateClient() throws Exception {
         PdpClientDTO pdpClientDTO = new PdpClientDTO();
         pdpClientDTO.setClientId(TEST_CLIENT);
-        pdpClientDTO.setOrganization(TEST_CLIENT);
+        pdpClientDTO.setOrganization(TEST_ORG);
         pdpClientDTO.setEnabled(true);
         pdpClientDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         pdpClientDTO.setRole(ADMIN_ROLE);
@@ -124,7 +125,7 @@ public class AdminAPIPdpClientTests {
     public void testCreateClientAttestor() throws Exception {
         PdpClientDTO pdpClientDTO = new PdpClientDTO();
         pdpClientDTO.setClientId(TEST_CLIENT);
-        pdpClientDTO.setOrganization(TEST_CLIENT);
+        pdpClientDTO.setOrganization(TEST_ORG);
         pdpClientDTO.setEnabled(true);
         pdpClientDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         Role role = roleService.findRoleByName(ATTESTOR_ROLE);
@@ -184,7 +185,7 @@ public class AdminAPIPdpClientTests {
     public void testUpdateClient() throws Exception {
         PdpClientDTO pdpClientDTO = new PdpClientDTO();
         pdpClientDTO.setClientId(TEST_CLIENT);
-        pdpClientDTO.setOrganization(TEST_CLIENT);
+        pdpClientDTO.setOrganization(TEST_ORG);
         pdpClientDTO.setEnabled(true);
         pdpClientDTO.setContract(buildContractDTO(VALID_CONTRACT_NUMBER));
         pdpClientDTO.setRole(ADMIN_ROLE);
@@ -365,7 +366,7 @@ public class AdminAPIPdpClientTests {
         Contract contract = dataSetup.setupContract(ENABLE_DISABLE_CONTRACT);
         PdpClient pdpClient = new PdpClient();
         pdpClient.setClientId(clientId);
-        pdpClient.setOrganization(TEST_CLIENT);
+        pdpClient.setOrganization(TEST_ORG);
         pdpClient.setEnabled(enabled);
         pdpClient.setContract(contract);
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -271,7 +271,7 @@ public class BulkDataAccessAPIIntegrationTests {
         pdpClient.setContract(contract);
         pdpClient.setEnabled(true);
         pdpClient.setClientId("test");
-        pdpClient.setOrganization("test");
+        pdpClient.setOrganization("test-org");
         pdpClientRepository.saveAndFlush(pdpClient);
         dataSetup.queueForCleanup(pdpClient);
 
@@ -1279,7 +1279,7 @@ public class BulkDataAccessAPIIntegrationTests {
         pdpClient.setContract(contract);
         pdpClient.setEnabled(true);
         pdpClient.setClientId("test");
-        pdpClient.setOrganization("test");
+        pdpClient.setOrganization("test-org");
         pdpClientRepository.saveAndFlush(pdpClient);
         dataSetup.queueForCleanup(pdpClient);
 

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -12,7 +12,7 @@ public final class Constants {
 
     public static final String JOB_LOG = "job";
 
-    public static final String CLIENT = "client";
+    public static final String ORGANIZATION = "organization";
 
     public static final String REQUEST_ID = "RequestId";
 

--- a/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
@@ -240,7 +240,7 @@ public class DataSetup {
     private PdpClient savePdpClient(String clientId, Contract contract, List<String> clientRoles) {
         PdpClient pdpClient = new PdpClient();
         pdpClient.setClientId(clientId);
-        pdpClient.setOrganization(clientId);
+        pdpClient.setOrganization("PDP-" + clientId);
         pdpClient.setContract(contract);
         pdpClient.setEnabled(true);
         pdpClient.setMaxParallelJobs(3);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3407](https://jira.cms.gov/browse/AB2D-3407) - API Event Organization Missing
 
### What Does This PR Do?

The JwtAuthenticationFilter was logging client ids. Change switches from logging client ids to logging the organization name which is not a sensitive piece of information.

All of the API response events also were attempting to log okta client ids. This has been updated to use the organization instead of the client id.

Fortunately, the SQL and Kinesis loggers were filtering those out but the rows are null in the dev environment.

### What Should Reviewers Watch For?

Any way the authentication filter could behave differently now than before this change.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure