### PR TITLE
Bug/ab2d-4358 Coverage Stability Check Tests Dec - Jan issue

### DIFF
--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -3,23 +3,21 @@ package gov.cms.ab2d.hpms.service;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.hpms.SpringBootTestApp;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")
@@ -37,8 +35,6 @@ class HPMSAuthServiceTest {
     @Test
     public void tokenTest() {
         assertNotNull(authService);
-
-        authService.cleanup();
 
         // Verifying initial state
         assertNull(authService.getAuthToken());

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -38,6 +38,8 @@ class HPMSAuthServiceTest {
     public void tokenTest() {
         assertNotNull(authService);
 
+        authService.cleanup();
+
         // Verifying initial state
         assertNull(authService.getAuthToken());
         assertEquals(0L, authService.getTokenExpires());

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/MockedFetchTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/MockedFetchTest.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.hpms.SpringBootTestApp;
 import gov.cms.ab2d.hpms.hmsapi.HPMSAttestation;
 import gov.cms.ab2d.hpms.hmsapi.HPMSOrganizationInfo;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -27,6 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class MockedFetchTest {
     @Autowired
     private HPMSFetcherImpl fetcher;
+
+    @Autowired
+    HPMSAuthServiceImpl authService;
 
     private final MockWebClient client = new MockWebClient();
 
@@ -62,5 +66,12 @@ class MockedFetchTest {
 
     private void attestation(Set<HPMSAttestation> hpmsAttestations) {
         assertTrue(hpmsAttestations.size() > 0);
+    }
+
+
+    //Needed because the HPMSFetcherImpl uses authservice that needs to be cleared
+    @AfterEach
+    public void shutdown() {
+        authService.cleanup();
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
@@ -210,7 +210,10 @@ public class CoverageCheckPredicatesIntegrationTest {
 
         assertFalse(stableCheck.test(contract));
 
-        assertEquals(2, issues.size());
+        int expectedIssues = attestationMonth.getMonth() == 12 || attestationMonthPlus1.getMonth() == 12
+                || attestationMonthPlus2.getMonth() == 12 ? 1 : 2;
+
+        assertEquals(expectedIssues, issues.size());
         issues.forEach(issue -> assertTrue(issue.contains("enrollment changed")));
         assertTrue(issues.get(0).contains("20%"));
     }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
@@ -185,7 +185,10 @@ public class CoverageCheckPredicatesUnitTest {
 
         assertFalse(stableCheck.test(contract));
 
-        assertEquals(2, issues.size());
+        int expectedIssues = ATTESTATION_TIME.getMonthValue() == 12 || ATTESTATION_TIME.plusMonths(1).getMonthValue() == 12
+                || ATTESTATION_TIME.plusMonths(2).getMonthValue() == 12 ? 1 : 2;
+
+        assertEquals(expectedIssues, issues.size());
         issues.forEach(issue -> assertTrue(issue.contains("enrollment changed")));
         assertTrue(issues.get(0).contains("20%"));
     }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4358](https://jira.cms.gov/browse/AB2D-4358) - Coverage Stability Check Tests Failing

### What Does This PR Do?

Handle the case in unit tests where a December -> January month to month coverage comparison is skipped.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure