### PR TITLE
Execution Env Enums and Auth Slack Alerts

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -14,8 +14,8 @@ import gov.cms.ab2d.common.service.InvalidContractException;
 import gov.cms.ab2d.common.service.InvalidJobAccessException;
 import gov.cms.ab2d.common.service.ResourceNotFoundException;
 import gov.cms.ab2d.common.service.JobOutputMissingException;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;
 import gov.cms.ab2d.eventlogger.events.ErrorEvent;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
@@ -42,7 +42,6 @@ import java.util.Map;
 
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
-import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 
 @ControllerAdvice
@@ -50,7 +49,6 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 public class ErrorHandler extends ResponseEntityExceptionHandler {
 
     private final LogManager eventLogger;
-    private final SlackLogger slackLogger;
     private final int retryAfterDelay;
 
     private static final Map<Class, HttpStatus> RESPONSE_MAP = new HashMap<>() {
@@ -76,9 +74,8 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         }
     };
 
-    public ErrorHandler(LogManager eventLogger, SlackLogger slackLogger, @Value("${api.retry-after.delay}") int retryAfterDelay) {
+    public ErrorHandler(LogManager eventLogger, @Value("${api.retry-after.delay}") int retryAfterDelay) {
         this.eventLogger = eventLogger;
-        this.slackLogger = slackLogger;
         this.retryAfterDelay = retryAfterDelay;
     }
 
@@ -121,9 +118,10 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
         eventLogger.log(new ErrorEvent(MDC.get(ORGANIZATION), null,
                 ErrorEvent.ErrorType.UNAUTHORIZED_CONTRACT, description));
-        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
-                "API Error", description, (String) request.getAttribute(REQUEST_ID)));
-        slackLogger.logAlert(description, PROD_LIST);
+
+        ApiResponseEvent responseEvent = new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
+                "API Error", description, (String) request.getAttribute(REQUEST_ID));
+        eventLogger.logAndAlert(responseEvent, Ab2dEnvironment.PROD_LIST);
 
         return new ResponseEntity<>(null, null, status);
     }
@@ -141,9 +139,9 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         String description = String.format("%s %s for request %s", ex.getClass().getSimpleName(), ex.getMessage(),
                 request.getAttribute(REQUEST_ID));
 
-        eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
-                "API Error", description, (String) request.getAttribute(REQUEST_ID)));
-        slackLogger.logAlert(description, PROD_LIST);
+        ApiResponseEvent responseEvent = new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
+                "API Error", description, (String) request.getAttribute(REQUEST_ID));
+        eventLogger.logAndAlert(responseEvent, Ab2dEnvironment.PROD_LIST);
 
         return new ResponseEntity<>(null, null, status);
     }
@@ -154,7 +152,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
         eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, status,
                 "API Error", ex.getClass().getSimpleName(), (String) request.getAttribute(REQUEST_ID)));
-        slackLogger.logTrace("Maintenance mode blocked API request " + request.getAttribute(REQUEST_ID), PROD_LIST);
+        eventLogger.trace("Maintenance mode blocked API request " + request.getAttribute(REQUEST_ID), Ab2dEnvironment.PROD_LIST);
 
         return new ResponseEntity<>(null, null, status);
     }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -14,7 +14,6 @@ import gov.cms.ab2d.common.service.InvalidContractException;
 import gov.cms.ab2d.common.service.InvalidJobAccessException;
 import gov.cms.ab2d.common.service.ResourceNotFoundException;
 import gov.cms.ab2d.common.service.JobOutputMissingException;
-import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -2,7 +2,9 @@ package gov.cms.ab2d.api.security;
 
 import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.service.PdpClientService;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,8 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.List;
+
 import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 
@@ -35,6 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
     private final CustomUserDetailsService customUserDetailsService;
     private final LogManager eventLogger;
+    private final SlackLogger slackLogger;
     private final PdpClientService pdpClientService;
 
     @Override
@@ -99,6 +104,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             // Log api response event to a database for long term analytics
             eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.resolve(status),
                     "API Error", securityException.getMessage(), (String) request.getAttribute(REQUEST_ID)));
+            slackLogger.logAlert(error, List.of(Ab2dEnvironment.PRODUCTION));
         } catch (Exception exception) {
             log.error("Could not additional logs for exception: " + exception.getCause());
         }

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -4,7 +4,6 @@ import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +22,6 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.util.List;
-
 import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 
@@ -39,7 +36,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
     private final CustomUserDetailsService customUserDetailsService;
     private final LogManager eventLogger;
-    private final SlackLogger slackLogger;
     private final PdpClientService pdpClientService;
 
     @Override
@@ -102,9 +98,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             log.warn(error);
 
             // Log api response event to a database for long term analytics
-            eventLogger.log(new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.resolve(status),
-                    "API Error", securityException.getMessage(), (String) request.getAttribute(REQUEST_ID)));
-            slackLogger.logAlert(error, List.of(Ab2dEnvironment.PRODUCTION));
+            ApiResponseEvent response = new ApiResponseEvent(MDC.get(ORGANIZATION), null, HttpStatus.resolve(status),
+                    "API Error", error, (String) request.getAttribute(REQUEST_ID));
+            eventLogger.logAndAlert(response, Ab2dEnvironment.PROD_LIST);
         } catch (Exception exception) {
             log.error("Could not additional logs for exception: " + exception.getCause());
         }

--- a/api/src/main/resources/logback-access.xml
+++ b/api/src/main/resources/logback-access.xml
@@ -9,7 +9,6 @@
                 <requestedUrl>requested_url</requestedUrl>
                 <statusCode>status_code</statusCode>
             </fieldNames>
-            <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator" />
             <requestHeaderFilter class="gov.cms.ab2d.api.log.LogstashHeaderFilter">
                 <exclude>Authorization</exclude>
             </requestHeaderFilter>

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -1,8 +1,6 @@
 <configuration>
     <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
     <root level="INFO">
         <appender-ref ref="jsonConsoleAppender"/>

--- a/common/src/main/java/gov/cms/ab2d/common/health/SlackAvailable.java
+++ b/common/src/main/java/gov/cms/ab2d/common/health/SlackAvailable.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.common.health;
 
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,6 @@ public class SlackAvailable {
     private final SlackLogger slackLogger;
 
     public boolean slackAvailable(String message) {
-        return slackLogger.logTrace(message);
+        return slackLogger.logTrace(message, Ab2dEnvironment.ALL);
     }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -45,4 +45,7 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Query("UPDATE Job j SET j.progress = :percentageCompleted WHERE j.jobUuid = :jobUuid ")
     int updatePercentageCompleted(String jobUuid, int percentageCompleted);
+
+    @Query("SELECT COUNT(j) FROM Job j WHERE j.contract = :contract AND j.status IN :statuses")
+    int countJobByContractAndStatus(Contract contract, List<JobStatus> statuses);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -85,7 +85,7 @@ public class JobServiceImpl implements JobService {
         eventLogger.log(EventUtils.getJobChangeEvent(job, JobStatus.SUBMITTED, "Job Created"));
 
         // Report client running first job in prod
-        if (clientNeverRunAJob(contract)) {
+        if (clientHasNeverCompletedJob(contract)) {
             String firstJobMessage = String.format("Organization %s is running their first job for contract %s",
                     pdpClient.getOrganization(), contract.getContractNumber());
             eventLogger.alert(firstJobMessage, PROD_LIST);
@@ -214,7 +214,7 @@ public class JobServiceImpl implements JobService {
         return jobs.size() < pdpClient.getMaxParallelJobs();
     }
 
-    private boolean clientNeverRunAJob(Contract contract) {
+    private boolean clientHasNeverCompletedJob(Contract contract) {
         int completedJobs = jobRepository.countJobByContractAndStatus(contract,
                 List.of(JobStatus.SUBMITTED, JobStatus.IN_PROGRESS, JobStatus.SUCCESSFUL));
         return completedJobs == 0;

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
-import static gov.cms.ab2d.common.model.JobStatus.FAILED;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_ROLE;
 import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -4,7 +4,6 @@ import gov.cms.ab2d.common.model.*; // NOPMD
 import gov.cms.ab2d.common.repository.JobRepository;
 
 import gov.cms.ab2d.common.util.EventUtils;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.fhir.FhirVersion;
 import gov.cms.ab2d.eventlogger.events.FileEvent;
 import gov.cms.ab2d.common.util.JobUtil;
@@ -37,20 +36,18 @@ public class JobServiceImpl implements JobService {
     private final JobRepository jobRepository;
     private final JobOutputService jobOutputService;
     private final LogManager eventLogger;
-    private final SlackLogger slackLogger;
     private final LoggerEventSummary loggerEventSummary;
     private final String fileDownloadPath;
 
     public static final String INITIAL_JOB_STATUS_MESSAGE = "0%";
 
     public JobServiceImpl(PdpClientService pdpClientService, JobRepository jobRepository, JobOutputService jobOutputService,
-                          LogManager eventLogger, SlackLogger slackLogger, LoggerEventSummary loggerEventSummary,
+                          LogManager eventLogger, LoggerEventSummary loggerEventSummary,
                           @Value("${efs.mount}") String fileDownloadPath) {
         this.pdpClientService = pdpClientService;
         this.jobRepository = jobRepository;
         this.jobOutputService = jobOutputService;
         this.eventLogger = eventLogger;
-        this.slackLogger = slackLogger;
         this.loggerEventSummary = loggerEventSummary;
         this.fileDownloadPath = fileDownloadPath;
     }
@@ -91,7 +88,7 @@ public class JobServiceImpl implements JobService {
         if (clientNeverRunAJob(contract)) {
             String firstJobMessage = String.format("Organization %s is running their first job for contract %s",
                     pdpClient.getOrganization(), contract.getContractNumber());
-            slackLogger.logAlert(firstJobMessage, PROD_LIST);
+            eventLogger.alert(firstJobMessage, PROD_LIST);
         }
         job.setContract(contract);
         job.setStatus(JobStatus.SUBMITTED);

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -109,9 +109,8 @@ class JobServiceTest {
     // Be safe and make sure nothing from another test will impact current test
     @BeforeEach
     public void setup() {
-        LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
-        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager,
-                slackLogger, loggerEventSummary, tmpJobLocation);
+        LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager, loggerEventSummary, tmpJobLocation);
         ReflectionTestUtils.setField(jobService, "fileDownloadPath", tmpJobLocation);
 
         dataSetup.setupNonStandardClient(CLIENTID, CONTRACT_NUMBER, List.of());

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -7,6 +7,7 @@ import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventSummary;
 import org.apache.commons.io.IOUtils;
@@ -46,6 +47,10 @@ import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
@@ -94,6 +99,9 @@ class JobServiceTest {
     @Mock
     private LoggerEventSummary loggerEventSummary;
 
+    @Mock
+    private SlackLogger slackLogger;
+
     @SuppressWarnings({"rawtypes", "unused"})
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
@@ -102,7 +110,8 @@ class JobServiceTest {
     @BeforeEach
     public void setup() {
         LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
-        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager, loggerEventSummary, tmpJobLocation);
+        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager,
+                slackLogger, loggerEventSummary, tmpJobLocation);
         ReflectionTestUtils.setField(jobService, "fileDownloadPath", tmpJobLocation);
 
         dataSetup.setupNonStandardClient(CLIENTID, CONTRACT_NUMBER, List.of());
@@ -174,6 +183,29 @@ class JobServiceTest {
 
         // Verify it actually got persisted in the DB
         assertEquals(job, jobRepository.findById(job.getId()).get());
+    }
+
+    @Test
+    void reportFirstJobRunForAContract() {
+        Contract contract = contractRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
+
+        Job job1 = jobService.createJob(EOB, LOCAL_HOST, contract.getContractNumber(), NDJSON_FIRE_CONTENT_TYPE, null, STU3);
+        dataSetup.queueForCleanup(job1);
+        verify(slackLogger, times(1)).logAlert(anyString(), any());
+
+        job1.setStatus(JobStatus.CANCELLED);
+        jobRepository.saveAndFlush(job1);
+
+        Job job2 = jobService.createJob(EOB, LOCAL_HOST, contract.getContractNumber(), NDJSON_FIRE_CONTENT_TYPE, null, STU3);
+        dataSetup.queueForCleanup(job2);
+        verify(slackLogger, times(2)).logAlert(anyString(), any());
+
+        job2.setStatus(JobStatus.SUCCESSFUL);
+        jobRepository.saveAndFlush(job2);
+
+        Job job3 = jobService.createJob(EOB, LOCAL_HOST, contract.getContractNumber(), NDJSON_FIRE_CONTENT_TYPE, null, STU3);
+        dataSetup.queueForCleanup(job3);
+        verify(slackLogger, times(2)).logAlert(anyString(), any());
     }
 
     @Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}"
       - NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME}"
       # LOCAL always to shut off Kinesis logging
-      - AB2D_EXECUTION_ENV=LOCAL
+      - AB2D_EXECUTION_ENV=${AB2D_EXECUTION_ENV:-local}
     ports:
       # Set port as an environment variable
       # The e2e-test forcefully sets this itself otherwise set via command line
@@ -84,7 +84,7 @@ services:
       # Location to store files within container
       - AB2D_EFS_MOUNT=/opt/ab2d
       # LOCAL always to shut off Kinesis logging
-      - AB2D_EXECUTION_ENV=LOCAL
+      - AB2D_EXECUTION_ENV=${AB2D_EXECUTION_ENV:-local}
       # BFD prod sandbox credentials and location
       - AB2D_BFD_URL=https://prod-sbx.bfd.cms.gov/v1/fhir/
       - AB2D_BFD_KEYSTORE_PASSWORD=${AB2D_BFD_KEYSTORE_PASSWORD}

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/Environment.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/Environment.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.e2etest;
 
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -11,13 +13,14 @@ import java.util.stream.Collectors;
 public enum Environment {
 
 
-    LOCAL("local-config.yml", List.of("docker-compose.yml")),
-    CI("local-config.yml", List.of("docker-compose.yml", "docker-compose.jenkins.yml")),
-    DEV("dev-config.yml", Collections.emptyList()),
-    SBX("sbx-config.yml", Collections.emptyList()),
-    IMP("imp-config.yml", Collections.emptyList()),
-    PROD("prod-config.yml", Collections.emptyList());
+    LOCAL(Ab2dEnvironment.LOCAL, "local-config.yml", List.of("docker-compose.yml")),
+    CI(Ab2dEnvironment.LOCAL, "local-config.yml", List.of("docker-compose.yml", "docker-compose.jenkins.yml")),
+    DEV(Ab2dEnvironment.DEV, "dev-config.yml", Collections.emptyList()),
+    SBX(Ab2dEnvironment.SANDBOX, "sbx-config.yml", Collections.emptyList()),
+    IMP(Ab2dEnvironment.IMPL, "imp-config.yml", Collections.emptyList()),
+    PROD(Ab2dEnvironment.PRODUCTION, "prod-config.yml", Collections.emptyList());
 
+    private final Ab2dEnvironment ab2dEnvironment;
     private final String configName;
 
     // Docker compose can actually accept a list of docker-compose yaml files
@@ -26,7 +29,8 @@ public enum Environment {
     // For more information see the documentation here: https://docs.docker.com/compose/extends/
     private final List<String> dockerComposeFiles;
 
-    Environment(String configName, List<String> dockerComposeFiles) {
+    Environment(Ab2dEnvironment ab2dEnvironment, String configName, List<String> dockerComposeFiles) {
+        this.ab2dEnvironment = ab2dEnvironment;
         this.configName = configName;
         this.dockerComposeFiles = dockerComposeFiles;
     }
@@ -49,6 +53,10 @@ public enum Environment {
         composeFiles.toArray(composeFilesArray);
 
         return composeFilesArray;
+    }
+
+    public Ab2dEnvironment getAb2dEnvironment() {
+        return ab2dEnvironment;
     }
 
     /**

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -166,6 +166,11 @@ class TestRunner {
                 .withEnv(System.getenv())
                 // Add api variable to environment to populate docker-compose port variable
                 .withEnv("API_PORT", "" + apiPort)
+                /**
+                 * Convert environment back to string that is
+                 * understandable by {@link gov.cms.ab2d.eventlogger.Ab2dEnvironment#fromName(String)} method
+                 */
+                .withEnv("AB2D_EXECUTION_ENV", environment.getAb2dEnvironment().getName())
                 .withLocalCompose(true)
                 .withScaledService("worker", 2)
                 .withScaledService("api", 1)

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/Ab2dEnvironment.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/Ab2dEnvironment.java
@@ -17,6 +17,8 @@ public enum Ab2dEnvironment {
     PRODUCTION_VALIDATION("ab2d-east-prod-test"),
     PRODUCTION("ab2d-east-prod");
 
+    public static final List<Ab2dEnvironment> ALL = List.of(LOCAL, DEV, SANDBOX, IMPL, PRODUCTION_VALIDATION, PRODUCTION);
+
     public static final List<Ab2dEnvironment> PROD_LIST = Collections.singletonList(PRODUCTION);
 
     // Name typically expected in application.eventlogger.properties config

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/Ab2dEnvironment.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/Ab2dEnvironment.java
@@ -1,0 +1,39 @@
+package gov.cms.ab2d.eventlogger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * List of environments AB2D can be deployed in.
+ *
+ * These environments can dictate logging behavior. In the local environment event logging is automatically disabled.
+ */
+public enum Ab2dEnvironment {
+    LOCAL("local"),
+    DEV("ab2d-dev"),
+    IMPL("ab2d-east-impl"),
+    SANDBOX("ab2d-sbx-sandbox"),
+    PRODUCTION_VALIDATION("ab2d-east-prod-test"),
+    PRODUCTION("ab2d-east-prod");
+
+    public static final List<Ab2dEnvironment> PROD_LIST = Collections.singletonList(PRODUCTION);
+
+    // Name typically expected in application.eventlogger.properties config
+    // or passed in as env variable during startup
+    private final String name;
+
+    Ab2dEnvironment(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Ab2dEnvironment fromName(String name) {
+        return Stream.of(Ab2dEnvironment.values())
+                .filter(env -> env.getName().equals(name)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(name + " is not a valid environment"));
+    }
+}

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/EnvironmentConfig.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/EnvironmentConfig.java
@@ -1,0 +1,19 @@
+package gov.cms.ab2d.eventlogger;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EnvironmentConfig {
+
+    /**
+     * Parse execution environment passed in during
+     * @param executionEnv string value of execution environment that must match the name of one {@link Ab2dEnvironment}
+     * @return current ab2d environment
+     */
+    @Bean
+    public Ab2dEnvironment getEnvironment(@Value("${execution.env}") String executionEnv) {
+        return Ab2dEnvironment.fromName(executionEnv);
+    }
+}

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LogManager.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LogManager.java
@@ -1,17 +1,22 @@
 package gov.cms.ab2d.eventlogger;
 
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class LogManager {
     private final SqlEventLogger sqlEventLogger;
     private final KinesisEventLogger kinesisEventLogger;
+    private final SlackLogger slackLogger;
 
-    public LogManager(SqlEventLogger sqlEventLogger, KinesisEventLogger kinesisEventLogger) {
+    public LogManager(SqlEventLogger sqlEventLogger, KinesisEventLogger kinesisEventLogger, SlackLogger slackLogger) {
         this.sqlEventLogger = sqlEventLogger;
         this.kinesisEventLogger = kinesisEventLogger;
+        this.slackLogger = slackLogger;
     }
 
     public enum LogType {
@@ -19,6 +24,10 @@ public class LogManager {
         KINESIS
     }
 
+    /**
+     * Log an event to all available event loggers without alerting
+     * @param event the event to log
+     */
     public void log(LoggableEvent event) {
         // Save to the database
         sqlEventLogger.log(event);
@@ -31,6 +40,57 @@ public class LogManager {
         sqlEventLogger.updateAwsId(event.getAwsId(), event);
     }
 
+    /**
+     * Alert AB2D team via relevant loggers
+     * @param message message to provide
+     * @param environments AB2D environments to alert on
+     */
+    public void alert(String message, List<Ab2dEnvironment> environments) {
+        slackLogger.logAlert(message, environments);
+    }
+
+    /**
+     * Alert AB2D team via relevant loggers with a low priority alert
+     * @param message message to provide
+     * @param environments AB2D environments to alert on
+     */
+    public void trace(String message, List<Ab2dEnvironment> environments) {
+        slackLogger.logTrace(message, environments);
+    }
+
+    /**
+     * Log the event and alert to relevant alert loggers only in the provided execution environments.
+     *
+     * The message published will be built using {@link LoggableEvent#asMessage()}
+     *
+     * @param event event to log an alert for.
+     * @param environments environments to log an alert for
+     */
+    public void logAndAlert(LoggableEvent event, List<Ab2dEnvironment> environments) {
+        log(event);
+
+        slackLogger.logAlert(event.asMessage(), environments);
+    }
+
+    /**
+     * Log the event and provided traces to relevant trace loggers only in the provided execution environments.
+     *
+     * The message published will be built using {@link LoggableEvent#asMessage()}
+     *
+     * @param event event to log an alert for.
+     * @param environments environments to log an alert for
+     */
+    public void logAndTrace(LoggableEvent event, List<Ab2dEnvironment> environments) {
+        log(event);
+
+        slackLogger.logTrace(event.asMessage(), environments);
+    }
+
+    /**
+     * Log an event without alerting
+     * @param type type of event logger to use
+     * @param event event to log
+     */
     public void log(LogType type, LoggableEvent event) {
         switch (type) {
             case SQL:

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LogManager.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LogManager.java
@@ -3,10 +3,12 @@ package gov.cms.ab2d.eventlogger;
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 public class LogManager {
     private final SqlEventLogger sqlEventLogger;
@@ -41,7 +43,7 @@ public class LogManager {
     }
 
     /**
-     * Alert AB2D team via relevant loggers
+     * Alert only AB2D team via relevant loggers with a high priority alert
      * @param message message to provide
      * @param environments AB2D environments to alert on
      */
@@ -50,7 +52,7 @@ public class LogManager {
     }
 
     /**
-     * Alert AB2D team via relevant loggers with a low priority alert
+     * Alert only AB2D team via relevant loggers with a low priority alert
      * @param message message to provide
      * @param environments AB2D environments to alert on
      */
@@ -69,7 +71,7 @@ public class LogManager {
     public void logAndAlert(LoggableEvent event, List<Ab2dEnvironment> environments) {
         log(event);
 
-        slackLogger.logAlert(event.asMessage(), environments);
+        slackLogger.logAlert(event, environments);
     }
 
     /**
@@ -83,7 +85,7 @@ public class LogManager {
     public void logAndTrace(LoggableEvent event, List<Ab2dEnvironment> environments) {
         log(event);
 
-        slackLogger.logTrace(event.asMessage(), environments);
+        slackLogger.logTrace(event, environments);
     }
 
     /**

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
@@ -43,6 +43,14 @@ public abstract class LoggableEvent {
         this.jobId = jobId;
     }
 
+    public void setEnvironment(Ab2dEnvironment executionEnv) {
+        this.environment = executionEnv.getName();
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
     /**
      * If you implement equals, you have to do hashCode. I gook the one created by lombok and cleaned it.
      * @return the hash code

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/LoggableEvent.java
@@ -52,6 +52,12 @@ public abstract class LoggableEvent {
     }
 
     /**
+     * Convert event to a message
+     * @return the event converted to an alert message.
+     */
+    public abstract String asMessage();
+
+    /**
      * If you implement equals, you have to do hashCode. I gook the one created by lombok and cleaned it.
      * @return the hash code
      */

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLogger.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.eventlogger.eventloggers.kinesis;
 
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.EventLogger;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import lombok.extern.slf4j.Slf4j;
@@ -21,17 +22,17 @@ public class KinesisEventLogger implements EventLogger {
 
     private final KinesisConfig config;
     private final AmazonKinesisFirehose client;
-    private final String appEnv;
+    private final Ab2dEnvironment ab2dEnvironment;
     private final KinesisMode kinesisEnabled;
     private final String streamId;
 
     public KinesisEventLogger(KinesisConfig config, AmazonKinesisFirehose client,
-                              @Value("${execution.env}") String appEnv,
+                              Ab2dEnvironment appEnv,
                               @Value("${eventlogger.kinesis.enabled}") KinesisMode kinesisEnabled,
                               @Value("${eventlogger.kinesis.stream.prefix:}") String streamId) {
         this.config = config;
         this.client = client;
-        this.appEnv = appEnv;
+        this.ab2dEnvironment = appEnv;
         this.kinesisEnabled = kinesisEnabled;
         this.streamId = streamId;
     }
@@ -42,7 +43,7 @@ public class KinesisEventLogger implements EventLogger {
     }
 
     public void log(LoggableEvent event, boolean block) {
-        event.setEnvironment(appEnv);
+        event.setEnvironment(ab2dEnvironment);
 
         // If kinesis is disabled then return immediately
         if (kinesisEnabled == KinesisMode.NONE) {

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLogger.java
@@ -48,16 +48,12 @@ public class SlackLogger {
      * Alerts are meant for the entire team and indicate an event that needs
      * to be tracked or handled immediately.
      *
-     * @param message message to log
+     * @param message alert to log
      * @return true if client successfully logged message
      */
-    public boolean logAlert(String message) {
-        return log(message, slack, ab2dEnvironment, slackAlertWebhooks);
-    }
-
     public boolean logAlert(String message, List<Ab2dEnvironment> ab2dEnvironments) {
         if (ab2dEnvironments != null && ab2dEnvironments.contains(ab2dEnvironment)) {
-            return logAlert(message);
+            return log(message, slack, ab2dEnvironment, slackAlertWebhooks);
         }
 
         return false;
@@ -69,16 +65,12 @@ public class SlackLogger {
      *
      * Traces are meant for developers.
      *
-     * @param message message to log
+     * @param message trace to log
      * @return true if all webhooks successfully received message
      */
-    public boolean logTrace(String message) {
-        return log(message, slack, ab2dEnvironment, slackTraceWebhooks);
-    }
-
     public boolean logTrace(String message, List<Ab2dEnvironment> ab2dEnvironments) {
         if (ab2dEnvironments != null && ab2dEnvironments.contains(ab2dEnvironment)) {
-            return logTrace(message);
+            return log(message, slack, ab2dEnvironment, slackTraceWebhooks);
         }
 
         return false;

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/eventloggers/sql/SqlEventLogger.java
@@ -1,10 +1,10 @@
 package gov.cms.ab2d.eventlogger.eventloggers.sql;
 
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.EventLogger;
 import gov.cms.ab2d.eventlogger.EventLoggingException;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -18,19 +18,20 @@ public class SqlEventLogger implements EventLogger {
 
     private final SqlMapperConfig mapperConfig;
     private final JdbcTemplate template;
-    private final String appEnv;
+    private final Ab2dEnvironment ab2dEnvironment;
 
     public SqlEventLogger(SqlMapperConfig mapperConfig, JdbcTemplate template,
-                          @Value("${execution.env}") String appEnv) {
+                          Ab2dEnvironment ab2dEnvironment) {
         this.mapperConfig = mapperConfig;
         this.template = template;
-        this.appEnv = appEnv;
+        this.ab2dEnvironment = ab2dEnvironment;
     }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void log(LoggableEvent event) {
-        event.setEnvironment(appEnv);
+        event.setEnvironment(ab2dEnvironment);
+
         try {
             SqlEventMapper mapper = mapperConfig.getMapper(event.getClass());
             if (mapper == null) {

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ApiRequestEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ApiRequestEvent.java
@@ -34,4 +34,9 @@ public class ApiRequestEvent extends LoggableEvent {
         }
         this.requestId = requestId;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("request to %s from %s", url, ipAddress);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ApiResponseEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ApiResponseEvent.java
@@ -34,4 +34,9 @@ public class ApiResponseEvent extends LoggableEvent {
         this.description = description;
         this.requestId = requestId;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s): %s", responseCode, description);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/BeneficiarySearchEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/BeneficiarySearchEvent.java
@@ -29,4 +29,11 @@ public class BeneficiarySearchEvent extends LoggableEvent {
         this.responseDate = endTime;
         this.beneId = beneId;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s) bene search %s response %s", getJobId(), contractNum, response);
+    }
 }
+
+

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ContractBeneSearchEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ContractBeneSearchEvent.java
@@ -32,4 +32,9 @@ public class ContractBeneSearchEvent extends LoggableEvent {
         this.numInContract = numInContract;
         this.numErrors = numErrors;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s) %s number in contract %s", getJobId(), contractNumber, numInContract);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
@@ -31,4 +31,9 @@ public class ErrorEvent extends LoggableEvent {
         this.errorType = errorType;
         this.description = description;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s): %s %s", getJobId(), errorType, description);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/FileEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/FileEvent.java
@@ -51,4 +51,9 @@ public class FileEvent extends LoggableEvent {
             return "";
         }
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s): %s %s", getJobId(), status, fileName);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/JobStatusChangeEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/JobStatusChangeEvent.java
@@ -27,4 +27,9 @@ public class JobStatusChangeEvent extends LoggableEvent {
         this.newStatus = newStatus;
         this.description = description;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s) %s -> %s %s", getJobId(), oldStatus, newStatus, description);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/JobSummaryEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/JobSummaryEvent.java
@@ -26,4 +26,9 @@ public class JobSummaryEvent extends LoggableEvent {
     private int errorSearched;
 
     public JobSummaryEvent() { }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s) submitted at %s successfully searched %d", getJobId(), submittedTime, successfullySearched);
+    }
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ReloadEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ReloadEvent.java
@@ -34,4 +34,9 @@ public class ReloadEvent extends LoggableEvent {
         this.fileName = fileName;
         this.numberLoaded = numLoaded;
     }
+
+    @Override
+    public String asMessage() {
+        return String.format("(%s) %s %s", getJobId(), fileType, fileName);
+    }
 }

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/Ab2dEnvironmentTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/Ab2dEnvironmentTest.java
@@ -1,0 +1,33 @@
+package gov.cms.ab2d.eventlogger;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Ab2dEnvironmentTest {
+
+    @Test
+    public void canProcessAllEnvironments() {
+        Ab2dEnvironment env = Ab2dEnvironment.fromName("ab2d-dev");
+        assertNotNull(env);
+        assertEquals(Ab2dEnvironment.DEV, env);
+
+        env = Ab2dEnvironment.fromName("ab2d-sbx-sandbox");
+        assertNotNull(env);
+        assertEquals(Ab2dEnvironment.SANDBOX, env);
+
+        env = Ab2dEnvironment.fromName("ab2d-east-impl");
+        assertNotNull(env);
+        assertEquals(Ab2dEnvironment.IMPL, env);
+
+        env = Ab2dEnvironment.fromName("ab2d-east-prod-test");
+        assertNotNull(env);
+        assertEquals(Ab2dEnvironment.PRODUCTION_VALIDATION, env);
+
+        env = Ab2dEnvironment.fromName("ab2d-east-prod");
+        assertNotNull(env);
+        assertEquals(Ab2dEnvironment.PRODUCTION, env);
+
+    }
+}

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/Ab2dEnvironmentTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/Ab2dEnvironmentTest.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.eventlogger;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
@@ -1,9 +1,11 @@
 package gov.cms.ab2d.eventlogger;
 
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventlogger.events.ErrorEvent;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,15 +30,24 @@ class LogManagerTest {
     @Mock
     private KinesisEventLogger kinesisEventLogger;
 
+    @Mock
+    private SlackLogger slackLogger;
+
     @Autowired
     private SqlEventLogger sqlEventLogger;
 
     @Autowired
     private LoggerEventRepository loggerEventRepository;
 
+    @AfterEach
+    public void cleanUp() {
+        reset(slackLogger);
+        loggerEventRepository.delete();
+    }
+
     @Test
     void log() {
-        logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
         ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
                 "File Deleted");
         doAnswer(invocation -> {
@@ -54,13 +65,59 @@ class LogManagerTest {
         assertEquals(1, events.size());
         ErrorEvent savedEvent = (ErrorEvent) events.get(0);
         assertEquals("aws1111", savedEvent.getAwsId());
+    }
 
-        loggerEventRepository.delete();
+    @Test
+    void logAndAlert() {
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+        ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
+                "File Deleted");
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
+        }).when(kinesisEventLogger).log(event, true);
+
+        logManager.logAndAlert(event, Ab2dEnvironment.ALL);
+        assertEquals("aws1111", event.getAwsId());
+        assertTrue(event.getId() > 0);
+
+        List<LoggableEvent> events = loggerEventRepository.load(ErrorEvent.class);
+        assertNotNull(events);
+        assertEquals(1, events.size());
+        ErrorEvent savedEvent = (ErrorEvent) events.get(0);
+        assertEquals("aws1111", savedEvent.getAwsId());
+
+        verify(slackLogger, times(1)).logAlert(any(), any());
+    }
+
+    @Test
+    void logAndTrace() {
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+        ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
+                "File Deleted");
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
+        }).when(kinesisEventLogger).log(event, true);
+
+        logManager.logAndTrace(event, Ab2dEnvironment.ALL);
+        assertEquals("aws1111", event.getAwsId());
+        assertTrue(event.getId() > 0);
+
+        List<LoggableEvent> events = loggerEventRepository.load(ErrorEvent.class);
+        assertNotNull(events);
+        assertEquals(1, events.size());
+        ErrorEvent savedEvent = (ErrorEvent) events.get(0);
+        assertEquals("aws1111", savedEvent.getAwsId());
+
+        verify(slackLogger, times(1)).logTrace(any(), any());
     }
 
     @Test
     void testOnlySql() {
-        logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
         ErrorEvent event = new ErrorEvent("organization", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
                 "File Deleted");
         logManager.log(LogManager.LogType.SQL, event);
@@ -72,25 +129,58 @@ class LogManagerTest {
         assertEquals(1, events.size());
         ErrorEvent savedEvent = (ErrorEvent) events.get(0);
         assertNull(savedEvent.getAwsId());
-
-        loggerEventRepository.delete();
     }
 
     @Test
     void testOnlyKin() {
         ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
                 "File Deleted");
-        logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             ((ErrorEvent)args[0]).setAwsId("aws1111");
             return null; // void method, so return null
         }).when(kinesisEventLogger).log(event);
+
         logManager.log(LogManager.LogType.KINESIS, event);
         assertEquals("aws1111", event.getAwsId());
         List<LoggableEvent> events = loggerEventRepository.load(ErrorEvent.class);
+
         assertNotNull(events);
         assertNull(event.getId());
         assertEquals(0, events.size());
+    }
+
+    @Test
+    void testAlert() {
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+        ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
+                "File Deleted");
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
+        }).when(kinesisEventLogger).log(event, true);
+
+        logManager.alert(event.getDescription(), Ab2dEnvironment.ALL);
+
+        verify(slackLogger, times(1)).logAlert(any(), any());
+    }
+
+    @Test
+    void testTrace() {
+        logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
+        ErrorEvent event = new ErrorEvent("user", "jobId", ErrorEvent.ErrorType.FILE_ALREADY_DELETED,
+                "File Deleted");
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ((ErrorEvent)args[0]).setAwsId("aws1111");
+            return null; // void method, so return null
+        }).when(kinesisEventLogger).log(event, true);
+
+        logManager.trace(event.getDescription(), Ab2dEnvironment.ALL);
+
+        verify(slackLogger, times(1)).logTrace(any(), any());
     }
 }

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
@@ -88,7 +88,7 @@ class LogManagerTest {
         ErrorEvent savedEvent = (ErrorEvent) events.get(0);
         assertEquals("aws1111", savedEvent.getAwsId());
 
-        verify(slackLogger, times(1)).logAlert(any(), any());
+        verify(slackLogger, times(1)).logAlert(any(LoggableEvent.class), any());
     }
 
     @Test
@@ -112,7 +112,7 @@ class LogManagerTest {
         ErrorEvent savedEvent = (ErrorEvent) events.get(0);
         assertEquals("aws1111", savedEvent.getAwsId());
 
-        verify(slackLogger, times(1)).logTrace(any(), any());
+        verify(slackLogger, times(1)).logTrace(any(LoggableEvent.class), any());
     }
 
     @Test
@@ -165,7 +165,7 @@ class LogManagerTest {
 
         logManager.alert(event.getDescription(), Ab2dEnvironment.ALL);
 
-        verify(slackLogger, times(1)).logAlert(any(), any());
+        verify(slackLogger, times(1)).logAlert(any(String.class), any());
     }
 
     @Test
@@ -181,6 +181,6 @@ class LogManagerTest {
 
         logManager.trace(event.getDescription(), Ab2dEnvironment.ALL);
 
-        verify(slackLogger, times(1)).logTrace(any(), any());
+        verify(slackLogger, times(1)).logTrace(any(String.class), any());
     }
 }

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
@@ -3,7 +3,8 @@ package gov.cms.ab2d.eventlogger.eventloggers.slack;
 import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookResponse;
-import liquibase.util.StringUtils;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -37,7 +38,7 @@ public class SlackLoggerTest {
             return WebhookResponse.builder().code(200).build();
         });
 
-        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), "testing");
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.LOCAL);
 
         boolean result = slackLogger.logAlert("This is a special announcement");
         assertTrue(result, "");
@@ -47,13 +48,81 @@ public class SlackLoggerTest {
 
         // Does payload contain the message and the environment sending the message
         assertTrue(webhookPayloads.get(0).toString().contains("This is a special announcement"));
-        assertTrue(webhookPayloads.get(0).toString().contains("testing"));
+        assertTrue(webhookPayloads.get(0).toString().contains("local"));
 
         slackLogger.logTrace("This is a not so special announcement");
         assertTrue(urls.containsAll(List.of("C", "D")));
         verify(slack, times(4)).send(anyString(), any(Payload.class));
 
         assertTrue(webhookPayloads.get(2).toString().contains("This is a not so special announcement"));
+    }
+
+    @DisplayName("SlackLogger sends logging if correct execution environment")
+    @Test
+    void slackLoggerSendsIfEnvironment() throws IOException {
+
+        List<String> urls = new ArrayList<>();
+        List<Payload> webhookPayloads = new ArrayList<>();
+        when(slack.send(anyString(), any(Payload.class))).thenAnswer((Answer<WebhookResponse>) invocation -> {
+
+            assertNotNull(invocation.getArgument(0));
+            assertFalse(StringUtils.isEmpty(invocation.getArgument(0)));
+
+            urls.add(invocation.getArgument(0));
+            webhookPayloads.add(invocation.getArgument(1));
+            return WebhookResponse.builder().code(200).build();
+        });
+
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.PRODUCTION);
+
+        // Send alert only in production environment
+        boolean result = slackLogger.logAlert("This is a special announcement",
+                List.of(Ab2dEnvironment.SANDBOX, Ab2dEnvironment.PRODUCTION));
+        assertTrue(result, "");
+
+        assertTrue(urls.containsAll(List.of("A", "B")));
+        verify(slack, times(2)).send(anyString(), any(Payload.class));
+
+        // Does payload contain the message and the environment sending the message
+        assertTrue(webhookPayloads.get(0).toString().contains(Ab2dEnvironment.PRODUCTION.getName()));
+
+        // Send trace only in production environment
+        slackLogger.logTrace("This is a not so special announcement",
+                List.of(Ab2dEnvironment.SANDBOX, Ab2dEnvironment.PRODUCTION));
+        assertTrue(urls.containsAll(List.of("C", "D")));
+        verify(slack, times(4)).send(anyString(), any(Payload.class));
+
+        assertTrue(webhookPayloads.get(2).toString().contains(Ab2dEnvironment.PRODUCTION.getName()));
+    }
+
+    @DisplayName("SlackLogger does not send logging if incorrect execution environment")
+    @Test
+    void slackLoggerSendsIfNotEnvironment() throws IOException {
+
+        List<String> urls = new ArrayList<>();
+        List<Payload> webhookPayloads = new ArrayList<>();
+        when(slack.send(anyString(), any(Payload.class))).thenAnswer((Answer<WebhookResponse>) invocation -> {
+
+            assertNotNull(invocation.getArgument(0));
+            assertFalse(StringUtils.isEmpty(invocation.getArgument(0)));
+
+            urls.add(invocation.getArgument(0));
+            webhookPayloads.add(invocation.getArgument(1));
+            return WebhookResponse.builder().code(200).build();
+        });
+
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.PRODUCTION);
+
+        // Send alert only in production environment
+        boolean result = slackLogger.logAlert("This is a special announcement",
+                List.of(Ab2dEnvironment.SANDBOX, Ab2dEnvironment.IMPL));
+        assertFalse(result, "");
+        verify(slack, never()).send(anyString(), any(Payload.class));
+
+        // Send trace only in production environment
+        slackLogger.logTrace("This is a not so special announcement",
+                List.of(Ab2dEnvironment.SANDBOX, Ab2dEnvironment.IMPL));
+        verify(slack, never()).send(anyString(), any(Payload.class));
     }
 
     @DisplayName("SlackLogger quietly handles Slack failure to process webhook")
@@ -63,7 +132,7 @@ public class SlackLoggerTest {
         when(slack.send(anyString(), any(Payload.class)))
                 .thenReturn(WebhookResponse.builder().code(400).build());
 
-        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), "testing");
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"),  Ab2dEnvironment.LOCAL);
 
         assertFalse(slackLogger.logAlert("oops"));
         assertFalse(slackLogger.logTrace("oops"));
@@ -75,7 +144,7 @@ public class SlackLoggerTest {
 
         when(slack.send(anyString(), any(Payload.class))).thenThrow(IOException.class);
 
-        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), "testing");
+        SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.LOCAL);
 
         assertFalse(slackLogger.logAlert("oops"));
         assertFalse(slackLogger.logTrace("oops"));

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/slack/SlackLoggerTest.java
@@ -4,6 +4,7 @@ import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookResponse;
 import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
+import gov.cms.ab2d.eventlogger.LoggableEvent;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ public class SlackLoggerTest {
 
         SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.LOCAL);
 
-        boolean result = slackLogger.logAlert("This is a special announcement");
+        boolean result = slackLogger.logAlert("This is a special announcement", Ab2dEnvironment.ALL);
         assertTrue(result, "");
 
         assertTrue(urls.containsAll(List.of("A", "B")));
@@ -50,7 +51,7 @@ public class SlackLoggerTest {
         assertTrue(webhookPayloads.get(0).toString().contains("This is a special announcement"));
         assertTrue(webhookPayloads.get(0).toString().contains("local"));
 
-        slackLogger.logTrace("This is a not so special announcement");
+        slackLogger.logTrace("This is a not so special announcement", Ab2dEnvironment.ALL);
         assertTrue(urls.containsAll(List.of("C", "D")));
         verify(slack, times(4)).send(anyString(), any(Payload.class));
 
@@ -134,8 +135,8 @@ public class SlackLoggerTest {
 
         SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"),  Ab2dEnvironment.LOCAL);
 
-        assertFalse(slackLogger.logAlert("oops"));
-        assertFalse(slackLogger.logTrace("oops"));
+        assertFalse(slackLogger.logAlert("oops", Ab2dEnvironment.ALL));
+        assertFalse(slackLogger.logTrace("oops", Ab2dEnvironment.ALL));
     }
 
     @DisplayName("SlackLogger quietly handles failure to send webhook")
@@ -146,7 +147,7 @@ public class SlackLoggerTest {
 
         SlackLogger slackLogger = new SlackLogger(slack, List.of("A", "B"), List.of("C", "D"), Ab2dEnvironment.LOCAL);
 
-        assertFalse(slackLogger.logAlert("oops"));
-        assertFalse(slackLogger.logTrace("oops"));
+        assertFalse(slackLogger.logAlert("oops", Ab2dEnvironment.ALL));
+        assertFalse(slackLogger.logTrace("oops", Ab2dEnvironment.ALL));
     }
 }

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
@@ -78,7 +78,7 @@ public class AllMapperEventTest {
 
         sqlEventLogger.log(jsce);
 
-        assertEquals("dev", jsce.getEnvironment());
+        assertEquals("ab2d-dev", jsce.getEnvironment());
 
         OffsetDateTime val = jsce.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(ApiRequestEvent.class);
@@ -93,7 +93,7 @@ public class AllMapperEventTest {
         jsce.setId(event.getId());
         assertEquals(event, jsce);
 
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getOrganization());
@@ -121,7 +121,7 @@ public class AllMapperEventTest {
         ApiResponseEvent jsce = new ApiResponseEvent("laila", "job123", HttpStatus.NOT_FOUND,
                 "Not Found", "Description", "123");
         sqlEventLogger.log(jsce);
-        assertEquals("dev", jsce.getEnvironment());
+        assertEquals("ab2d-dev", jsce.getEnvironment());
         long id = jsce.getId();
         OffsetDateTime val = jsce.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(ApiResponseEvent.class);
@@ -129,7 +129,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = loggerEventRepository.load();
         assertEquals(events.size(), events2.size());
         ApiResponseEvent event = (ApiResponseEvent) events.get(0);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getOrganization());
@@ -155,7 +155,7 @@ public class AllMapperEventTest {
         ContractBeneSearchEvent cbse = new ContractBeneSearchEvent(
                 "laila", "jobIdVal", "Contract123", 100, 98, 2);
         sqlEventLogger.log(cbse);
-        assertEquals("dev", cbse.getEnvironment());
+        assertEquals("ab2d-dev", cbse.getEnvironment());
         long id = cbse.getId();
         OffsetDateTime val = cbse.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(ContractBeneSearchEvent.class);
@@ -163,7 +163,7 @@ public class AllMapperEventTest {
         List<LoggableEvent> events2 = loggerEventRepository.load();
         assertEquals(events.size(), events2.size());
         ContractBeneSearchEvent event = (ContractBeneSearchEvent) events.get(0);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event, cbse);
         assertEquals(event.getId(), cbse.getId());
@@ -190,7 +190,7 @@ public class AllMapperEventTest {
         ErrorEvent jsce = new ErrorEvent("laila", "job123", ErrorEvent.ErrorType.CONTRACT_NOT_FOUND,
                 "Description");
         sqlEventLogger.log(jsce);
-        assertEquals("dev", jsce.getEnvironment());
+        assertEquals("ab2d-dev", jsce.getEnvironment());
         long id = jsce.getId();
         OffsetDateTime val = jsce.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(ErrorEvent.class);
@@ -199,7 +199,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
         ErrorEvent event = (ErrorEvent) events.get(0);
         assertEquals(event, jsce);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getOrganization());
@@ -227,7 +227,7 @@ public class AllMapperEventTest {
         FileEvent jsce = new FileEvent("laila", "job123", f, FileEvent.FileStatus.CLOSE);
         String hash = jsce.getFileHash();
         sqlEventLogger.log(jsce);
-        assertEquals("dev", jsce.getEnvironment());
+        assertEquals("ab2d-dev", jsce.getEnvironment());
         long id = jsce.getId();
         OffsetDateTime val = jsce.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(FileEvent.class);
@@ -236,7 +236,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
         FileEvent event = (FileEvent) events.get(0);
         assertEquals(event, jsce);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getOrganization());
@@ -264,7 +264,7 @@ public class AllMapperEventTest {
         JobStatusChangeEvent jsce = new JobStatusChangeEvent("laila", "job123", "IN_PROGRESS",
                 "FAILED", "Description");
         sqlEventLogger.log(jsce);
-        assertEquals("dev", jsce.getEnvironment());
+        assertEquals("ab2d-dev", jsce.getEnvironment());
         long id = jsce.getId();
         OffsetDateTime val = jsce.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(JobStatusChangeEvent.class);
@@ -273,7 +273,7 @@ public class AllMapperEventTest {
         assertEquals(events.size(), events2.size());
         JobStatusChangeEvent event = (JobStatusChangeEvent) events.get(0);
         assertEquals(event, jsce);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), jsce.getId());
         assertEquals("laila", event.getOrganization());
@@ -298,7 +298,7 @@ public class AllMapperEventTest {
         ReloadEvent cbse = new ReloadEvent(null, ReloadEvent.FileType.CONTRACT_MAPPING,
                 "filename", 10);
         sqlEventLogger.log(cbse);
-        assertEquals("dev", cbse.getEnvironment());
+        assertEquals("ab2d-dev", cbse.getEnvironment());
         long id = cbse.getId();
         OffsetDateTime val = cbse.getTimeOfEvent();
         List<LoggableEvent> events = loggerEventRepository.load(ReloadEvent.class);
@@ -307,7 +307,7 @@ public class AllMapperEventTest {
         assertEquals(1, events.size());
         ReloadEvent event = (ReloadEvent) events.get(0);
         assertEquals(event, cbse);
-        assertEquals("dev", event.getEnvironment());
+        assertEquals("ab2d-dev", event.getEnvironment());
         assertTrue(event.getId() > 0);
         assertEquals(event.getId(), cbse.getId());
         assertNull(event.getOrganization());

--- a/eventlogger/src/test/resources/application.properties
+++ b/eventlogger/src/test/resources/application.properties
@@ -15,7 +15,7 @@ efs.mount=${java.io.tmpdir}/jobdownloads/
 
 logging.level.liquibase=ERROR
 
-execution.env=${AB2D_EXECUTION_ENV:#{'dev'}}
+execution.env=${AB2D_EXECUTION_ENV:#{'ab2d-dev'}}
 # Default to true for testing
 eventlogger.kinesis.enabled=send_events
 

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/quartz/HPMSIngestJob.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/quartz/HPMSIngestJob.java
@@ -20,6 +20,8 @@ public class HPMSIngestJob extends QuartzJobBean {
     @SuppressWarnings("NullableProblems")
     @Override
     protected void executeInternal(JobExecutionContext context) {
+        // todo additionally filter hpms engagement by tracking the environment ab2d is running in.
+        //      if the environment is not sandbox or prod do not poll hpms
         if (FeatureEngagement.IN_GEAR == getEngagement()) {
             aus.pollOrganizations();
         }

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/quartz/HPMSIngestQuartzSetup.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/quartz/HPMSIngestQuartzSetup.java
@@ -6,9 +6,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /*
- *  jtodo: Don't know how to make this nice feature work using with the PropertiesService.  Instead, just allow the timer
- *  to fire, invoking HPMSIngestJob which immediately returns if not engaged.
- *  @ConditionalOnProperty(name = Constants.HPMS_INGESTION_ENGAGEMENT, havingValue = "engaged", matchIfMissing = false)
+ *  todo: Don't know how to make this nice feature work using with the PropertiesService.  Instead, just allow the timer
+ *      to fire, invoking HPMSIngestJob which immediately returns if not engaged.
+ *      @ConditionalOnProperty(name = Constants.HPMS_INGESTION_ENGAGEMENT, havingValue = "engaged", matchIfMissing = false)
  */
 @Configuration
 public class HPMSIngestQuartzSetup {

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
@@ -2,7 +2,8 @@ package gov.cms.ab2d.hpms.service;
 
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.repository.ContractRepository;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
+import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.hpms.hmsapi.*;  // NOPMD
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
@@ -21,15 +22,15 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
 
     private final ContractRepository contractRepository;
 
-    private final SlackLogger slackLogger;
+    private final LogManager eventLogger;
 
     @Autowired
     public AttestationUpdaterServiceImpl(ContractRepository contractRepository,
                                          HPMSFetcher hpmsFetcher,
-                                         SlackLogger slackLogger) {
+                                         LogManager eventLogger) {
         this.contractRepository = contractRepository;
         this.hpmsFetcher = hpmsFetcher;
-        this.slackLogger = slackLogger;
+        this.eventLogger = eventLogger;
     }
 
     @Override
@@ -106,8 +107,8 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
                     + "Number: " + contract.getContractNumber() + "\n"
                     + "HPMS Attested On: " + attest.getAttestationDate() + "\n"
                     + "Contract Attested On: " + contract.getAttestedOn() + "\n";
-            if (slackLogger != null) {
-                slackLogger.logAlert(msg);
+            if (eventLogger != null) {
+                eventLogger.alert(msg, Ab2dEnvironment.ALL);
             }
             contractRepository.save(contract);
         }
@@ -122,8 +123,8 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
                         + "Name: " + c.getContractName() + "\n"
                         + "Id: " + c.getContractId() + "\n"
                         + "Org: " + c.getOrgMarketingName() + "\n";
-                if (slackLogger != null) {
-                    slackLogger.logAlert(msg);
+                if (eventLogger != null) {
+                    eventLogger.alert(msg, Ab2dEnvironment.ALL);
                 }
             }
         );

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
@@ -3,7 +3,7 @@ package gov.cms.ab2d.hpms.service;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
+import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.hpms.SpringBootTestApp;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
@@ -58,7 +58,7 @@ public class AttestationUpdaterServiceTest {
     @TestConfiguration
     static class MockHpmsFetcherConfig {
         @Mock
-        private SlackLogger slackLogger;
+        private LogManager logManager;
 
         @Autowired
         private ContractRepository contractRepository;
@@ -67,7 +67,7 @@ public class AttestationUpdaterServiceTest {
         @Bean()
         public AttestationUpdaterServiceImpl getMockService()
         {
-            return new AttestationUpdaterServiceImpl(contractRepository, new MockHpmsFetcher(), slackLogger);
+            return new AttestationUpdaterServiceImpl(contractRepository, new MockHpmsFetcher(), logManager);
         }
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheck.java
@@ -85,7 +85,7 @@ class BFDHealthCheck {
         PropertiesDTO propertiesDTO = new PropertiesDTO();
         propertiesDTO.setKey(MAINTENANCE_MODE);
         propertiesDTO.setValue(statusString);
-        logManager.alert("Maintenance Mode status for determined from " + data.getVersion() +
+        logManager.alert("Maintenance Mode status for " + data.getVersion() +
                 " is: " + statusString, Ab2dEnvironment.ALL);
         propertiesService.updateProperties(List.of(propertiesDTO));
         log.info("Updated the {} property to {}", MAINTENANCE_MODE, statusString);

--- a/worker/src/main/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheck.java
@@ -3,7 +3,8 @@ package gov.cms.ab2d.worker.bfdhealthcheck;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.service.PropertiesService;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
+import gov.cms.ab2d.eventlogger.LogManager;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseConformance;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,17 +21,17 @@ import static gov.cms.ab2d.worker.bfdhealthcheck.HealthCheckData.Status;
 @Slf4j
 class BFDHealthCheck {
 
-    private final SlackLogger slackLogger;
+    private final LogManager logManager;
     private final PropertiesService propertiesService;
     private final BFDClient bfdClient;
     private final int consecutiveSuccessesToBringUp;
     private final int consecutiveFailuresToTakeDown;
     private final List<HealthCheckData> healthCheckData = new ArrayList<>();
 
-    BFDHealthCheck(SlackLogger slackLogger, PropertiesService propertiesService, BFDClient bfdClient,
+    BFDHealthCheck(LogManager logManager, PropertiesService propertiesService, BFDClient bfdClient,
                           @Value("${bfd.health.check.consecutive.successes}") int consecutiveSuccessesToBringUp,
                           @Value("${bfd.health.check.consecutive.failures}") int consecutiveFailuresToTakeDown) {
-        this.slackLogger = slackLogger;
+        this.logManager = logManager;
         this.propertiesService = propertiesService;
         this.bfdClient = bfdClient;
         this.consecutiveSuccessesToBringUp = consecutiveSuccessesToBringUp;
@@ -84,7 +85,8 @@ class BFDHealthCheck {
         PropertiesDTO propertiesDTO = new PropertiesDTO();
         propertiesDTO.setKey(MAINTENANCE_MODE);
         propertiesDTO.setValue(statusString);
-        slackLogger.logAlert("Maintenance Mode status for determined from " + data.getVersion() + " is: " + statusString);
+        logManager.alert("Maintenance Mode status for determined from " + data.getVersion() +
+                " is: " + statusString, Ab2dEnvironment.ALL);
         propertiesService.updateProperties(List.of(propertiesDTO));
         log.info("Updated the {} property to {}", MAINTENANCE_MODE, statusString);
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -10,8 +10,8 @@ import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.repository.JobOutputRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.common.util.EventUtils;
+import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
-import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ContractBeneSearchEvent;
 import gov.cms.ab2d.eventlogger.events.FileEvent;
 import gov.cms.ab2d.worker.processor.coverage.CoverageDriver;
@@ -36,7 +36,6 @@ import java.util.concurrent.ExecutionException;
 
 import static gov.cms.ab2d.common.model.JobStatus.*;
 import static gov.cms.ab2d.common.util.EventUtils.getOrganization;
-import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.ZIP;
 
@@ -64,7 +63,6 @@ public class JobProcessorImpl implements JobProcessor {
     private final ContractProcessor contractProcessor;
     private final CoverageDriver coverageDriver;
     private final LogManager eventLogger;
-    private final SlackLogger slackLogger;
 
     /**
      * Load the job and process it
@@ -98,8 +96,7 @@ public class JobProcessorImpl implements JobProcessor {
 
             // Log exception to relevant loggers
             String message = "Job %s failed for contract #%s because " + e.getMessage();
-            eventLogger.log(EventUtils.getJobChangeEvent(job, FAILED, message));
-            slackLogger.logAlert(message, PROD_LIST);
+            eventLogger.logAndAlert(EventUtils.getJobChangeEvent(job, FAILED, message), Ab2dEnvironment.PROD_LIST);
             log.error("Unexpected exception ", e);
 
             // Update database status

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -40,6 +40,7 @@ import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.ZIP;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -11,6 +11,7 @@ import gov.cms.ab2d.common.repository.JobOutputRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.common.util.EventUtils;
 import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.events.ContractBeneSearchEvent;
 import gov.cms.ab2d.eventlogger.events.FileEvent;
 import gov.cms.ab2d.worker.processor.coverage.CoverageDriver;
@@ -35,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 
 import static gov.cms.ab2d.common.model.JobStatus.*;
 import static gov.cms.ab2d.common.util.EventUtils.getOrganization;
+import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.NDJSON;
 import static gov.cms.ab2d.worker.processor.StreamHelperImpl.FileOutputType.ZIP;
 
@@ -61,6 +63,7 @@ public class JobProcessorImpl implements JobProcessor {
     private final ContractProcessor contractProcessor;
     private final CoverageDriver coverageDriver;
     private final LogManager eventLogger;
+    private final SlackLogger slackLogger;
 
     /**
      * Load the job and process it
@@ -91,13 +94,19 @@ public class JobProcessorImpl implements JobProcessor {
                 deleteExistingDirectory(outputDirPath, job);
             }
         } catch (Exception e) {
-            eventLogger.log(EventUtils.getJobChangeEvent(job, FAILED, "Job Failed - " + e.getMessage()));
+
+            // Log exception to relevant loggers
+            String message = "Job %s failed for contract #%s because " + e.getMessage();
+            eventLogger.log(EventUtils.getJobChangeEvent(job, FAILED, message));
+            slackLogger.logAlert(message, PROD_LIST);
             log.error("Unexpected exception ", e);
+
+            // Update database status
             job.setStatus(FAILED);
             job.setStatusMessage(e.getMessage());
             job.setCompletedAt(OffsetDateTime.now());
-            jobRepository.save(job);
             log.info("Job: [{}] FAILED", jobUuid);
+            jobRepository.save(job);
         }
 
         return job;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorImplTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorImplTest.java
@@ -2,16 +2,14 @@ package gov.cms.ab2d.worker.processor;
 
 import gov.cms.ab2d.common.model.CoverageSummary;
 import gov.cms.ab2d.common.model.Identifiers;
-import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.common.util.fhir.FhirUtils;
-import gov.cms.ab2d.eventlogger.LogManager;
-import gov.cms.ab2d.worker.service.FileService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static gov.cms.ab2d.worker.processor.ContractProcessorImpl.ID_EXT;
@@ -20,25 +18,6 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ContractProcessorImplTest {
-
-    @Mock
-    private FileService fileService;
-
-    @Mock
-    private PatientClaimsProcessor patientClaimsProcessor;
-
-    @Mock
-    private LogManager eventLogger;
-
-    @Mock
-    private JobRepository jobRepository;
-
-    private ContractProcessorImpl processor;
-
-    @BeforeEach
-    public void before() {
-        processor = new ContractProcessorImpl(fileService, jobRepository, patientClaimsProcessor, eventLogger);
-    }
 
     @Test
     @DisplayName("Creating mbis is done successfully")

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.processor;
 
-import ca.uhn.fhir.context.FhirContext;
 import gov.cms.ab2d.common.model.*;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.eventlogger.LogManager;
@@ -57,7 +56,6 @@ class ContractProcessorUnitTest {
     @BeforeEach
     void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        FhirContext fhirContext = ca.uhn.fhir.context.FhirContext.forDstu3();
 
         patientClaimsProcessor = spy(PatientClaimsProcessorStub.class);
 
@@ -78,8 +76,6 @@ class ContractProcessorUnitTest {
 
         var outputDirPath = Paths.get(efsMountTmpDir.toString(), jobUuid);
         outputDir = Files.createDirectories(outputDirPath);
-
-
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -8,6 +8,7 @@ import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventlogger.events.*;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
@@ -60,6 +61,9 @@ class JobPreProcessorIntegrationTest {
     @Mock
     private KinesisEventLogger kinesisEventLogger;
 
+    @Mock
+    private SlackLogger slackLogger;
+
     private PdpClient pdpClient;
     private Job job;
 
@@ -68,7 +72,7 @@ class JobPreProcessorIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        LogManager manager = new LogManager(sqlEventLogger, kinesisEventLogger);
+        LogManager manager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
 
         cut = new JobPreProcessorImpl(jobRepository, manager, coverageDriver);
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.processor;
 
-import ca.uhn.fhir.context.FhirContext;
 import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.*;
 import gov.cms.ab2d.common.repository.ContractRepository;
@@ -12,6 +11,7 @@ import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.eventlogger.eventloggers.kinesis.KinesisEventLogger;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventlogger.events.*;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
@@ -98,6 +98,9 @@ class JobProcessorIntegrationTest {
     private KinesisEventLogger kinesisEventLogger;
 
     @Mock
+    private SlackLogger slackLogger;
+
+    @Mock
     private BFDClient mockBfdClient;
 
     @TempDir
@@ -131,7 +134,6 @@ class JobProcessorIntegrationTest {
 
         fail = new RuntimeException("TEST EXCEPTION");
 
-        FhirContext fhirContext = FhirContext.forDstu3();
         PatientClaimsProcessor patientClaimsProcessor = new PatientClaimsProcessorImpl(mockBfdClient, logManager);
         ReflectionTestUtils.setField(patientClaimsProcessor, "startDate", "01/01/1900");
         ContractProcessor contractProcessor = new ContractProcessorImpl(
@@ -155,7 +157,8 @@ class JobProcessorIntegrationTest {
                 jobOutputRepository,
                 contractProcessor,
                 coverageDriver,
-                logManager
+                logManager,
+                slackLogger
         );
 
         ReflectionTestUtils.setField(cut, "efsMount", tmpEfsMountDir.toString());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -116,7 +116,7 @@ class JobProcessorIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger);
+        LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
         PdpClient pdpClient = createClient();
 
         Contract contract = createContract();
@@ -157,8 +157,7 @@ class JobProcessorIntegrationTest {
                 jobOutputRepository,
                 contractProcessor,
                 coverageDriver,
-                logManager,
-                slackLogger
+                logManager
         );
 
         ReflectionTestUtils.setField(cut, "efsMount", tmpEfsMountDir.toString());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
-import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
@@ -47,7 +46,6 @@ class JobProcessorUnitTest {
     @Mock private JobOutputRepository jobOutputRepository;
     @Mock private ContractProcessor contractProcessor;
     @Mock private LogManager eventLogger;
-    @Mock private SlackLogger slackLogger;
 
     private CoverageDriverStub coverageDriver;
     private Job job;
@@ -63,8 +61,7 @@ class JobProcessorUnitTest {
                 jobOutputRepository,
                 contractProcessor,
                 coverageDriver,
-                eventLogger,
-                slackLogger
+                eventLogger
         );
 
         ReflectionTestUtils.setField(cut, "efsMount", efsMountTmpDir.toString());
@@ -187,7 +184,7 @@ class JobProcessorUnitTest {
 
         verify(fileService).createDirectory(any());
         verify(coverageDriver, never()).pageCoverage(any(Job.class));
-        verify(slackLogger, times(1)).logAlert(anyString(), any());
+        verify(eventLogger, times(1)).logAndAlert(any(), any());
     }
 
     private PdpClient createClient() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.common.model.*;
 import gov.cms.ab2d.common.repository.JobOutputRepository;
 import gov.cms.ab2d.common.repository.JobRepository;
 import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.worker.processor.coverage.CoverageDriverStub;
 import gov.cms.ab2d.worker.service.FileService;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,7 @@ class JobProcessorUnitTest {
     @Mock private JobOutputRepository jobOutputRepository;
     @Mock private ContractProcessor contractProcessor;
     @Mock private LogManager eventLogger;
+    @Mock private SlackLogger slackLogger;
 
     private CoverageDriverStub coverageDriver;
     private Job job;
@@ -61,7 +63,8 @@ class JobProcessorUnitTest {
                 jobOutputRepository,
                 contractProcessor,
                 coverageDriver,
-                eventLogger
+                eventLogger,
+                slackLogger
         );
 
         ReflectionTestUtils.setField(cut, "efsMount", efsMountTmpDir.toString());
@@ -184,6 +187,7 @@ class JobProcessorUnitTest {
 
         verify(fileService).createDirectory(any());
         verify(coverageDriver, never()).pageCoverage(any(Job.class));
+        verify(slackLogger, times(1)).logAlert(anyString(), any());
     }
 
     private PdpClient createClient() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.eventloggers.slack.SlackLogger;
 import gov.cms.ab2d.worker.processor.coverage.CoverageDriver;
 import gov.cms.ab2d.worker.processor.coverage.CoverageDriverStub;
 import gov.cms.ab2d.worker.service.FileService;
@@ -61,6 +62,9 @@ class ProgressTrackerIntegrationTest {
     private LogManager eventLogger;
 
     @Mock
+    private SlackLogger slackLogger;
+
+    @Mock
     private BFDClient bfdClient;
 
     @Container
@@ -72,7 +76,7 @@ class ProgressTrackerIntegrationTest {
         CoverageDriver coverageDriver = new CoverageDriverStub(10, 20);
 
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository,
-                contractProcessor, coverageDriver, eventLogger);
+                contractProcessor, coverageDriver, eventLogger, slackLogger);
     }
 
     @AfterEach

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ProgressTrackerIntegrationTest.java
@@ -62,9 +62,6 @@ class ProgressTrackerIntegrationTest {
     private LogManager eventLogger;
 
     @Mock
-    private SlackLogger slackLogger;
-
-    @Mock
     private BFDClient bfdClient;
 
     @Container
@@ -76,7 +73,7 @@ class ProgressTrackerIntegrationTest {
         CoverageDriver coverageDriver = new CoverageDriverStub(10, 20);
 
         cut = new JobProcessorImpl(fileService, jobRepository, jobOutputRepository,
-                contractProcessor, coverageDriver, eventLogger, slackLogger);
+                contractProcessor, coverageDriver, eventLogger);
     }
 
     @AfterEach


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3602](https://jira.cms.gov/browse/AB2D-3602) - Create Enums for Environments
[AB2D-3603](https://jira.cms.gov/browse/AB2D-3603) - Add Slack Alerts for Auth Failure
 
### What Does This PR Do?

Created Ab2dEnvironment enum with list of environments. All event loggers have been converted to using the enum now.

Alerts related to
* Requests rejected due to maintenance mode
* Requests rejected due to Authn/Authz issues
* A client running their first job

#### Maintenance Mode Alert
In the production environment the following conditions will trigger a Slack Alert:

* AB2D goes into maintenance mode
* A PDP has an action rejected because the API is in maintenance mode

#### Authentication and Authorization Alerts
In the prod environment any of the following failures will trigger a Slack Alert:

* If a request arrives missing an Auth Header
* If a request passes a bad (not interpretable) JWT header
* If a request passes disabled set of credentials are used in an API call
* If a request passes a set of credentials that cannot be verified with Okta
* If a request passes a set of credentials for which the Okta Client ID does not exist in the AB2D database
* If a request attempts to access a job for which it does not have authority to access (a job for a different contract)
* If a request attempts to start a job for a contract that it does not have authority over
* If a request passes a set of credentials that do not have the correct client role (admin, sponsor, etc.) for the action being performed

#### Client Running First Job
In the prod environment whenever a PDP runs a job for a contract for the first time an alert will be generated. If they cancel their first job then the alert will continue being generated until a job has completed successfully.

### What Should Reviewers Watch For?

* Any other areas where the execution env needs to be changed to the Ab2dEnvironment enum.
* Using the enum does not risk breaking the other eventloggers.
* The ErrorHandler and SecurityConfig have all of the alerts that are necessary and those alerts will contain useful text.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure