### PR TITLE
AB2D-3763 Update text from green to black

### DIFF
--- a/website/accessing-claims-data.md
+++ b/website/accessing-claims-data.md
@@ -337,7 +337,7 @@ active-nav: accessing-claims-data-nav
                          actual Medicare Parts A and B claims data.</li>
                         <li>The AB2D team will work closely with the organization and its "AB2D Data Operations Specialist" to answer any questions or troubleshoot
                          any issues they have connecting to the AB2D API.</li>
-                         <li style="color: #6AA84F;">For more information and to help answer any remaining question you may have, production documentation 
+                         <li>For more information and to help answer any remaining question you may have, production documentation 
                             can be found in the <a href="https://github.com/CMSgov/ab2d-pdp-documentation" rel="noopener noreferrer" target="_blank">AB2D Githhub repository</a>. 
                         </li>
                     </ul> 


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3763](https://jira.cms.gov/browse/AB2D-3763):

The text on the bottom of this page needs to be black instead of green. https://ab2d.cms.gov/accessing-claims-data.html

The text reads:

    For more information and to help answer any remaining question you may have, production documentation can be found in the AB2D Githhub repository."

That linked text is OK to stay linked. The rest needs to be black instead of green
 
### What Does This PR Do?

Updates the last point on Accessing Claims Data page to be black instead of green

### What Should Reviewers Watch For?
Ensure the text is black

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?
N/A
### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure