### PR TITLE
HPMS Connection Reset Errors

### DIFF
--- a/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
-import reactor.netty.tcp.TcpClient;
 
 @Configuration
 public class WebClientConfig {
@@ -15,10 +14,9 @@ public class WebClientConfig {
     @Bean
     public WebClient buildWebClient() {
         final int timeout = 90;
-        TcpClient tcpClient = TcpClient.newConnection();
-        HttpClient httpClient = HttpClient.from(tcpClient)
-                .tcpConfiguration(client -> client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout * 1000)
-                        .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeout))));
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout * 1000)
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeout)));
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
@@ -1,0 +1,27 @@
+package gov.cms.ab2d.hpms.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient buildWebClient() {
+        final int timeout = 90;
+        TcpClient tcpClient = TcpClient.newConnection();
+        HttpClient httpClient = HttpClient.from(tcpClient)
+                .tcpConfiguration(client -> client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout * 1000)
+                        .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeout))));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/config/WebClientConfig.java
@@ -1,22 +1,18 @@
 package gov.cms.ab2d.hpms.config;
 
-import io.netty.channel.ChannelOption;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient buildWebClient() {
-        final int timeout = 90;
-        HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout * 1000)
-                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeout)));
+        HttpClient httpClient = HttpClient.create(ConnectionProvider.newConnection());
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -103,13 +103,12 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     }
 
     // Text Blocks are still a preview feature in JDK 13 and 14, otherwise, it would really clean this up.
-    private static final String AUTH_PAYLOAD_TEMPLATE = """
-            {
-                "userName": "CDA-AB2D-API",
-                "keyId": "%s",
-                "keySecret": "%s",
-                "scopes": "cda_org_att"
-            }""";
+    private static final String AUTH_PAYLOAD_TEMPLATE = "{\n" +
+            "    \"userName\": \"CDA-AB2D-API\",\n" +
+            "    \"keyId\": \"%s\",\n" +
+            "    \"keySecret\": \"%s\",\n" +
+            "    \"scopes\": \"cda_org_att\"\n" +
+            "}";
 
 
     String getAuthToken() {

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.hpms.service;
 
 import gov.cms.ab2d.hpms.hmsapi.HPMSAuthResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -30,6 +31,9 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
 
     @Value("${HPMS_AUTH_KEY_SECRET}")
     private String hpmsSecret;
+
+    @Autowired
+    private WebClient webClient;
 
     private URI fullAuthURI;
 
@@ -63,7 +67,7 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     private void refreshToken(long currentTimestamp) {
         authToken = null;
 
-        Flux<HPMSAuthResponse> orgInfoFlux = WebClient.create()
+        Flux<HPMSAuthResponse> orgInfoFlux = webClient
                 .post().uri(fullAuthURI)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(retrieveAuthRequestPayload())
@@ -99,12 +103,13 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     }
 
     // Text Blocks are still a preview feature in JDK 13 and 14, otherwise, it would really clean this up.
-    private static final String AUTH_PAYLOAD_TEMPLATE = "{\n" +
-            "    \"userName\": \"CDA-AB2D-API\",\n" +
-            "    \"keyId\": \"%s\",\n" +
-            "    \"keySecret\": \"%s\",\n" +
-            "    \"scopes\": \"cda_org_att\"\n" +
-            "}";
+    private static final String AUTH_PAYLOAD_TEMPLATE = """
+            {
+                "userName": "CDA-AB2D-API",
+                "keyId": "%s",
+                "keySecret": "%s",
+                "scopes": "cda_org_att"
+            }""";
 
 
     String getAuthToken() {

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSFetcherImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSFetcherImpl.java
@@ -31,9 +31,12 @@ public class HPMSFetcherImpl extends AbstractHPMSService implements HPMSFetcher 
 
     private final HPMSAuthService authService;
 
+    private final WebClient webClient;
+
     @Autowired
-    public HPMSFetcherImpl(HPMSAuthService authService) {
+    public HPMSFetcherImpl(HPMSAuthService authService, WebClient webClient) {
         this.authService = authService;
+        this.webClient = webClient;
     }
 
     @PostConstruct
@@ -44,7 +47,7 @@ public class HPMSFetcherImpl extends AbstractHPMSService implements HPMSFetcher 
 
     @Override
     public void retrieveSponsorInfo(Consumer<List<HPMSOrganizationInfo>> hpmsOrgCallback) {
-        Mono<List<HPMSOrganizationInfo>> orgInfoMono = WebClient.create()
+        Mono<List<HPMSOrganizationInfo>> orgInfoMono = webClient
                 .get().uri(organizationBaseUri)
                 .headers(authService::buildAuthHeaders)
                 .retrieve()
@@ -56,7 +59,7 @@ public class HPMSFetcherImpl extends AbstractHPMSService implements HPMSFetcher 
 
     @Override
     public void retrieveAttestationInfo(Consumer<Set<HPMSAttestation>> hpmsAttestationCallback, List<String> contractIds) {
-        Mono<Set<HPMSAttestation>> contractsMono = WebClient.create()
+        Mono<Set<HPMSAttestation>> contractsMono = webClient
                 .get().uri(buildAttestationURI(contractIds))
                 .headers(authService::buildAuthHeaders)
                 .retrieve()


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-42](https://jira.cms.gov/browse/AB2D-4238) - Eliminate HPMS Connection Errors

***Related Tickets***
 
### What Does This PR Do?

It configures a single WebClient that does not use the default connection pool.  In fact, it uses no connection pool.  Given the reactive model coupled with running only once an hour, there really is no benefit to using a connection pool.  The drawbacks are stale connections in the default pool that generate these errors.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure