### PR TITLE
Updated header for file so that it doesn't error out with swagger

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -42,6 +42,7 @@ public class FileDownloadCommon {
         log.info("Sending " + filename + " file to client");
 
         response.setHeader(HttpHeaders.CONTENT_TYPE, NDJSON_FIRE_CONTENT_TYPE);
+        response.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
 
         try (OutputStream out = response.getOutputStream(); FileInputStream in = new FileInputStream(downloadResource.getFile())) {
             IOUtils.copy(in, out);

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -41,8 +41,10 @@ public class FileDownloadCommon {
 
         log.info("Sending " + filename + " file to client");
 
+        String fileDownloadName = downloadResource.getFile().getName();
+
         response.setHeader(HttpHeaders.CONTENT_TYPE, NDJSON_FIRE_CONTENT_TYPE);
-        response.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
+        response.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + fileDownloadName + "\"");
 
         try (OutputStream out = response.getOutputStream(); FileInputStream in = new FileInputStream(downloadResource.getFile())) {
             IOUtils.copy(in, out);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4332](https://jira.cms.gov/browse/AB2D-4332) - The new swagger errors out when you try to download the files

### What Does This PR Do?

Updates response header to give swagger instructions. It prevents it from hanging and allows users to download the file with a click

### What Should Reviewers Watch For?

There should be no impact for other clients

### Usage/Deployment Instructions

Deploy to sandbox

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure