### PR TITLE
AB2D-4363: Fixes stale contract usage.

### DIFF
--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
@@ -53,7 +53,9 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
                 .map(Optional::get)
                 .collect(Collectors.toList());
         if (!changedContracts.isEmpty()) {
-            contractRepository.saveAll(changedContracts);
+            List<Contract> updatedContracts = contractRepository.saveAll(changedContracts);
+            // Replace changed contracts in the existing map.  Fixes
+            updatedContracts.forEach(contract -> existingMap.put(contract.getContractNumber(), contract));
         }
 
         // detect new Contracts

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceImpl.java
@@ -54,7 +54,7 @@ public class AttestationUpdaterServiceImpl implements AttestationUpdaterService 
                 .collect(Collectors.toList());
         if (!changedContracts.isEmpty()) {
             List<Contract> updatedContracts = contractRepository.saveAll(changedContracts);
-            // Replace changed contracts in the existing map.  Fixes
+            // Replace changed contracts in the existing map.  Fixes AB2D-4363.
             updatedContracts.forEach(contract -> existingMap.put(contract.getContractNumber(), contract));
         }
 


### PR DESCRIPTION
Fixes the case where a contract has both an informational change and an attestation change.  A stale object was then used.

**JIRA Tickets:**

[AB2D-42](https://jira.cms.gov/browse/AB2D-4363) - Update issue for E4744.

***Related Tickets***
 
### What Does This PR Do?
Bug fix.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure