### PR TITLE
Verify since date before making eob request

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -125,14 +125,24 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
      * @param request patient claims request which may contain a since time or attestation time to use
      */
     private OffsetDateTime getSinceTime(PatientClaimsRequest request) {
-        OffsetDateTime sinceTime = null;
-        if (request.getSinceTime() == null) {
-            if (request.getAttTime().isAfter(START_CHECK)) {
+        OffsetDateTime sinceTime = request.getSinceTime();
+
+        if (sinceTime == null) {
+            if (request.getAttTime().isAfter(START_CHECK) || request.getAttTime().isEqual(START_CHECK)) {
                 sinceTime = request.getAttTime();
             }
         } else {
-            sinceTime = request.getSinceTime();
+
+            if (sinceTime.isBefore(request.getAttTime())) {
+                sinceTime = request.getAttTime();
+            }
+
+            // Should not be possible but just in case
+            if (sinceTime.isBefore(START_CHECK)) {
+                sinceTime = null;
+            }
         }
+
         return sinceTime;
     }
 


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4004](https://jira.cms.gov/browse/AB2D-4004) - Since Date not Verified for EOB Requests

### What Does This PR Do?

Fix a bug where it was possible to give a bad since date as part of an EOB request. Providing a bad since date would either lead to slow performance or it being ignored.

Other checks prevent providing data before the ab2d epoch or a contract's attestation date so this would not lead to providing extra data.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure