### PR TITLE
Update tests & code to handle new BFD Patient endpoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,17 +98,17 @@ pipeline {
                             string(credentialsId: 'SANDBOX_BFD_KEYSTORE_PASSWORD', variable: 'AB2D_BFD_KEYSTORE_PASSWORD')]) {
 
                     sh '''
-                        export AB2D_BFD_KEYSTORE_LOCATION="/opt/ab2d/ab2d_bfd_keystore"
+                        export AB2D_BFD_KEYSTORE_LOCATION="$WORKSPACE/opt/ab2d/ab2d_bfd_keystore"
 
-                        export KEYSTORE_LOCATION="$WORKSPACE/opt/ab2d/ab2d_bfd_keystore"
+                        cp $SANDBOX_BFD_KEYSTORE $AB2D_BFD_KEYSTORE_LOCATION
 
-                        cp $SANDBOX_BFD_KEYSTORE $KEYSTORE_LOCATION
+                        test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
 
-                        test -f $KEYSTORE_LOCATION && echo "created keystore file"
+                        chmod 666 $AB2D_BFD_KEYSTORE_LOCATION
 
-                        chmod 666 $KEYSTORE_LOCATION
+                        ls -la $AB2D_BFD_KEYSTORE_LOCATION
 
-                        ls -la $KEYSTORE_LOCATION
+                        export AB2D_V2_ENABLED=false
 
                         mvn test -pl e2e-patient-test -am -Dtest=PatientEndpointTests -DfailIfNoTests=false
                     '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,32 @@ pipeline {
             }
         }
 
+        stage('Run e2e-patient-test') {
+
+            steps {
+
+                withCredentials([file(credentialsId: 'SANDBOX_BFD_KEYSTORE', variable: 'SANDBOX_BFD_KEYSTORE'),
+                            string(credentialsId: 'SANDBOX_BFD_KEYSTORE_PASSWORD', variable: 'AB2D_BFD_KEYSTORE_PASSWORD')]) {
+
+                    sh '''
+                        export AB2D_BFD_KEYSTORE_LOCATION="/opt/ab2d/ab2d_bfd_keystore"
+
+                        export KEYSTORE_LOCATION="$WORKSPACE/opt/ab2d/ab2d_bfd_keystore"
+
+                        cp $SANDBOX_BFD_KEYSTORE $KEYSTORE_LOCATION
+
+                        test -f $KEYSTORE_LOCATION && echo "created keystore file"
+
+                        chmod 666 $KEYSTORE_LOCATION
+
+                        ls -la $KEYSTORE_LOCATION
+
+                        mvn test -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false
+                    '''
+                }
+            }
+        }
+
         stage('Run e2e-test') {
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
 
                         ls -la $KEYSTORE_LOCATION
 
-                        mvn test -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false
+                        mvn test -pl e2e-patient-test -am -Dtest=PatientEndpointTests -DfailIfNoTests=false
                     '''
                 }
             }

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -298,7 +298,7 @@ class TestRunner {
         JSONArray errors = json.getJSONArray("error");
 
         if (errors.length() > 0) {
-            System.out.println(errors);
+            log.error(errors.toString());
         }
 
         assertEquals(0, errors.length());
@@ -469,10 +469,10 @@ class TestRunner {
                 String val = (String) obj.get(i);
                 if (!allowedFields.contains(val)) {
                     if (disallowedFields.contains(val)) {
-                        System.out.println("********** API outputted invalid field '" + val + "'");
+                        log.info("********** API outputted invalid field '" + val + "'");
                         return false;
                     } else {
-                        System.out.println("********** API outputted unknown field '" + val + "'");
+                        log.info("********** API outputted unknown field '" + val + "'");
                         return false;
                     }
                 }
@@ -517,7 +517,7 @@ class TestRunner {
         while ((read = zipIn.read()) != -1) {
             result.append((char) read);
         }
-        System.out.println("    Entry " + entry.getName() + " - size: " + result.length());
+        log.info("    Entry " + entry.getName() + " - size: " + result.length());
         return result.toString();
     }
 
@@ -554,7 +554,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(1)
     void runSystemWideExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 1 - " + version.toString());
+        log.info("Starting test 1 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
         assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
@@ -568,10 +568,9 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(2)
     void runSystemWideExportSince(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 2 - " + version.toString());
+        log.info("Starting test 2 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, earliest, version);
         log.info("run system wide export since {}", exportResponse);
-        System.out.println(earliest);
         assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
 
@@ -584,7 +583,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(3)
     void runErrorSince(FhirVersion version) throws IOException, InterruptedException {
-        System.out.println("Starting test 3 - " + version.toString());
+        log.info("Starting test 3 - " + version.toString());
         OffsetDateTime timeBeforeEarliest = earliest.minus(1, ChronoUnit.MINUTES);
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, timeBeforeEarliest, version);
         assertEquals(400, exportResponse.statusCode());
@@ -598,7 +597,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(4)
     void runSystemWideZipExport(FhirVersion version) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 4 - " + version.toString());
+        log.info("Starting test 4 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(ZIPFORMAT, null, version);
         log.info("run system wide zip export {}", exportResponse);
         assertEquals(400, exportResponse.statusCode());
@@ -608,7 +607,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(5)
     void runContractNumberExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 5 - " + version.toString());
+        log.info("Starting test 5 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, FHIR_TYPE, null, version);
         log.info("run contract number export {}", exportResponse);
         assertEquals(202, exportResponse.statusCode());
@@ -623,7 +622,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(6)
     void runContractNumberZipExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 6 - " + version.toString());
+        log.info("Starting test 6 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, ZIPFORMAT, null, version);
         log.info("run contract number zip export {}", exportResponse);
         assertEquals(400, exportResponse.statusCode());
@@ -633,7 +632,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(7)
     void testDelete(FhirVersion version) throws IOException, InterruptedException {
-        System.out.println("Starting test 7 - " + version.toString());
+        log.info("Starting test 7 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
         assertEquals(202, exportResponse.statusCode());
@@ -649,7 +648,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(8)
     void testClientCannotDownloadOtherClientsJob(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
-        System.out.println("Starting test 8 - " + version.toString());
+        log.info("Starting test 8 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, FHIR_TYPE, null, version);
         assertEquals(202, exportResponse.statusCode());
         List<String> contentLocationList = exportResponse.headers().map().get("content-location");
@@ -666,7 +665,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(9)
     void testClientCannotDeleteOtherClientsJob(FhirVersion version) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
-        System.out.println("Starting test 9 - " + version.toString());
+        log.info("Starting test 9 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
         assertEquals(202, exportResponse.statusCode());
@@ -688,7 +687,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(10)
     void testClientCannotCheckStatusOtherClientsJob(FhirVersion version) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
-        System.out.println("Starting test 10 - " + version.toString());
+        log.info("Starting test 10 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
         assertEquals(202, exportResponse.statusCode());
@@ -718,7 +717,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(11)
     void testClientCannotMakeRequestWithoutToken(FhirVersion version) throws IOException, InterruptedException {
-        System.out.println("Starting test 11 - " + version.toString());
+        log.info("Starting test 11 - " + version.toString());
         HttpRequest exportRequest = HttpRequest.newBuilder()
                 .uri(URI.create(APIClient.buildAB2DAPIUrl(version) + PATIENT_EXPORT_PATH))
                 .timeout(Duration.ofSeconds(30))
@@ -735,7 +734,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(12)
     void testClientCannotMakeRequestWithSelfSignedToken(FhirVersion version) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 12 - " + version.toString());
+        log.info("Starting test 12 - " + version.toString());
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
         Instant now = Instant.now();
@@ -773,7 +772,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(13)
     void testClientCannotMakeRequestWithNullClaims(FhirVersion version) throws IOException, InterruptedException, JSONException {
-        System.out.println("Starting test 13 - " + version.toString());
+        log.info("Starting test 13 - " + version.toString());
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
         Instant now = Instant.now();
@@ -804,7 +803,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(14)
     void testBadQueryParameterResource(FhirVersion version) throws IOException, InterruptedException {
-        System.out.println("Starting test 14 - " + version.toString());
+        log.info("Starting test 14 - " + version.toString());
         var params = new HashMap<>() {{
             put("_type", "BadParam");
         }};
@@ -818,7 +817,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(15)
     void testBadQueryParameterOutputFormat(FhirVersion version) throws IOException, InterruptedException {
-        System.out.println("Starting test 15 - " + version.toString());
+        log.info("Starting test 15 - " + version.toString());
         var params = new HashMap<>() {{
             put("_outputFormat", "BadParam");
         }};
@@ -832,7 +831,7 @@ class TestRunner {
     @Test
     @Order(16)
     void testHealthEndPoint() throws IOException, InterruptedException {
-        System.out.println("Starting test 16");
+        log.info("Starting test 16");
         HttpResponse<String> healthCheckResponse = apiClient.healthCheck();
 
         assertEquals(200, healthCheckResponse.statusCode());

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -554,6 +554,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(1)
     void runSystemWideExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 1 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
         assertEquals(202, exportResponse.statusCode());
@@ -568,6 +569,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(2)
     void runSystemWideExportSince(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 2 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, earliest, version);
         log.info("run system wide export since {}", exportResponse);
@@ -583,6 +585,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(3)
     void runErrorSince(FhirVersion version) throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 3 - " + version.toString());
         OffsetDateTime timeBeforeEarliest = earliest.minus(1, ChronoUnit.MINUTES);
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, timeBeforeEarliest, version);
@@ -597,6 +600,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(4)
     void runSystemWideZipExport(FhirVersion version) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 4 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(ZIPFORMAT, null, version);
         log.info("run system wide zip export {}", exportResponse);
@@ -607,6 +611,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(5)
     void runContractNumberExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 5 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, FHIR_TYPE, null, version);
         log.info("run contract number export {}", exportResponse);
@@ -622,6 +627,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(6)
     void runContractNumberZipExport(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 6 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, ZIPFORMAT, null, version);
         log.info("run contract number zip export {}", exportResponse);
@@ -632,6 +638,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(7)
     void testDelete(FhirVersion version) throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 7 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
@@ -648,6 +655,7 @@ class TestRunner {
     @MethodSource("getVersionAndContract")
     @Order(8)
     void testClientCannotDownloadOtherClientsJob(FhirVersion version, String contract) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+        System.out.println();
         log.info("Starting test 8 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportByContractRequest(contract, FHIR_TYPE, null, version);
         assertEquals(202, exportResponse.statusCode());
@@ -665,6 +673,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(9)
     void testClientCannotDeleteOtherClientsJob(FhirVersion version) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+        System.out.println();
         log.info("Starting test 9 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
@@ -687,6 +696,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(10)
     void testClientCannotCheckStatusOtherClientsJob(FhirVersion version) throws IOException, InterruptedException, JSONException, NoSuchAlgorithmException, KeyManagementException {
+        System.out.println();
         log.info("Starting test 10 - " + version.toString());
         HttpResponse<String> exportResponse = apiClient.exportRequest(FHIR_TYPE, null, version);
 
@@ -717,6 +727,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(11)
     void testClientCannotMakeRequestWithoutToken(FhirVersion version) throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 11 - " + version.toString());
         HttpRequest exportRequest = HttpRequest.newBuilder()
                 .uri(URI.create(APIClient.buildAB2DAPIUrl(version) + PATIENT_EXPORT_PATH))
@@ -734,6 +745,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(12)
     void testClientCannotMakeRequestWithSelfSignedToken(FhirVersion version) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 12 - " + version.toString());
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
@@ -772,6 +784,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(13)
     void testClientCannotMakeRequestWithNullClaims(FhirVersion version) throws IOException, InterruptedException, JSONException {
+        System.out.println();
         log.info("Starting test 13 - " + version.toString());
         String clientSecret = "wefikjweglkhjwelgkjweglkwegwegewg";
         SecretKey sharedSecret = Keys.hmacShaKeyFor(clientSecret.getBytes(StandardCharsets.UTF_8));
@@ -803,6 +816,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(14)
     void testBadQueryParameterResource(FhirVersion version) throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 14 - " + version.toString());
         var params = new HashMap<>() {{
             put("_type", "BadParam");
@@ -817,6 +831,7 @@ class TestRunner {
     @MethodSource("getVersion")
     @Order(15)
     void testBadQueryParameterOutputFormat(FhirVersion version) throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 15 - " + version.toString());
         var params = new HashMap<>() {{
             put("_outputFormat", "BadParam");
@@ -831,6 +846,7 @@ class TestRunner {
     @Test
     @Order(16)
     void testHealthEndPoint() throws IOException, InterruptedException {
+        System.out.println();
         log.info("Starting test 16");
         HttpResponse<String> healthCheckResponse = apiClient.healthCheck();
 

--- a/e2e-test/src/test/resources/logback.xml
+++ b/e2e-test/src/test/resources/logback.xml
@@ -5,6 +5,7 @@
         </encoder>
     </appender>
     <logger name="org.testcontainers.containers" level="WARN"/>
+    <logger name="ca.uhn.fhir.parser.LenientErrorHandler" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/e2e-test/src/test/resources/logback.xml
+++ b/e2e-test/src/test/resources/logback.xml
@@ -4,8 +4,7 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.testcontainers.containers" level="WARN"/>
-    <logger name="ca.uhn.fhir.parser.LenientErrorHandler" level="INFO"/>
+    <logger name="org.testcontainers.containers" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <project.root>${basedir}</project.root>
         <java.version>11</java.version>
-        <hapi.version>5.4.1</hapi.version>
+        <hapi.version>5.4.0</hapi.version>
         <!-- eventlogger is imported first by all other modules, if that changes then
          okhttp3 must be imported first anywhere the slack client is used-->
         <okhttp3.version>4.9.1</okhttp3.version>
@@ -181,7 +181,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>85%</minimum>
+                                            <minimum>20%</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>20%</minimum>
+                                            <minimum>85%</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
@@ -46,11 +46,11 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
 
     public CoverageMappingCallable(FhirVersion version, CoverageMapping coverageMapping, BFDClient bfdClient,
                                    boolean skipBillablePeriodCheck) {
+        this.skipBillablePeriodCheck = skipBillablePeriodCheck;
         this.coverageMapping = coverageMapping;
         this.bfdClient = bfdClient;
         this.completed = new AtomicBoolean(false);
         this.year = getCorrectedYear(coverageMapping.getPeriod().getYear());
-        this.skipBillablePeriodCheck = skipBillablePeriodCheck;
         this.version = version;
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
@@ -38,7 +38,8 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
     private int hasHistoricalMbi;
     private int filteredByYear;
 
-    public CoverageMappingCallable(FhirVersion version, CoverageMapping coverageMapping, BFDClient bfdClient, boolean skipBillablePeriodCheck) {
+    public CoverageMappingCallable(FhirVersion version, CoverageMapping coverageMapping, BFDClient bfdClient,
+                                   boolean skipBillablePeriodCheck) {
         this.coverageMapping = coverageMapping;
         this.bfdClient = bfdClient;
         this.completed = new AtomicBoolean(false);
@@ -70,7 +71,7 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
 
             BFDClient.BFD_BULK_JOB_ID.set(coverageMapping.getJobId());
 
-            IBaseBundle bundle = getBundle(contractNumber, month);
+            IBaseBundle bundle = getBundle(contractNumber, month, year);
             patientIds.addAll(extractAndFilter(bundle));
 
             String availableLinks = BundleUtils.getAvailableLinks(bundle);
@@ -197,11 +198,12 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
      *
      * @param contractNumber - the PDP's contract number
      * @param month - the month to pull data for (1-12)
+     * @param year - the year to pull data for
      * @return a FHIR bundle of resources containing active patients
      */
-    private IBaseBundle getBundle(String contractNumber, int month) {
+    private IBaseBundle getBundle(String contractNumber, int month, int year) {
         try {
-            return bfdClient.requestPartDEnrolleesFromServer(version, contractNumber, month);
+            return bfdClient.requestPartDEnrolleesFromServer(version, contractNumber, month, year);
         } catch (Exception e) {
             final Throwable rootCause = ExceptionUtils.getRootCause(e);
             log.error("Error while calling for Contract-2-Bene API : {}", e.getMessage(), rootCause);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallable.java
@@ -26,6 +26,8 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
     public static final String HISTORIC_MBI = "historic";
     public static final String MBI_ID = "http://hl7.org/fhir/sid/us-mbi";
 
+    // Use year 3 by default since all synthetic data has this year on it
+    // todo get rid of this when data is updated
     private static final int SYNTHETIC_DATA_YEAR = 3;
 
     private final CoverageMapping coverageMapping;
@@ -45,10 +47,7 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
         this.coverageMapping = coverageMapping;
         this.bfdClient = bfdClient;
         this.completed = new AtomicBoolean(false);
-
-        // Use year 3 by default since all synthetic data has this year on it
-        // todo get rid of this when data is updated
-        this.year = skipBillablePeriodCheck ? 3 : coverageMapping.getPeriod().getYear();
+        this.year = coverageMapping.getPeriod().getYear();
         this.skipBillablePeriodCheck = skipBillablePeriodCheck;
         this.version = version;
     }
@@ -208,6 +207,7 @@ public class CoverageMappingCallable implements Callable<CoverageMapping> {
      */
     private IBaseBundle getBundle(String contractNumber, int month, int year) {
         try {
+            // Use specific year for synthetic data if in a sandbox environment
             if (skipBillablePeriodCheck) {
                 return bfdClient.requestPartDEnrolleesFromServer(version, contractNumber, month, SYNTHETIC_DATA_YEAR);
             }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -430,7 +430,7 @@ class CoverageDriverTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         processor.queueCoveragePeriod(january, false);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallableTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageMappingCallableTest.java
@@ -45,7 +45,7 @@ class CoverageMappingCallableTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20, 2020);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         Contract contract = new Contract();
@@ -85,7 +85,7 @@ class CoverageMappingCallableTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20, 3,2020);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         Contract contract = new Contract();
@@ -138,7 +138,7 @@ class CoverageMappingCallableTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20, 3,2020);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         Contract contract = new Contract();
@@ -188,7 +188,7 @@ class CoverageMappingCallableTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20, 2019);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         Contract contract = new Contract();
@@ -238,7 +238,7 @@ class CoverageMappingCallableTest {
             patient.setIdentifier(emptyList());
         });
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         Contract contract = new Contract();

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -407,7 +407,7 @@ class CoverageUpdateAndProcessorTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20);
 
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         processor.queueCoveragePeriod(january, false);
@@ -459,7 +459,7 @@ class CoverageUpdateAndProcessorTest {
         org.hl7.fhir.dstu3.model.Bundle bundle2 = buildBundle(10, 20);
 
         Mockito.clearInvocations();
-        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt())).thenReturn(bundle1);
+        when(bfdClient.requestPartDEnrolleesFromServer(eq(STU3), anyString(), anyInt(), anyInt())).thenReturn(bundle1);
         when(bfdClient.requestNextBundleFromServer(eq(STU3), any(org.hl7.fhir.dstu3.model.Bundle.class))).thenReturn(bundle2);
 
         driver.loadMappingJob();


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3766](https://jira.cms.gov/browse/AB2D-3766) - Fix tests

### What Does This PR Do?

The new BFD Patient endpoint defaults to the current year instead of no year if no year is provided. This causes test to fail since all attribution data for sandbox data is in the year 3. The year 3 has to be explicitly passed during sandbox e2e tests

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure