### PR TITLE
remove max pool size param and set core pool to fixed value

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/config/CoverageQueueConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/CoverageQueueConfig.java
@@ -14,11 +14,10 @@ public class CoverageQueueConfig {
 
     @Bean(name = "patientCoverageThreadPool")
     public ThreadPoolTaskExecutor patientContractThreadPool(
-            @Value("#{new Integer('${coverage.core.pool.size}')}") int corePoolSize,
-            @Value("#{new Integer('${coverage.max.pool.size}')}") int maxPoolSize) {
+            @Value("#{new Integer('${coverage.core.pool.size}')}") int corePoolSize) {
         final ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
         taskExecutor.setCorePoolSize(corePoolSize);
-        taskExecutor.setMaxPoolSize(maxPoolSize);
+        taskExecutor.setMaxPoolSize(corePoolSize);
         taskExecutor.setThreadNamePrefix("coveragep-");
         taskExecutor.initialize();
         return taskExecutor;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
@@ -98,8 +98,8 @@ public class CoverageProcessorImpl implements CoverageProcessor {
 
     public boolean isProcessorBusy() {
 
-        boolean busy = coverageInsertionQueue.size() >= executor.getMaxPoolSize() ||
-                executor.getActiveCount() >= executor.getMaxPoolSize();
+        boolean busy = coverageInsertionQueue.size() >= executor.getCorePoolSize() ||
+                executor.getActiveCount() >= executor.getCorePoolSize();
 
         // Useful log if we run into concurrency issues
         if (busy) {

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -40,8 +40,7 @@ job.max.pool.size=${AB2D_JOB_POOL_MAX_SIZE:#{10}}
 job.queue.capacity=${AB2D_JOB_QUEUE_CAPACITY:#{0}}
 
 ## These properties apply to "patientCoverageThreadPool"
-coverage.core.pool.size=5
-coverage.max.pool.size=10
+coverage.core.pool.size=10
 
 # Coverage processor parameterization to find stale jobs, stuck jobs, and limit allowed failures
 # Run every minute for testing

--- a/worker/src/test/resources/application.properties
+++ b/worker/src/test/resources/application.properties
@@ -50,8 +50,7 @@ job.queue.capacity=0
 ## These properties apply to "patientCoverageThreadPool"
 # Never run automatically in testing
 coverage.update.schedule=0 0 0 1 * ? 2099
-coverage.core.pool.size=6
-coverage.max.pool.size=12
+coverage.core.pool.size=12
 coverage.update.max.attempts=3
 coverage.update.initial.delay=1
 # Never runs because the date is February 31st


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3815](https://jira.cms.gov/browse/AB2D-3815) - Enrollment Thread Pool Size
 
### What Does This PR Do?

ThreadPoolTaskExecutors uses queue capacity to dictate when to increase the number of threads in the pool. This is too complicated for enrollment and frankly we don't care about scaling this pool. So instead the pool size is going to be hard-coded to the same core pool size and max pool size. Logic is in place to prevent adding jobs when the pool is full.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure