### PR TITLE
Bump logback-access-spring-boot-starter from 2.11.0 to 3.0.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -82,9 +82,9 @@
             <version>${logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.rakugakibox.spring.boot</groupId>
+            <groupId>dev.akkinoc.spring.boot</groupId>
             <artifactId>logback-access-spring-boot-starter</artifactId>
-            <version>2.11.0</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What Does This PR Do?

Update the logback starter for spring boot package to point at the new module group name in Maven. Dependabot PR is failing due to movement of the module.

Related PRs: #791 

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure