### PR TITLE
Bug/ab2d 3715 performance tweaks testing round 1

### DIFF
--- a/bfd/src/main/resources/application.bfd.properties
+++ b/bfd/src/main/resources/application.bfd.properties
@@ -9,8 +9,8 @@ bfd.socketTimeout=${AB2D_BFD_SOCKET_TIMEOUT:#{30000}}
 bfd.requestTimeout=${AB2D_BFD_REQUEST_TIMEOUT:#{5000}}
 bfd.eob.pagesize=${AB2D_BFD_EOB_PAGE_SIZE:#{-1}}
 bfd.contract.to.bene.pagesize=${AB2D_BFD_C2B_PAGE_SIZE:#{500}}
-bfd.http.maxConnPerRoute=150
-bfd.http.maxConnTotal=150
+bfd.http.maxConnPerRoute=750
+bfd.http.maxConnTotal=750
 bfd.http.connTTL=60000
 
 bfd.hash.pepper=${AB2D_HICN_HASH_PEPPER:6E6F747468657265616C706570706572}

--- a/fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
+++ b/fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
@@ -22,7 +22,6 @@ public enum FhirVersion {
 
     private final String classLocation;
     private final FhirContext context;
-    private IParser jsonParser;
     private final FhirVersionEnum fhirVersionEnum;
     private final String versionString;
     private final Object patientEnum;
@@ -37,11 +36,8 @@ public enum FhirVersion {
     }
 
     public IParser getJsonParser() {
-        if (this.jsonParser == null) {
-            EncodingEnum respType = EncodingEnum.forContentType(EncodingEnum.JSON_PLAIN_STRING);
-            this.jsonParser = respType.newParser(this.context);
-        }
-        return jsonParser;
+        EncodingEnum respType = EncodingEnum.forContentType(EncodingEnum.JSON_PLAIN_STRING);
+        return respType.newParser(FhirContext.forCached(fhirVersionEnum));
     }
 
     public static FhirVersion from(FhirVersionEnum fhirVersionEnum) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -271,6 +271,7 @@ public class ContractProcessorImpl implements ContractProcessor {
      * @param progressTracker - progress tracker instance
      * @param future          - a specific future
      */
+    @Trace
     private EobSearchResult processFuture(List<Future<EobSearchResult>> futureHandles, ProgressTracker progressTracker,
                                           Future<EobSearchResult> future, Map<String, CoverageSummary> patients) {
         progressTracker.incrementEobProcessedCount();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/TextStreamHelperImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/TextStreamHelperImpl.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.processor;
 
+import com.newrelic.api.agent.Trace;
 import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.util.EventUtils;
 import gov.cms.ab2d.eventlogger.LogManager;
@@ -62,6 +63,7 @@ public class TextStreamHelperImpl extends StreamHelperImpl {
      *
      * @param data - the data to write
      */
+    @Trace
     @Override
     public void addData(byte[] data) throws IOException {
         if (data == null || data.length == 0) {


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3715](https://jira.cms.gov/browse/AB2D-3715) - Performance Tweaks from first round of performance testing

### What Does This PR Do?

* Increase number of connections available in Apache Http Connection Pool to support more concurrent requests.
* Separate reading and parsing the response to EOB requests from BFD. If parsing is slow this makes sure that we release the connection quickly so BFD can use it.
* Create a new JsonParser for each EOB request instead of sharing one between all threads. There is no thread-safe guarantee for this parser.
* Use a cached FhirContext for each JsonParser because every new FhirContext has high overhead when retrieving schema definitions for the parser. 
* Add additional NR @Trace annotations to track the post processing overhead per EOB request.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure