### PR TITLE
Feature/ab2d 3838 drop coverage table

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -116,3 +116,5 @@ databaseChangeLog:
       file: db/changelog/test_only/coverage-fake-partitions.sql
   - include:
       file: db/changelog/v2021/replace_coverage_table.sql
+  - include:
+      file: db/changelog/v2021/drop_old_coverage_table.sql

--- a/common/src/main/resources/db/changelog/v2021/drop_old_coverage_table.sql
+++ b/common/src/main/resources/db/changelog/v2021/drop_old_coverage_table.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+--changeset sb-wnyffenegger:drop_old_coverage_table failOnError:true
+
+DROP TABLE coverage_deprecated;
+

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorImpl.java
@@ -135,8 +135,6 @@ public class CoverageProcessorImpl implements CoverageProcessor {
             if (!inShutdown.get()) {
                 Iterator<CoverageMappingCallable> mappingCallableIterator = inProgressMappings.iterator();
 
-                log.info("Checking running jobs for changes in state");
-
                 while (mappingCallableIterator.hasNext()) {
 
                     CoverageMappingCallable mappingCallable = mappingCallableIterator.next();


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3838](https://jira.cms.gov/browse/AB2D-3838) - Drop the old coverage table
 
### What Does This PR Do?

Drop the old coverage table via Liquibase.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure