### PR TITLE
AB2D-3878: Add connection timeouts to Netty for fresh HPMS pulls

### DIFF
--- a/common/src/main/resources/application.common.properties
+++ b/common/src/main/resources/application.common.properties
@@ -10,4 +10,10 @@ hpms.api.params=${AB2D_HPMS_API_PARAMS:{ACS:'wlVuThEThipRlBu37Pra'}}
 # Ingest Hourly
 hpms.ingest.schedule=0 0 0/1 1/1 * ?
 
+## ----------------------------------------------------------------------------------------  Web Client Connection Pool
+# Both are in msec, idle time to 1 minute, max life to 10 minutes.  The entire HPMS pull takes a couple of minutes
+# and runs once per hour.  Thus, have a fresh set of connections every time it is run.
+reactor.netty.pool.maxIdleTime=60000
+reactor.netty.pool.maxLifeTime=600000
+
 spring.liquibase.contexts=none


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-3878](https://jira.cms.gov/browse/AB2D-3878) - Add connection timeouts to Netty for fresh HPMS pulls

***Related Tickets***

[AB2D-41](https://jira.cms.gov/browse/AB2D-41) - Reason it's related
 
### What Does This PR Do?

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure