### PR TITLE
Wasn't finding the currency on R4 MBI Identifiers

### DIFF
--- a/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -276,9 +276,10 @@ public final class IdentifierUtils {
         }
         if (system.equalsIgnoreCase(PatientIdentifier.Type.MBI.getSystem())) {
             PatientIdentifier.Currency currency = getCurrencyMbi(identifier);
-            if (currency == PatientIdentifier.Currency.UNKNOWN) {
-                return getCurrencyMbiStandard(identifier);
+            if (currency != PatientIdentifier.Currency.UNKNOWN) {
+                return currency;
             }
+            return getCurrencyMbiStandard(identifier);
         }
         return PatientIdentifier.Currency.UNKNOWN;
     }

--- a/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -219,14 +219,14 @@ public final class IdentifierUtils {
                 Object extension = extensions.get(0);
                 String url = (String) Versions.invokeGetMethod(extension, "getUrl");
                 if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
-                    Object extValue = Versions.invokeGetMethod(extension, "getValue");
-                    String extValueSystem = (String) Versions.invokeGetMethod(extValue, "getSystem");
+                    Object currValue = Versions.invokeGetMethod(extension, "getValue");
+                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, "getSystem");
                     if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
-                        String extValueCode = (String) Versions.invokeGetMethod(extValue, "getCode");
-                        if (CURRENT_MBI.equalsIgnoreCase(extValueCode)) {
+                        String currValueCode = (String) Versions.invokeGetMethod(currValue, "getCode");
+                        if (CURRENT_MBI.equalsIgnoreCase(currValueCode)) {
                             return PatientIdentifier.Currency.CURRENT;
                         }
-                        if (HISTORIC_MBI.equalsIgnoreCase(extValueCode)) {
+                        if (HISTORIC_MBI.equalsIgnoreCase(currValueCode)) {
                             return PatientIdentifier.Currency.HISTORIC;
                         }
                     }
@@ -275,10 +275,10 @@ public final class IdentifierUtils {
             return null;
         }
         if (system.equalsIgnoreCase(PatientIdentifier.Type.MBI.getSystem())) {
-            return getCurrencyMbi(identifier);
-        }
-        if (system.equalsIgnoreCase(PatientIdentifier.Type.MBI_R4.getSystem())) {
-            return getCurrencyMbiStandard(identifier);
+            PatientIdentifier.Currency currency = getCurrencyMbi(identifier);
+            if (currency == PatientIdentifier.Currency.UNKNOWN) {
+                return getCurrencyMbiStandard(identifier);
+            }
         }
         return PatientIdentifier.Currency.UNKNOWN;
     }

--- a/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -29,6 +29,11 @@ public final class IdentifierUtils {
             "https://bluebutton.cms.gov/resources/codesystem/identifier-currency";
     public static final String BENEFICIARY_ID = "https://bluebutton.cms.gov/resources/variables/bene_id";
 
+    private static final String GET_SYSTEM = "getSystem";
+    private static final String GET_VALUE = "getValue";
+    private static final String GET_IDENTIFIER = "getIdentifier";
+    private static final String GET_CODE = "getCode";
+
     private IdentifierUtils() {
     }
 
@@ -52,7 +57,7 @@ public final class IdentifierUtils {
             derivedIds.add(beneId);
         }
 
-        List identifiers = (List) Versions.invokeGetMethod(patient, "getIdentifier");
+        List identifiers = (List) Versions.invokeGetMethod(patient, GET_IDENTIFIER);
         derivedIds.addAll((List<PatientIdentifier>) identifiers.stream()
                 .map(c -> getIdentifier((ICompositeType) c))
                 .filter(c -> c != null)
@@ -80,12 +85,12 @@ public final class IdentifierUtils {
      * @return - our standardized identifier
      */
     public static PatientIdentifier getIdentifier(ICompositeType id) {
-        String system = (String) Versions.invokeGetMethod(id, "getSystem");
+        String system = (String) Versions.invokeGetMethod(id, GET_SYSTEM);
         if (system == null) {
             return null;
         }
         PatientIdentifier derivedId = new PatientIdentifier();
-        String value = (String) Versions.invokeGetMethod(id, "getValue");
+        String value = (String) Versions.invokeGetMethod(id, GET_VALUE);
         derivedId.setValue(value);
         derivedId.setType(PatientIdentifier.Type.fromSystem(system));
         derivedId.setCurrency(getCurrency(id));
@@ -148,7 +153,7 @@ public final class IdentifierUtils {
      * @return the value of the system
      */
     private static String getSystem(ICompositeType identifier) {
-        return (String) Versions.invokeGetMethod(identifier, "getSystem");
+        return (String) Versions.invokeGetMethod(identifier, GET_SYSTEM);
     }
 
     /**
@@ -158,7 +163,7 @@ public final class IdentifierUtils {
      * @return the value of the identifier
      */
     private static String getValue(ICompositeType identifier) {
-        return (String) Versions.invokeGetMethod(identifier, "getValue");
+        return (String) Versions.invokeGetMethod(identifier, GET_VALUE);
     }
 
     /**
@@ -172,11 +177,11 @@ public final class IdentifierUtils {
         if (currencyExtension.isEmpty()) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
-        Object code = Versions.invokeGetMethod(currencyExtension.get(), "getValue");
+        Object code = Versions.invokeGetMethod(currencyExtension.get(), GET_VALUE);
         if (code == null) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
-        String codeValue = (String) Versions.invokeGetMethod(code, "getCode");
+        String codeValue = (String) Versions.invokeGetMethod(code, GET_CODE);
         switch (codeValue) {
             case HISTORIC_MBI:
                 return PatientIdentifier.Currency.HISTORIC;
@@ -211,18 +216,18 @@ public final class IdentifierUtils {
             return PatientIdentifier.Currency.UNKNOWN;
         }
         Object val = vals.get(0);
-        String codeSystem = (String) Versions.invokeGetMethod(val, "getSystem");
-        String codeValue = (String) Versions.invokeGetMethod(val, "getCode");
+        String codeSystem = (String) Versions.invokeGetMethod(val, GET_SYSTEM);
+        String codeValue = (String) Versions.invokeGetMethod(val, GET_CODE);
         if (codeSystem != null && codeSystem.equalsIgnoreCase(MBI_ID_R4) && ("MB".equalsIgnoreCase(codeValue) || "MC".equalsIgnoreCase(codeValue))) {
             List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
             if (extensions != null && extensions.size() > 0) {
                 Object extension = extensions.get(0);
                 String url = (String) Versions.invokeGetMethod(extension, "getUrl");
                 if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
-                    Object currValue = Versions.invokeGetMethod(extension, "getValue");
-                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, "getSystem");
+                    Object currValue = Versions.invokeGetMethod(extension, GET_VALUE);
+                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_VALUE);
                     if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
-                        String currValueCode = (String) Versions.invokeGetMethod(currValue, "getCode");
+                        String currValueCode = (String) Versions.invokeGetMethod(currValue, GET_CODE);
                         if (CURRENT_MBI.equalsIgnoreCase(currValueCode)) {
                             return PatientIdentifier.Currency.CURRENT;
                         }

--- a/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -225,7 +225,7 @@ public final class IdentifierUtils {
                 String url = (String) Versions.invokeGetMethod(extension, "getUrl");
                 if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
                     Object currValue = Versions.invokeGetMethod(extension, GET_VALUE);
-                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_VALUE);
+                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_SYSTEM);
                     if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
                         String currValueCode = (String) Versions.invokeGetMethod(currValue, GET_CODE);
                         if (CURRENT_MBI.equalsIgnoreCase(currValueCode)) {

--- a/fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -103,6 +103,7 @@ class PatientIdentifierUtilsTest {
 
             PatientIdentifier mbiCurrentId = IdentifierUtils.getCurrentMbi(ids);
             assertTrue(currentMbis.contains(mbiCurrentId.getValue()));
+            assertEquals(CURRENT, mbiCurrentId.getCurrency());
 
             /* Currently, no historical MBIs are in test data */
             Set<PatientIdentifier> historicalMbi = IdentifierUtils.getHistoricMbi(ids);

--- a/fhir/src/test/resources/data/r4patients.json
+++ b/fhir/src/test/resources/data/r4patients.json
@@ -8,15 +8,11 @@
   "link": [
     {
       "relation": "self",
-      "url": "https://prod-sbx.bfd.cms.gov/v2/fhir/Patient?_has%3ACoverage.extension=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Fptdcntrct12%7CZ0002&_count=3&_format=json"
+      "url": "https://prod-sbx.bfd.cms.gov/v2/fhir/Patient?_has%3ACoverage.extension=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Fptdcntrct01%7CZ1001&_has%3ACoverage.rfrncyr=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Frfrnc_yr%7C2021&_count=4000&_format=json"
     },
     {
       "relation": "first",
-      "url": "https://prod-sbx.bfd.cms.gov/v2/fhir/Patient?_has%3ACoverage.extension=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Fptdcntrct12%7CZ0002&_count=3&_format=json"
-    },
-    {
-      "relation": "next",
-      "url": "https://prod-sbx.bfd.cms.gov/v2/fhir/Patient?_has%3ACoverage.extension=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Fptdcntrct12%7CZ0002&_count=3&_format=json&cursor=-19990000001103"
+      "url": "https://prod-sbx.bfd.cms.gov/v2/fhir/Patient?_has%3ACoverage.extension=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Fptdcntrct01%7CZ1001&_has%3ACoverage.rfrncyr=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fvariables%2Frfrnc_yr%7C2021&_count=4000&_format=json"
     }
   ],
   "entry": [
@@ -58,91 +54,7 @@
           },
           {
             "url": "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
-            "valueDate": "0003"
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_01",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_01",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_02",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_02",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_03",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_03",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_04",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_04",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_05",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_05",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_06",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_06",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_07",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_07",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_08",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_08",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_09",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_09",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_10",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_10",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_11",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_11",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_12",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_12",
-              "code": "AA"
-            }
+            "valueDate": "2021"
           }
         ],
         "identifier": [
@@ -180,29 +92,24 @@
               ]
             },
             "system": "http://hl7.org/fhir/sid/us-mbi",
-            "value": "3S24A00AA00",
-            "period": {
-              "start": "2020-01-01"
-            }
+            "value": "3S24A00AA00"
           }
         ],
         "name": [
           {
             "use": "usual",
-            "family": "Doe",
+            "family": "Tromp100",
             "given": [
-              "Jane",
-              "X"
+              "Franklyn361"
             ]
           }
         ],
         "gender": "female",
         "birthDate": "1999-06-01",
-        "deceasedDateTime": "1981-03-17",
+        "deceasedBoolean": false,
         "address": [
           {
-            "state": "03",
-            "postalCode": "99999"
+            "state": "22"
           }
         ]
       }
@@ -245,91 +152,7 @@
           },
           {
             "url": "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
-            "valueDate": "0003"
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_01",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_01",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_02",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_02",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_03",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_03",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_04",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_04",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_05",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_05",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_06",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_06",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_07",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_07",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_08",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_08",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_09",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_09",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_10",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_10",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_11",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_11",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_12",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_12",
-              "code": "AA"
-            }
+            "valueDate": "2021"
           }
         ],
         "identifier": [
@@ -376,10 +199,9 @@
         "name": [
           {
             "use": "usual",
-            "family": "Doe",
+            "family": "Tillman293",
             "given": [
-              "John",
-              "X"
+              "Benny518"
             ]
           }
         ],
@@ -388,8 +210,8 @@
         "deceasedDateTime": "1981-03-17",
         "address": [
           {
-            "state": "31",
-            "postalCode": "99999"
+            "state": "22",
+            "postalCode": "02169"
           }
         ]
       }
@@ -432,91 +254,7 @@
           },
           {
             "url": "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
-            "valueDate": "0003"
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_01",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_01",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_02",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_02",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_03",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_03",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_04",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_04",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_05",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_05",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_06",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_06",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_07",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_07",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_08",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_08",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_09",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_09",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_10",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_10",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_11",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_11",
-              "code": "AA"
-            }
-          },
-          {
-            "url": "https://bluebutton.cms.gov/resources/variables/dual_12",
-            "valueCoding": {
-              "system": "https://bluebutton.cms.gov/resources/variables/dual_12",
-              "code": "AA"
-            }
+            "valueDate": "2021"
           }
         ],
         "identifier": [
@@ -563,10 +301,9 @@
         "name": [
           {
             "use": "usual",
-            "family": "Doe",
+            "family": "Abshire638",
             "given": [
-              "John",
-              "X"
+              "Gracie337"
             ]
           }
         ],


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3894](https://jira.cms.gov/browse/AB2D-3894) - Not picking up currency of R4 MBIs in Patient Identifiers
 
### What Does This PR Do?

While doing some Synthea testing, I noticed that we were not finding the currency (current or historic) values for the MBIs, even when they were present. It was marking them as UNKNOWN.

Under further investigation, it looks like BFD reverted to the MBI identifier system URL they used for STU3 instead of the new one they said they were going to use for R4. The currency was still in the new place for R4 but because the system of the identifier was the old STU3 version, it was never finding the value because because it was only looking in the STU3 location.

Also did some variable cleanup and updated the patient R4 json test file with the most current implementation of results being returned from BFD. Explicitly tested for currency since the tests were passing because if you ask for current and you can't find one marked current, it was choosing the UNKNOWN one if it had no better options which masked the bug.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure