### PR TITLE
Reduced precision for date

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityStatementSTU3.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityStatementSTU3.java
@@ -8,6 +8,7 @@ import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.dstu3.model.Reference;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -17,11 +18,18 @@ import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 
 public class CapabilityStatementSTU3 {
     public static CapabilityStatement populateCS(String server) {
+        SimpleDateFormat sdfLess = new SimpleDateFormat("MM/dd/yyyy HH:mm");
         CapabilityStatement cs = new CapabilityStatement();
         cs.setPublisher("Centers for Medicare &amp; Medicaid Services");
         cs.setKind(CapabilityStatement.CapabilityStatementKind.INSTANCE);
         cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
-        cs.setDate(new Date());
+
+        String dt = sdfLess.format(new Date());
+        try {
+            cs.setDate(sdfLess.parse(dt));
+        } catch (ParseException e) {
+            cs.setDate(new Date());
+        }
         cs.setAcceptUnknown(CapabilityStatement.UnknownContentCode.EXTENSIONS);
         cs.setFhirVersion(FhirVersionEnum.DSTU3.getFhirVersionString());
 


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-42](https://jira.cms.gov/browse/AB2D-3493) - Reduced precision for date

### What Does This PR Do?

The date in the STU3 capability statement is so precise that tests are failing because the generated capability statement is one second off the received version. Remove the seconds precision. Still may have issue across minutes but a lot less likely.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure