### PR TITLE
Remove Pinned Log4J and Logback Versions given Springboot Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,8 @@
         <jacoco.version>0.8.7</jacoco.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
-
-        
-        <!-- Temporarily force log4j version to 2.17.1 in case someone enterprising decides to change to log4j -->
-        <log4j2.version>2.17.1</log4j2.version>
-        <logback.version>1.2.10</logback.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
### What Does This PR Do?

Springboot dependencies has been updated to include up-to-date versions of log4j and logback that are not vulnerable to the disclosed CVEs.

We no longer need to pin the versions of log4j and logback in our parent pom.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure