### PR TITLE
Fail Job if Enrollment Loading Fails

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageService.java
@@ -180,6 +180,18 @@ public interface CoverageService {
     Optional<CoverageMapping> startSearch(CoverageSearch search, String description);
 
     /**
+     * Resubmit a search that has failed but still has attempts
+     * @param periodId unique id of a coverage search
+     * @param attempts number of attempts already conducted
+     * @param failedDescription reason or explanation for change
+     * @param restartDescription reason or explanation for change
+     * @param prioritize whether to force coverage period to front of the queue
+     * @return resulting coverage search event
+     */
+    CoverageSearchEvent resubmitSearch(int periodId, int attempts, String failedDescription,
+                                       String restartDescription, boolean prioritize);
+
+    /**
      * Change a coverage search to {@link JobStatus#CANCELLED} and log an event.
      * @param periodId unique id of a coverage search
      * @param description reason or explanation for change

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -237,6 +237,28 @@ public class CoverageServiceImpl implements CoverageService {
         return Optional.of(updateStatus(period, description, JobStatus.SUBMITTED));
     }
 
+    @Override
+    public CoverageSearchEvent resubmitSearch(int periodId, int attempts, String failedDescription,
+                                              String restartDescription, boolean prioritize) {
+        CoveragePeriod period = findCoveragePeriod(periodId);
+
+        updateStatus(period, failedDescription, JobStatus.FAILED, true);
+
+        // Add to queue of jobs to do
+        CoverageSearch search = new CoverageSearch();
+        search.setPeriod(period);
+        search.setAttempts(attempts);
+
+        // Force to front of the queue if necessary
+        if (prioritize) {
+            search.setCreated(OffsetDateTime.of(2000, 1, 1,
+                    0, 0, 0, 0, ZoneOffset.UTC));
+        }
+
+        coverageSearchRepo.saveAndFlush(search);
+
+        return updateStatus(period, restartDescription, JobStatus.SUBMITTED);
+    }
 
     @Override
     public Optional<CoverageSearchEvent> prioritizeSearch(int periodId, String description) {
@@ -357,6 +379,10 @@ public class CoverageServiceImpl implements CoverageService {
     }
 
     private CoverageSearchEvent updateStatus(CoveragePeriod period, String description, JobStatus status) {
+        return updateStatus(period, description, status, true);
+    }
+
+    private CoverageSearchEvent updateStatus(CoveragePeriod period, String description, JobStatus status, boolean updateCoveragePeriod) {
         CoverageSearchEvent currentStatus = getLastEvent(period);
 
         logStatusChange(period, description, status);
@@ -375,7 +401,9 @@ public class CoverageServiceImpl implements CoverageService {
             period.setLastSuccessfulJob(OffsetDateTime.now());
         }
 
-        coveragePeriodRepo.saveAndFlush(period);
+        if (updateCoveragePeriod) {
+            coveragePeriodRepo.saveAndFlush(period);
+        }
 
         return coverageSearchEventRepo.saveAndFlush(newStatus);
     }

--- a/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/CoverageServiceImpl.java
@@ -242,7 +242,7 @@ public class CoverageServiceImpl implements CoverageService {
                                               String restartDescription, boolean prioritize) {
         CoveragePeriod period = findCoveragePeriod(periodId);
 
-        updateStatus(period, failedDescription, JobStatus.FAILED, true);
+        updateStatus(period, failedDescription, JobStatus.FAILED, false);
 
         // Add to queue of jobs to do
         CoverageSearch search = new CoverageSearch();
@@ -395,13 +395,13 @@ public class CoverageServiceImpl implements CoverageService {
         newStatus.setNewStatus(status);
         newStatus.setDescription(description);
 
-        period.setStatus(status);
 
         if (status == JobStatus.SUCCESSFUL) {
             period.setLastSuccessfulJob(OffsetDateTime.now());
         }
 
         if (updateCoveragePeriod) {
+            period.setStatus(status);
             coveragePeriodRepo.saveAndFlush(period);
         }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.worker.config;
 
+import gov.cms.ab2d.common.model.Job;
+import gov.cms.ab2d.common.model.JobStatus;
 import gov.cms.ab2d.common.service.FeatureEngagement;
 import gov.cms.ab2d.common.service.ResourceNotFoundException;
 import gov.cms.ab2d.worker.service.WorkerService;
@@ -50,6 +52,10 @@ public class JobHandler implements MessageHandler {
 
         final List<Map<String, Object>> payload = (List<Map<String, Object>>) message.getPayload();
 
+        if (!payload.isEmpty()) {
+            log.info("iterating over {} submitted jobs to attempt to find one to start", payload.size());
+        }
+
         for (Map<String, Object> submittedJob : payload) {
 
             final String jobId = getJobId(submittedJob);
@@ -66,7 +72,11 @@ public class JobHandler implements MessageHandler {
 
                     // Attempt to start (mark an eob job as in progress) an eob job.
                     // A job may not be started if the workers are busy or if coverage metadata needs an update.
-                    workerService.process(jobId);
+                    Job job = workerService.process(jobId);
+                    if (job.getStatus() == JobStatus.IN_PROGRESS) {
+                        log.info("{} job has been started so exiting loop", jobId);
+                        break;
+                    }
 
                 } catch (ResourceNotFoundException rnfe) {
                     throw new MessagingException("could not find job in database for " + jobId + " job uuid", rnfe);

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
@@ -1,7 +1,5 @@
 package gov.cms.ab2d.worker.config;
 
-import gov.cms.ab2d.common.model.Job;
-import gov.cms.ab2d.common.model.JobStatus;
 import gov.cms.ab2d.common.service.FeatureEngagement;
 import gov.cms.ab2d.common.service.ResourceNotFoundException;
 import gov.cms.ab2d.worker.service.WorkerService;

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
@@ -73,6 +73,10 @@ public class JobHandler implements MessageHandler {
                     if (job.getStatus() == JobStatus.IN_PROGRESS) {
                         log.info("{} job has been started", jobId);
                         break;
+                    } else if (job.getStatus() == JobStatus.CANCELLED) {
+                        log.info("{} job has been cancelled", jobId);
+                    } else if (job.getStatus() == JobStatus.FAILED) {
+                        log.info("{} job has failed to start", jobId);
                     }
 
                 } catch (ResourceNotFoundException rnfe) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
@@ -68,16 +68,7 @@ public class JobHandler implements MessageHandler {
 
                     // Attempt to start (mark an eob job as in progress) an eob job.
                     // A job may not be started if the workers are busy or if coverage metadata needs an update.
-                    // However if a job is started then
-                    Job job = workerService.process(jobId);
-                    if (job.getStatus() == JobStatus.IN_PROGRESS) {
-                        log.info("{} job has been started", jobId);
-                        break;
-                    } else if (job.getStatus() == JobStatus.CANCELLED) {
-                        log.info("{} job has been cancelled", jobId);
-                    } else if (job.getStatus() == JobStatus.FAILED) {
-                        log.info("{} job has failed to start", jobId);
-                    }
+                    workerService.process(jobId);
 
                 } catch (ResourceNotFoundException rnfe) {
                     throw new MessagingException("could not find job in database for " + jobId + " job uuid", rnfe);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
@@ -114,7 +114,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
         queueCoveragePeriod(mapping.getPeriod(), mapping.getCoverageSearch().getAttempts(), prioritize);
     }
 
-    private void restartMapping(CoverageMapping mapping, String failedDescription, String restartDescription, boolean prioritize) {
+    private void resubmitMapping(CoverageMapping mapping, String failedDescription, String restartDescription, boolean prioritize) {
 
         if (inShutdown.get()) {
             return;
@@ -169,7 +169,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
 
             log.warn("could not complete coverage mapping job but will re-attempt");
 
-            restartMapping(mapping, "could not complete coverage mapping due to error",
+            resubmitMapping(mapping, "could not complete coverage mapping due to error",
                     "could not complete coverage mapping job but will re-attempt", true);
         }
     }
@@ -205,7 +205,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
                         " contract %s during %d-%d, will re-attempt", contractNumber, month, year);
                 log.debug(message);
 
-                restartMapping(result, message,
+                resubmitMapping(result, message,
                 "shutting down coverage processor before beneficiary data can be inserted into database",
                         true);
             }
@@ -257,7 +257,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
                     insertedMapping.getPeriod().getYear());
             log.debug(message);
 
-            restartMapping(insertedMapping, message, message, false);
+            resubmitMapping(insertedMapping, message, message, false);
         }
 
         // Force shutdown all running bfd queries
@@ -273,7 +273,7 @@ public class CoverageProcessorImpl implements CoverageProcessor {
                         mapping.getPeriod().getYear());
                 log.debug(message);
 
-                restartMapping(mapping, message, message, false);
+                resubmitMapping(mapping, message, message, false);
             });
         }
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
@@ -39,10 +39,16 @@ public class WorkerServiceImpl implements WorkerService {
             Job job = jobPreprocessor.preprocess(jobUuid);
 
             if (job.getStatus() == JobStatus.IN_PROGRESS) {
-                log.info("Job was put in progress");
+                log.info("{} has been started", jobUuid);
 
                 job = jobProcessor.process(jobUuid);
                 log.info("Job was processed");
+            } else if (job.getStatus() == JobStatus.SUBMITTED) {
+                log.info("{} job is waiting for enrollment information", jobUuid);
+            } else if (job.getStatus() == JobStatus.CANCELLED) {
+                log.warn("{} job has been cancelled", jobUuid);
+            } else if (job.getStatus() == JobStatus.FAILED) {
+                log.warn("{} job has failed to start", jobUuid);
             }
 
             // Check that job hasn't been cancelled by processor and that we actually changed

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -530,6 +530,33 @@ class CoverageUpdateAndProcessorTest {
         assertEquals(0, twoThreads.getActiveCount());
     }
 
+    @DisplayName("Coverage availability throws exception after max attempts retries")
+    @Test
+    void coverageAvailabilityLimitsRetries() {
+
+        Job job = new Job();
+        job.setCreatedAt(OffsetDateTime.now());
+        job.setContract(contract);
+
+        try {
+            Thread.sleep(1000);
+
+            january.setStatus(JobStatus.FAILED);
+            coveragePeriodRepo.saveAndFlush(january);
+
+            february.setStatus(JobStatus.FAILED);
+            coveragePeriodRepo.saveAndFlush(february);
+
+            driver.isCoverageAvailable(job);
+
+            fail("Coverage driver method should throw an exception");
+        } catch (CoverageDriverException coverageDriverException) {
+            // passed
+        } catch (InterruptedException interruptedException) {
+            fail("could not complete test");
+        }
+    }
+
     private CoverageSearchEvent createEvent(CoveragePeriod period, JobStatus status, OffsetDateTime created) {
         CoverageSearchEvent event = new CoverageSearchEvent();
         event.setCoveragePeriod(period);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3441](https://jira.cms.gov/browse/AB2D-3441) - Fail Job if Enrollment Loading Fails
 
### What Does This PR Do?

Force the failure of an EOB job if the underlying enrollment information cannot be pulled. This PR changes the process for retrying an enrollment search to avoid marking a job as failed until after max retries is exceeded.

### What Should Reviewers Watch For?

Cases where the `CoverageDriverException` is not thrown but coverage retries may be exceeded.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure