### PR TITLE
Switch to Hotspot JVM

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9
+FROM adoptopenjdk:11.0.11_9-jre-hotspot
 WORKDIR /usr/src/ab2d-api
 ADD target/api-*-SNAPSHOT.jar /usr/src/ab2d-api/api.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-api/newrelic/newrelic.jar

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-openj9
+FROM adoptopenjdk:11.0.11_9-jre-hotspot
 WORKDIR /usr/src/ab2d-worker
 ADD target/worker-*-SNAPSHOT.jar /usr/src/ab2d-worker/worker.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-worker/newrelic/newrelic.jar


### PR DESCRIPTION
### What Does This PR Do?

Change from OpenJ9 which limits the JVM to 25 GB of RAM. New JVM will be Hotspot maintained by Oracle.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure