### PR TITLE
Move PDP client out of the JobService

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
@@ -152,7 +152,7 @@ public class ApiCommon {
         checkIfCurrentClientCanAddJob();
         checkResourceTypesAndOutputFormat(resourceTypes, outputFormat);
         checkSinceTime(since);
-        return new StartJobDTO(contractNumber, null, resourceTypes,
+        return new StartJobDTO(contractNumber, pdpClient.getOrganization(), resourceTypes,
                 getCurrentUrl(request), outputFormat, since, version);
     }
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiCommon.java
@@ -6,7 +6,6 @@ import gov.cms.ab2d.common.dto.StartJobDTO;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.PdpClient;
-import gov.cms.ab2d.common.service.ContractService;
 import gov.cms.ab2d.common.service.InvalidClientInputException;
 import gov.cms.ab2d.common.service.InvalidContractException;
 import gov.cms.ab2d.common.service.JobService;
@@ -28,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
 import java.util.Set;
 
-import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 import static gov.cms.ab2d.common.service.JobService.ZIPFORMAT;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
@@ -47,22 +45,19 @@ public class ApiCommon {
     private final JobService jobService;
     private final PropertiesService propertiesService;
     private final PdpClientService pdpClientService;
-    private final ContractService contractService;
 
     // Since this is used in an annotation, it can't be derived from the Set, otherwise it will be an error
     public static final String ALLOWABLE_OUTPUT_FORMATS =
             "application/fhir+ndjson,application/ndjson,ndjson," + ZIPFORMAT;
     public static final Set<String> ALLOWABLE_OUTPUT_FORMAT_SET = Set.of(ALLOWABLE_OUTPUT_FORMATS.split(","));
     public static final String JOB_CANCELLED_MSG = "Job canceled";
-    public static final String JOB_NOT_FOUND_ERROR_MSG = "Job not found. " + GENERIC_FHIR_ERR_MSG;
 
     public ApiCommon(LogManager eventLogger, JobService jobService, PropertiesService propertiesService,
-                     PdpClientService pdpClientService, ContractService contractService) {
+                     PdpClientService pdpClientService) {
         this.eventLogger = eventLogger;
         this.jobService = jobService;
         this.propertiesService = propertiesService;
         this.pdpClientService = pdpClientService;
-        this.contractService = contractService;
     }
 
     public boolean shouldReplaceWithHttps(HttpServletRequest request) {
@@ -167,7 +162,6 @@ public class ApiCommon {
         }
 
         if (contract == null) {
-//            contract = fetchContract(contractNumber);
             throw new IllegalStateException("Not sure if we should really look up a contract if we aren't bound to it.");
         }
 
@@ -186,38 +180,4 @@ public class ApiCommon {
         // Validated contract
         return contractNumber;
     }
-
-    /*
-    @NotNull
-    private Contract fetchContract(String contractNumber) {
-        Contract contract;
-        Optional<Contract> contractOptional = contractService.getContractByContractNumber(contractNumber);
-        if (contractOptional.isEmpty()) {
-            // Users are bound to a contract and contracts always exist.
-            String errorMsg = "Lookup for contract: " + contractNumber + " failed.";
-            log.error(errorMsg);
-            throw new IllegalStateException(errorMsg);
-        }
-        contract = contractOptional.get();
-        return contract;
-    }
-
-     */
-
-    /*
-            // Check to see if there is any attestation
-        Contract contract = pdpClient.getContract();
-        String contractNumber = startJobDTO.getContractNumber();
-        if (contractNumber != null && !contractNumber.equals(contract.getContractNumber())) {
-            String errorMsg = "Specifying contract: " + contractNumber + " not associated with internal id: " + pdpClient.getId();
-            log.error(errorMsg);
-            throw new InvalidContractException(errorMsg);
-        }
-
-        if (!contract.hasAttestation()) {
-            String errorMsg = "Contract: " + contractNumber + " is not attested.";
-            log.error(errorMsg);
-            throw new InvalidContractException(errorMsg);
-        }
-     */
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.api.controller.common;
 
 import gov.cms.ab2d.common.service.JobService;
+import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;
 import lombok.AllArgsConstructor;
@@ -31,13 +32,15 @@ import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 public class FileDownloadCommon {
     private final JobService jobService;
     private final LogManager eventLogger;
+    private final PdpClientService pdpClientService;
 
     public ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         MDC.put(JOB_LOG, jobUuid);
         MDC.put(FILE_LOG, filename);
         log.info("Request submitted to download file");
 
-        Resource downloadResource = jobService.getResourceForJob(jobUuid, filename, "TODO");
+        Resource downloadResource = jobService.getResourceForJob(jobUuid, filename,
+                pdpClientService.getCurrentClient().getOrganization());
 
         log.info("Sending " + filename + " file to client");
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -37,7 +37,7 @@ public class FileDownloadCommon {
         MDC.put(FILE_LOG, filename);
         log.info("Request submitted to download file");
 
-        Resource downloadResource = jobService.getResourceForJob(jobUuid, filename);
+        Resource downloadResource = jobService.getResourceForJob(jobUuid, filename, "TODO");
 
         log.info("Sending " + filename + " file to client");
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -153,7 +153,7 @@ public class StatusCommon {
         MDC.put(JOB_LOG, jobUuid);
         log.info("Request submitted to cancel job");
 
-        jobService.cancelJob(jobUuid, "TODO");
+        jobService.cancelJob(jobUuid, pdpClientService.getCurrentClient().getOrganization());
 
         log.info("Job successfully cancelled");
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -5,7 +5,9 @@ import gov.cms.ab2d.api.controller.JobProcessingException;
 import gov.cms.ab2d.api.controller.TooManyRequestsException;
 import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobOutput;
+import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.service.JobService;
+import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.events.ApiResponseEvent;
 import lombok.extern.slf4j.Slf4j;
@@ -37,17 +39,20 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 @Service
 @Slf4j
 public class StatusCommon {
+    private final PdpClientService pdpClientService;
     private final JobService jobService;
     private final LogManager eventLogger;
     private final int retryAfterDelay;
 
-    StatusCommon(JobService jobService, LogManager eventLogger, @Value("${api.retry-after.delay}") int retryAfterDelay) {
+    StatusCommon(PdpClientService pdpClientService, JobService jobService,
+                 LogManager eventLogger, @Value("${api.retry-after.delay}") int retryAfterDelay) {
+        this.pdpClientService = pdpClientService;
         this.jobService = jobService;
         this.eventLogger = eventLogger;
         this.retryAfterDelay = retryAfterDelay;
     }
 
-    public ResponseEntity throwFailedResponse(String msg) {
+    public void throwFailedResponse(String msg) {
         log.error(msg);
         throw new JobProcessingException(msg);
     }
@@ -56,7 +61,11 @@ public class StatusCommon {
         MDC.put(JOB_LOG, jobUuid);
         log.info("Request submitted to get job status");
 
-        Job job = jobService.getAuthorizedJobByJobUuidAndRole(jobUuid);
+        PdpClient pdpClient = pdpClientService.getCurrentClient();
+        Job job = (pdpClient.isAdmin()) ?
+                jobService.getJobByJobUuid(jobUuid) :
+                jobService.getAuthorizedJobByJobUuid(jobUuid, pdpClient.getOrganization());
+
 
         if (pollingTooMuch(job)) {
             log.error("Client was polling too frequently");
@@ -111,8 +120,7 @@ public class StatusCommon {
             return new JobCompletedResponse.Output(o.getFhirResourceType(), getUrlPath(job, o.getFilePath(), request, apiPrefix), valueOutputs);
         }).collect(Collectors.toList()));
 
-        resp.setError(job.getJobOutputs().stream().filter(o ->
-                o.getError()).map(o -> {
+        resp.setError(job.getJobOutputs().stream().filter(JobOutput::getError).map(o -> {
             List<JobCompletedResponse.FileMetadata> valueOutputs = generateValueOutputs(o);
             return new JobCompletedResponse.Output(o.getFhirResourceType(), getUrlPath(job, o.getFilePath(), request, apiPrefix), valueOutputs);
         }).collect(Collectors.toList()));
@@ -145,7 +153,7 @@ public class StatusCommon {
         MDC.put(JOB_LOG, jobUuid);
         log.info("Request submitted to cancel job");
 
-        jobService.cancelJob(jobUuid);
+        jobService.cancelJob(jobUuid, "TODO");
 
         log.info("Job successfully cancelled");
 

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package gov.cms.ab2d.api.security;
 
 import gov.cms.ab2d.common.model.PdpClient;
-import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
@@ -23,7 +22,8 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.eventlogger.events.SlackEvents.API_AUTHNZ_ERROR;
 
@@ -61,7 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilterAfter(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeRequests()
             .antMatchers(API_PREFIX_V1 + ADMIN_PREFIX + "/**").hasAuthority(ADMIN_ROLE)
-            .antMatchers(API_PREFIX_V1 + FHIR_PREFIX + "/**").hasAnyAuthority(Role.SPONSOR_ROLE)
+            .antMatchers(API_PREFIX_V1 + FHIR_PREFIX + "/**").hasAnyAuthority(SPONSOR_ROLE)
             .anyRequest().authenticated();
 
         // Override default behavior to add more informative logs

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.api.security;
 
 import gov.cms.ab2d.common.model.PdpClient;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
@@ -60,7 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilterAfter(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeRequests()
             .antMatchers(API_PREFIX_V1 + ADMIN_PREFIX + "/**").hasAuthority(ADMIN_ROLE)
-            .antMatchers(API_PREFIX_V1 + FHIR_PREFIX + "/**").hasAnyAuthority(SPONSOR_ROLE)
+            .antMatchers(API_PREFIX_V1 + FHIR_PREFIX + "/**").hasAnyAuthority(Role.SPONSOR_ROLE)
             .anyRequest().authenticated();
 
         // Override default behavior to add more informative logs

--- a/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
+++ b/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
@@ -1,8 +1,5 @@
 package gov.cms.ab2d.api.util;
 
-import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
-import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-
 public final class Constants {
 
     public static final String GENERIC_FHIR_ERR_MSG = "The body will contain a FHIR " +

--- a/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
+++ b/api/src/main/java/gov/cms/ab2d/api/util/Constants.java
@@ -11,14 +11,6 @@ public final class Constants {
             "Please refer to the body of the response for " +
             "details.";
 
-    public static final String ADMIN_ROLE = "ADMIN";
-
-    public static final String BASE_SANDBOX_URL = "https://sandbox.ab2d.cms.gov";
-
-    public static final String FHIR_SANDBOX_URL = BASE_SANDBOX_URL + API_PREFIX_V1 + FHIR_PREFIX;
-
     private Constants() {
     }
-
-
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -6,6 +6,7 @@ import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.model.Job;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -73,7 +74,7 @@ public class AdminAPIMaintenanceModeTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE, ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE, ADMIN_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -6,7 +6,6 @@ import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.model.Job;
-import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -34,7 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static gov.cms.ab2d.api.controller.BulkDataAccessAPIIntegrationTests.PATIENT_EXPORT_PATH;
-import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
@@ -74,7 +74,7 @@ public class AdminAPIMaintenanceModeTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE, ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE, ADMIN_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -27,9 +27,12 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.function.Predicate;
 
+import static gov.cms.ab2d.common.model.Role.ATTESTOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
-import static gov.cms.ab2d.common.util.Constants.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -259,7 +262,8 @@ public class AdminAPIPdpClientTests {
         String header = mvcResult.getResponse().getHeader(CONTENT_LOCATION);
 
         Job job = jobRepository.findByJobUuid(header.substring(header.indexOf("/Job/") + 5, header.indexOf("/$status")));
-        PdpClient jobPdpClient = job.getPdpClient();
+        PdpClient jobPdpClient = pdpClientRepository.findAll().stream()
+                .filter(pdp -> job.getOrganization().equals(pdp.getOrganization())).findFirst().get();
         dataSetup.queueForCleanup(jobPdpClient);
         dataSetup.queueForCleanup(job);
         assertEquals("regularClient", jobPdpClient.getClientId());

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
@@ -60,7 +61,7 @@ public class AdminAPIPropertiesTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(Role.ADMIN_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.Constants.ADMIN_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,7 +62,7 @@ public class AdminAPIPropertiesTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(Role.ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(ADMIN_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.api.controller;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
-import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -25,6 +24,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.Collections;
 import java.util.List;
 
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,7 +58,7 @@ public class AuthenticationTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.api.controller;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -57,7 +58,7 @@ public class AuthenticationTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import static gov.cms.ab2d.api.controller.JobCompletedResponse.CHECKSUM_STRING;
 import static gov.cms.ab2d.api.controller.JobCompletedResponse.CONTENT_LENGTH_STRING;
 import static gov.cms.ab2d.api.controller.common.ApiText.*;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
@@ -101,7 +102,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @BeforeEach
     public void setup() throws JwtVerificationException {
         testUtil.turnMaintenanceModeOff();
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -101,7 +101,7 @@ public class BulkDataAccessAPIIntegrationTests {
     @BeforeEach
     public void setup() throws JwtVerificationException {
         testUtil.turnMaintenanceModeOff();
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
     }
 
     @AfterEach
@@ -163,7 +163,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("http://localhost" + API_PREFIX_V1 + FHIR_PREFIX + PATIENT_EXPORT_PATH, job.getRequestUrl());
         assertEquals(EOB, job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -186,7 +186,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("https://localhost" + API_PREFIX_V1 + FHIR_PREFIX + PATIENT_EXPORT_PATH, job.getRequestUrl());
         assertEquals(EOB, job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -280,7 +280,7 @@ public class BulkDataAccessAPIIntegrationTests {
         dataSetup.queueForCleanup(pdpClient);
 
         for(Job job : jobs) {
-            job.setPdpClient(pdpClient);
+            job.setOrganization(pdpClient.getOrganization());
             jobRepository.saveAndFlush(job);
             dataSetup.queueForCleanup(job);
         }
@@ -313,7 +313,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("http://localhost" + API_PREFIX_V1 + FHIR_PREFIX + PATIENT_EXPORT_PATH + typeParams, job.getRequestUrl());
         assertEquals(EOB, job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -1096,7 +1096,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("https://localhost" + API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export", job.getRequestUrl());
         assertNull(job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -1121,7 +1121,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals("http://localhost" + API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export",
                 job.getRequestUrl());
         assertNull(job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -1149,7 +1149,7 @@ public class BulkDataAccessAPIIntegrationTests {
         assertEquals("http://localhost" + API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export" + typeParams,
                 job.getRequestUrl());
         assertEquals(EOB, job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -1295,7 +1295,7 @@ public class BulkDataAccessAPIIntegrationTests {
 
         List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
         for(Job job : jobs) {
-            job.setPdpClient(pdpClient);
+            job.setOrganization(pdpClient.getOrganization());
             jobRepository.saveAndFlush(job);
             dataSetup.queueForCleanup(job);
         }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -190,7 +190,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportDuplicateSubmission() throws Exception {
+    void testPatientExportDuplicateSubmission() throws Exception {
         createMaxJobs();
 
         MvcResult mvcResult = this.mockMvc.perform(
@@ -230,7 +230,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportDuplicateSubmissionWithCancelledStatus() throws Exception {
+    void testPatientExportDuplicateSubmissionWithCancelledStatus() throws Exception {
         createMaxJobs();
 
         List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
@@ -246,7 +246,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testPatientExportDuplicateSubmissionWithInProgressStatus() throws Exception {
+    void testPatientExportDuplicateSubmissionWithInProgressStatus() throws Exception {
         createMaxJobs();
 
         List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
@@ -262,7 +262,6 @@ public class BulkDataAccessAPIIntegrationTests {
                 .andExpect(header().string("Retry-After", "30"))
                 .andExpect(header().doesNotExist(X_PROG))
                 .andExpect(header().exists(CONTENT_LOCATION));
-        ;
     }
 
     @Test
@@ -526,7 +525,7 @@ public class BulkDataAccessAPIIntegrationTests {
     }
 
     @Test
-    public void testGetStatusWhileInProgress() throws Exception {
+    void testGetStatusWhileInProgress() throws Exception {
         MvcResult mvcResult = this.mockMvc.perform(
                 get(API_PREFIX_V1 + FHIR_PREFIX + PATIENT_EXPORT_PATH).contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + token))
@@ -555,7 +554,6 @@ public class BulkDataAccessAPIIntegrationTests {
                 .andExpect(header().string("Retry-After", "30"))
                 .andExpect(header().doesNotExist("X-Progress"))
                 .andExpect(header().doesNotExist(CONTENT_LOCATION));
-        ;
     }
 
     @Test

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.api.controller;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.Job;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -74,7 +75,7 @@ public class BulkDataAccessAPIUnusualDataTests {
     @Test
     void testPatientExportWithNoAttestation() throws Exception {
         // Valid contract number for sponsor, but no attestation
-        String token = testUtil.setupContractWithNoAttestation(List.of(SPONSOR_ROLE));
+        String token = testUtil.setupContractWithNoAttestation(List.of(Role.SPONSOR_ROLE));
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         this.mockMvc.perform(get(API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export")
@@ -101,7 +102,7 @@ public class BulkDataAccessAPIUnusualDataTests {
 
     @Test
     public void testPatientExportWithOnlyParentAttestation() throws Exception {
-        String token = testUtil.setupContractSponsorForParentClientData(List.of(SPONSOR_ROLE));
+        String token = testUtil.setupContractSponsorForParentClientData(List.of(Role.SPONSOR_ROLE));
 
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
@@ -123,7 +124,7 @@ public class BulkDataAccessAPIUnusualDataTests {
         assertEquals("http://localhost" + API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export",
                 job.getRequestUrl());
         assertNull(job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
 
     }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static gov.cms.ab2d.common.model.JobStatus.SUBMITTED;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.*;
@@ -75,7 +76,7 @@ public class BulkDataAccessAPIUnusualDataTests {
     @Test
     void testPatientExportWithNoAttestation() throws Exception {
         // Valid contract number for sponsor, but no attestation
-        String token = testUtil.setupContractWithNoAttestation(List.of(Role.SPONSOR_ROLE));
+        String token = testUtil.setupContractWithNoAttestation(List.of(SPONSOR_ROLE));
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();
         this.mockMvc.perform(get(API_PREFIX_V1 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export")
@@ -102,7 +103,7 @@ public class BulkDataAccessAPIUnusualDataTests {
 
     @Test
     public void testPatientExportWithOnlyParentAttestation() throws Exception {
-        String token = testUtil.setupContractSponsorForParentClientData(List.of(Role.SPONSOR_ROLE));
+        String token = testUtil.setupContractSponsorForParentClientData(List.of(SPONSOR_ROLE));
 
         Optional<Contract> contractOptional = contractRepository.findContractByContractNumber(VALID_CONTRACT_NUMBER);
         Contract contract = contractOptional.get();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import static gov.cms.ab2d.common.service.JobServiceImpl.INITIAL_JOB_STATUS_MESSAGE;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -109,7 +109,7 @@ public class BulkDataAccessAPIV2IntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("https://localhost" + API_PREFIX_V2 + FHIR_PREFIX + PATIENT_EXPORT_PATH, job.getRequestUrl());
         assertEquals(EOB, job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 
     @Test
@@ -135,6 +135,6 @@ public class BulkDataAccessAPIV2IntegrationTests {
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals("https://localhost" + API_PREFIX_V2 + FHIR_PREFIX + "/Group/" + contract.getContractNumber() + "/$export", job.getRequestUrl());
         assertNull(job.getResourceTypes());
-        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT), job.getPdpClient());
+        assertEquals(pdpClientRepository.findByClientId(TEST_PDP_CLIENT).getOrganization(), job.getOrganization());
     }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.api.controller;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -55,7 +56,7 @@ public class InvalidTokenTest {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupInvalidToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupInvalidToken(List.of(Role.SPONSOR_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.api.controller;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
-import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -20,6 +19,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,7 +56,7 @@ public class InvalidTokenTest {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
-        token = testUtil.setupInvalidToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupInvalidToken(List.of(SPONSOR_ROLE));
     }
 
     @AfterEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.ab2d.api.SpringBootApp;
+import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -21,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.InputStream;
 import java.util.List;
 
+import static gov.cms.ab2d.common.model.Role.ATTESTOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -66,7 +68,7 @@ public class RoleTests {
     // This will test the API using a role that should not be able to access sponsor URLs
     @Test
     public void testAdminRoleAccessingSponsorApiIsDisabled() throws Exception {
-        token = testUtil.setupToken(List.of(ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(Role.ADMIN_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 + FHIR_PREFIX + "/Patient/$export")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -88,7 +90,7 @@ public class RoleTests {
     // This will test the API using a role that should not be able to access admin URLs
     @Test
     public void testWrongRoleAdminApi() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         String fileName = "parent_org_and_legal_entity_20191031_111812.xls";
         InputStream inputStream = this.getClass().getResourceAsStream("/" + fileName);
@@ -141,7 +143,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleClientCreate() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(post(API_PREFIX_V1 +  ADMIN_PREFIX + "/client")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -151,7 +153,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleClientUpdate() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -161,7 +163,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRolePropertiesRetrieval() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 +  ADMIN_PREFIX + "/properties")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -171,7 +173,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRolePropertiesUpdate() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/properties")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -181,7 +183,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleCreateJobOnBehalfOfClient() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/testclient/job")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -191,7 +193,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleCreateJobByContractOnBehalfOfClient() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/testclient/job/Z0001")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -201,7 +203,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleEnableClient() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT + "/enable")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -211,7 +213,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleDisableClient() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT + "/disable")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -221,7 +223,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleGetClient() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -231,7 +233,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleIPs() throws Exception {
-        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
 
         ObjectMapper mapper = new ObjectMapper();
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.ab2d.api.SpringBootApp;
-import gov.cms.ab2d.common.model.Role;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
@@ -22,7 +21,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.InputStream;
 import java.util.List;
 
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
 import static gov.cms.ab2d.common.model.Role.ATTESTOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -68,7 +69,7 @@ public class RoleTests {
     // This will test the API using a role that should not be able to access sponsor URLs
     @Test
     public void testAdminRoleAccessingSponsorApiIsDisabled() throws Exception {
-        token = testUtil.setupToken(List.of(Role.ADMIN_ROLE));
+        token = testUtil.setupToken(List.of(ADMIN_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 + FHIR_PREFIX + "/Patient/$export")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -90,7 +91,7 @@ public class RoleTests {
     // This will test the API using a role that should not be able to access admin URLs
     @Test
     public void testWrongRoleAdminApi() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         String fileName = "parent_org_and_legal_entity_20191031_111812.xls";
         InputStream inputStream = this.getClass().getResourceAsStream("/" + fileName);
@@ -143,7 +144,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleClientCreate() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(post(API_PREFIX_V1 +  ADMIN_PREFIX + "/client")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -153,7 +154,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleClientUpdate() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -163,7 +164,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRolePropertiesRetrieval() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 +  ADMIN_PREFIX + "/properties")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -173,7 +174,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRolePropertiesUpdate() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/properties")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -183,7 +184,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleCreateJobOnBehalfOfClient() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/testclient/job")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -193,7 +194,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleCreateJobByContractOnBehalfOfClient() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/testclient/job/Z0001")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -203,7 +204,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleEnableClient() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT + "/enable")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -213,7 +214,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleDisableClient() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(put(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT + "/disable")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -223,7 +224,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleGetClient() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         this.mockMvc.perform(get(API_PREFIX_V1 +  ADMIN_PREFIX + "/client/" + TEST_PDP_CLIENT)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -233,7 +234,7 @@ public class RoleTests {
 
     @Test
     public void testWrongRoleIPs() throws Exception {
-        token = testUtil.setupToken(List.of(Role.SPONSOR_ROLE));
+        token = testUtil.setupToken(List.of(SPONSOR_ROLE));
 
         ObjectMapper mapper = new ObjectMapper();
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 
-import static gov.cms.ab2d.api.util.Constants.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
 import static gov.cms.ab2d.common.util.Constants.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
+++ b/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
@@ -128,7 +128,7 @@ class FileDeletionServiceTest {
         job.setCreatedAt(OffsetDateTime.now().minusDays(5));
         job.setCompletedAt(OffsetDateTime.now().minusDays(4));
         job.setExpiresAt(OffsetDateTime.now().minusDays(1));
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setFhirVersion(STU3);
         job.setContractNumber(contractNumber);
         jobService.updateJob(job);
@@ -138,7 +138,7 @@ class FileDeletionServiceTest {
         jobInProgress.setStatus(JobStatus.IN_PROGRESS);
         jobInProgress.setJobUuid(UUID.randomUUID().toString());
         jobInProgress.setCreatedAt(OffsetDateTime.now().minusHours(1));
-        jobInProgress.setPdpClient(pdpClient);
+        jobInProgress.setOrganization(pdpClient.getOrganization());
         jobInProgress.setFhirVersion(STU3);
         jobInProgress.setContractNumber(contractNumber);
         jobService.updateJob(jobInProgress);
@@ -150,7 +150,7 @@ class FileDeletionServiceTest {
         jobNotExpiredYet.setCreatedAt(OffsetDateTime.now().minusHours(60));
         jobNotExpiredYet.setCompletedAt(OffsetDateTime.now().minusHours(55));
         jobNotExpiredYet.setExpiresAt(OffsetDateTime.now().plusHours(17));
-        jobNotExpiredYet.setPdpClient(pdpClient);
+        jobNotExpiredYet.setOrganization(pdpClient.getOrganization());
         jobNotExpiredYet.setFhirVersion(STU3);
         jobNotExpiredYet.setContractNumber(contractNumber);
 
@@ -158,7 +158,7 @@ class FileDeletionServiceTest {
         jobCancelled.setStatus(JobStatus.CANCELLED);
         jobCancelled.setJobUuid(UUID.randomUUID().toString());
         jobCancelled.setCreatedAt(OffsetDateTime.now().minusHours(1));
-        jobCancelled.setPdpClient(pdpClient);
+        jobCancelled.setOrganization(pdpClient.getOrganization());
         jobCancelled.setFhirVersion(STU3);
         jobCancelled.setContractNumber(contractNumber);
         jobService.updateJob(jobCancelled);
@@ -167,7 +167,7 @@ class FileDeletionServiceTest {
         jobFailed.setStatus(JobStatus.FAILED);
         jobFailed.setJobUuid(UUID.randomUUID().toString());
         jobFailed.setCreatedAt(OffsetDateTime.now().minusHours(1));
-        jobFailed.setPdpClient(pdpClient);
+        jobFailed.setOrganization(pdpClient.getOrganization());
         jobFailed.setFhirVersion(STU3);
         jobFailed.setContractNumber(contractNumber);
         jobService.updateJob(jobFailed);
@@ -639,7 +639,7 @@ class FileDeletionServiceTest {
         newJob.setCreatedAt(OffsetDateTime.now().minusDays(1));
         newJob.setCompletedAt(OffsetDateTime.now().minusDays(1));
         newJob.setExpiresAt(OffsetDateTime.now().plusDays(2));
-        newJob.setPdpClient(job.getPdpClient());
+        newJob.setOrganization(job.getOrganization());
         newJob.setFhirVersion(STU3);
         newJob.setContractNumber("11111");
         jobService.updateJob(newJob);

--- a/common/src/main/java/gov/cms/ab2d/common/dto/StartJobDTO.java
+++ b/common/src/main/java/gov/cms/ab2d/common/dto/StartJobDTO.java
@@ -7,13 +7,23 @@ import lombok.Data;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 
-@Data //NOSONAR
+/**
+ * StartJobDTO is a fully verified and validated request to start a job.
+ *
+ * This means the caller has the permission to run against this contract and that the contract is attested.
+ */
+@Data
 @AllArgsConstructor
 public class StartJobDTO {
+    @NotNull
     private final String contractNumber;
-    private final String organization;  //NOSONAR - not quite in use yet
+    @NotNull
+    private final String organization;
+    @NotNull
     private final String resourceTypes;
+    @NotNull
     private final String url;
+    @NotNull
     private final String outputFormat;
     private final OffsetDateTime since;
     @NotNull

--- a/common/src/main/java/gov/cms/ab2d/common/model/Job.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Job.java
@@ -32,10 +32,8 @@ public class Job {
     @NotNull
     private String jobUuid;
 
-    @ManyToOne
     @NotNull
-    @JoinColumn(name = "user_account_id")
-    private PdpClient pdpClient;
+    private String organization;
 
     @OneToMany(
             mappedBy = "job",

--- a/common/src/main/java/gov/cms/ab2d/common/model/PdpClient.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/PdpClient.java
@@ -107,4 +107,13 @@ public class PdpClient extends TimestampBase implements UserDetails {
     public boolean isEnabled() {
         return enabled;
     }
+
+    public boolean isAdmin() {
+        for (Role role : getRoles()) {
+            if (role.getName().equals(Role.ADMIN_ROLE)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/gov/cms/ab2d/common/model/Role.java
+++ b/common/src/main/java/gov/cms/ab2d/common/model/Role.java
@@ -16,6 +16,10 @@ import javax.persistence.Id;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class Role extends TimestampBase {
 
+    public static final String SPONSOR_ROLE = "SPONSOR";
+    public static final String ADMIN_ROLE = "ADMIN";
+    public static final String ATTESTOR_ROLE = "ATTESTOR";
+
     @Id
     @GeneratedValue
     private Long id;

--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.common.repository;
 
 import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobStartedBy;
-import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.model.JobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,8 +24,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
 
     Job findByJobUuid(String jobUuid);
 
-    @Query("select j from Job j where j.pdpClient = :pdpClient and (j.status = 'IN_PROGRESS' or j.status = 'SUBMITTED')")
-    List<Job> findActiveJobsByClient(PdpClient pdpClient);
+    @Query("select j from Job j where j.organization = :organization and (j.status = 'IN_PROGRESS' or j.status = 'SUBMITTED')")
+    List<Job> findActiveJobsByClient(String organization);
 
     List<Job> findByContractNumberEqualsAndStatusInAndStartedByOrderByCompletedAtDesc(
             String contractNumber, List<JobStatus> statuses, JobStartedBy startedBy);

--- a/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
+++ b/common/src/main/java/gov/cms/ab2d/common/repository/JobRepository.java
@@ -30,9 +30,6 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     List<Job> findByContractNumberEqualsAndStatusInAndStartedByOrderByCompletedAtDesc(
             String contractNumber, List<JobStatus> statuses, JobStartedBy startedBy);
 
-    @Query("SELECT j.status FROM Job j WHERE j.jobUuid = :jobUuid ")
-    JobStatus findJobStatus(String jobUuid);
-
     @Query("FROM Job j WHERE j.createdAt < :createdAt AND j.status = 'IN_PROGRESS' AND j.completedAt IS NULL ")
     List<Job> findStuckJobs(OffsetDateTime createdAt);
 

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobService.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobService.java
@@ -13,19 +13,19 @@ public interface JobService {
 
     Job createJob(StartJobDTO startJobDTO);
 
-    void cancelJob(String jobUuid);
+    void cancelJob(String jobUuid, String organization);
 
-    Job getAuthorizedJobByJobUuidAndRole(String jobUuid);
+    Job getAuthorizedJobByJobUuid(String jobUuid, String organization);
 
     Job getJobByJobUuid(String jobUuid);
 
     Job updateJob(Job job);
 
-    Resource getResourceForJob(String jobUuid, String fileName) throws MalformedURLException;
+    Resource getResourceForJob(String jobUuid, String fileName, String organization) throws MalformedURLException;
 
     void deleteFileForJob(File file, String jobUuid);
 
-    boolean checkIfCurrentClientCanAddJob();
+    int activeJobs(String organization);
 
-    List<String> getActiveJobIds();
+    List<String> getActiveJobIds(String organization);
 }

--- a/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/JobServiceImpl.java
@@ -41,7 +41,7 @@ public class JobServiceImpl implements JobService {
 
     public static final String INITIAL_JOB_STATUS_MESSAGE = "0%";
 
-    public JobServiceImpl(PdpClientService pdpClientService, JobRepository jobRepository, JobOutputService jobOutputService,
+    public JobServiceImpl(JobRepository jobRepository, JobOutputService jobOutputService,
                           LogManager eventLogger, LoggerEventSummary loggerEventSummary,
                           @Value("${efs.mount}") String fileDownloadPath) {
         this.jobRepository = jobRepository;

--- a/common/src/main/java/gov/cms/ab2d/common/service/PdpClientServiceImpl.java
+++ b/common/src/main/java/gov/cms/ab2d/common/service/PdpClientServiceImpl.java
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static java.util.stream.Collectors.toList;
 
 /**

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -20,12 +20,6 @@ public final class Constants {
 
     public static final String CONTRACT_LOG = "contract";
 
-    public static final String SPONSOR_ROLE = "SPONSOR";
-
-    public static final String ADMIN_ROLE = "ADMIN";
-
-    public static final String ATTESTOR_ROLE = "ATTESTOR";
-
     public static final String API_PREFIX_V1 = "/api/v1";
 
     public static final String API_PREFIX_V2 = "/api/v2";

--- a/common/src/main/java/gov/cms/ab2d/common/util/EventUtils.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/EventUtils.java
@@ -18,8 +18,11 @@ public class EventUtils {
         return new FileEvent(getOrganization(job), getJobId(job), file, status);
     }
 
-    public static String getOrganization(Job job) {
-        return job != null && job.getPdpClient() != null ? job.getPdpClient().getOrganization() : null;
+    private static String getOrganization(Job job) {
+        if (job == null)
+            return null;
+
+        return job.getOrganization();
     }
 
     private static String getJobId(Job job) {

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -139,3 +139,5 @@ databaseChangeLog:
       file: db/changelog/test_only/create-ab2d-analyst.sql
   - include:
       file: db/changelog/v2022/create-analyst-view.sql
+  - include:
+      file: db/changelog/v2022/job_pdp_client_bus_key.sql

--- a/common/src/main/resources/db/changelog/v2022/job_pdp_client_bus_key.sql
+++ b/common/src/main/resources/db/changelog/v2022/job_pdp_client_bus_key.sql
@@ -1,0 +1,35 @@
+--changeset enolan:contract_bus_key failOnError:true
+
+DROP VIEW job_view;
+
+-- Create and populate the contract business key
+ALTER TABLE job ADD COLUMN organization VARCHAR(255) NOT NULL DEFAULT '';
+
+UPDATE job
+SET organization = ua.organization
+FROM user_account ua
+WHERE job.user_account_id = ua.id;
+
+-- Foreign key is no longer needed.  The business key will be used going forward
+ALTER TABLE job DROP CONSTRAINT fk_job_to_user_account;
+ALTER TABLE job DROP COLUMN user_account_id;
+
+-- recreate job_view
+-- Job view gives high level information concerning a job including contract_number and organization
+-- but excludes any information about Okta client creds or internal database ids.
+CREATE VIEW job_view AS
+SELECT j.id, j.job_uuid, j.created_at, j.completed_at, j.expires_at, j.resource_types, j.status, j.request_url,
+       j.output_format, j.since, j.fhir_version, tz_weeks.year_week, tz_weeks.week_start, tz_weeks.week_end,
+       j.organization, c.contract_number, c.contract_name, c.contract_type
+FROM job j
+         -- Create a series of weeks that when joined give a specific week that a job was run in
+-- This supports reporting weekly statistics
+         INNER JOIN (
+    SELECT week_start, week_start + INTERVAL '7' DAY AS week_end, to_char(week_start, 'IYYY-IW') year_week
+    FROM (SELECT week_start AT TIME ZONE 'America/New_York' AS week_start
+          FROM generate_series('2020-02-03 0:00:00.00+00', current_timestamp AT TIME ZONE 'America/New_York', '1 week'::INTERVAL) AS week_start
+         ) AS tz_weeks
+) AS tz_weeks ON j.created_at >= tz_weeks.week_start AND j.created_at < tz_weeks.week_end
+         LEFT JOIN contract c ON c.contract_number = j.contract_number
+-- Only report jobs that were started by a PDP since those jobs are the only ones we care about for analytics
+WHERE j.started_by = 'PDP' and j.contract_number != 'UNKNOWN';

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobOutputServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobOutputServiceTest.java
@@ -41,9 +41,6 @@ class JobOutputServiceTest {
     JobRepository jobRepository;
 
     @Autowired
-    PdpClientRepository pdpClientRepository;
-
-    @Autowired
     ContractRepository contractRepository;
 
     @Autowired
@@ -80,7 +77,7 @@ class JobOutputServiceTest {
     void testJobOutputUpdate() {
         Job job = new Job();
         job.setJobUuid("uuid");
-        job.setPdpClient(pdpClientRepository.findByClientId(TEST_PDP_CLIENT));
+        job.setOrganization(TEST_PDP_CLIENT);
         job.setStatus(JobStatus.FAILED);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);
@@ -112,7 +109,7 @@ class JobOutputServiceTest {
     void testJobOutputRetrieval() {
         Job job = new Job();
         job.setJobUuid("uuid");
-        job.setPdpClient(pdpClientRepository.findByClientId(TEST_PDP_CLIENT));
+        job.setOrganization(TEST_PDP_CLIENT);
         job.setStatus(JobStatus.FAILED);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);
@@ -139,7 +136,7 @@ class JobOutputServiceTest {
     void testJobOutputRetrievalNotFound() {
         Job job = new Job();
         job.setJobUuid("uuid");
-        job.setPdpClient(pdpClientRepository.findByClientId(TEST_PDP_CLIENT));
+        job.setOrganization(TEST_PDP_CLIENT);
         job.setStatus(JobStatus.FAILED);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);

--- a/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/JobServiceTest.java
@@ -119,7 +119,7 @@ class JobServiceTest {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         LogManager logManager = new LogManager(sqlEventLogger, kinesisEventLogger, slackLogger);
-        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager, loggerEventSummary, tmpJobLocation);
+        jobService = new JobServiceImpl(jobRepository, jobOutputService, logManager, loggerEventSummary, tmpJobLocation);
         ReflectionTestUtils.setField(jobService, "fileDownloadPath", tmpJobLocation);
 
         dataSetup.setupNonStandardClient(CLIENTID, CONTRACT_NUMBER, List.of());
@@ -234,22 +234,6 @@ class JobServiceTest {
         verify(slackLogger, times(2)).logAlert(anyString(), any());
     }
 
-    // TODO - move this test to the API module
-//    @Test
-    void createJobWithSpecificContractNoAttestation() {
-        dataSetup.setupContractWithNoAttestation(CLIENTID, CONTRACT_NUMBER, List.of());
-        assertThrows(InvalidContractException.class,
-                () -> jobService.createJob(buildStartJobContract(DataSetup.VALID_CONTRACT_NUMBER)));
-    }
-
-    // TODO - move this test to the API module
-//    @Test
-    void createJobWithAllContractsNoAttestation() {
-        dataSetup.setupContractWithNoAttestation(CLIENTID, CONTRACT_NUMBER, List.of());
-        assertThrows(InvalidContractException.class,
-                () -> jobService.createJob(buildStartJobContract(CONTRACT_NUMBER)));
-    }
-
     @Test
     void failedValidation() {
         assertThrows(TransactionSystemException.class,
@@ -351,7 +335,7 @@ class JobServiceTest {
     }
 
     @Test
-    public void testJobInCancelledState() {
+    void testJobInCancelledState() {
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         job.setStatus(JobStatus.CANCELLED);
@@ -363,7 +347,7 @@ class JobServiceTest {
     }
 
     @Test
-    public void testJobInFailedState() {
+    void testJobInFailedState() {
         Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
 
         job.setStatus(JobStatus.FAILED);

--- a/common/src/test/java/gov/cms/ab2d/common/service/PdpClientServiceTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/PdpClientServiceTest.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
-import static gov.cms.ab2d.common.util.Constants.ADMIN_ROLE;
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.ADMIN_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_EPOCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/common/src/test/java/gov/cms/ab2d/common/util/EventUtilsTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/EventUtilsTest.java
@@ -32,7 +32,7 @@ class EventUtilsTest {
         job = new Job();
         job.setStatus(JobStatus.IN_PROGRESS);
         job.setJobUuid(jobId);
-        job.setPdpClient(pdpClient);
+        job.setOrganization(ORGANIZATION);
         job.setFhirVersion(STU3);
     }
 

--- a/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
+++ b/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
@@ -362,7 +362,7 @@ public class EndToEndBfdTests {
         job.setProgress(0);
         job.setSince(since);
         job.setFhirVersion(version);
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
 
         // Check to see if there is any attestation
         Contract contract = pdpClient.getContract();

--- a/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
+++ b/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
@@ -180,7 +180,7 @@ public class EndToEndBfdTests {
                 propertiesService, coverageProcessor, coverageLockWrapper, contractToContractCoverageMapping);
 
         // Instantiate the job processors
-        jobService = new JobServiceImpl(pdpClientService, jobRepository, jobOutputService, logManager, logEventSummary, path.getAbsolutePath());
+        jobService = new JobServiceImpl(jobRepository, jobOutputService, logManager, logEventSummary, path.getAbsolutePath());
         jobPreProcessor = new JobPreProcessorImpl(contractRepository, jobRepository, logManager, coverageDriver);
 
         jobProcessor = new JobProcessorImpl(new FileServiceImpl(), jobChannelService, jobProgressService, jobProgressUpdateService,

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -46,7 +46,6 @@ import static gov.cms.ab2d.aggregator.FileOutputType.DATA;
 import static gov.cms.ab2d.aggregator.FileOutputType.ERROR;
 
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
-import static gov.cms.ab2d.common.util.EventUtils.getOrganization;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
@@ -332,7 +331,7 @@ public class ContractProcessorImpl implements ContractProcessor {
             var patientClaimsRequest = new PatientClaimsRequest(patient,
                     contractData.getContract().getAttestedOn(),
                     job.getSince(),
-                    getOrganization(job),
+                    job.getOrganization(),
                     jobUuid,
                     job.getContractNumber(),
                     contractData.getContract().getContractType(),

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutionException;
 
 import static gov.cms.ab2d.common.model.JobStatus.FAILED;
 import static gov.cms.ab2d.common.model.JobStatus.SUCCESSFUL;
-import static gov.cms.ab2d.common.util.EventUtils.getOrganization;
 import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PROD_LIST;
 import static gov.cms.ab2d.eventlogger.Ab2dEnvironment.PUBLIC_LIST;
 
@@ -196,7 +195,7 @@ public class JobProcessorImpl implements JobProcessor {
                 : job.getJobOutputs().size() - 1;
 
         // Regardless of whether we pass or fail the basic
-        eventLogger.log(new ContractSearchEvent(getOrganization(job),
+        eventLogger.log(new ContractSearchEvent(job.getOrganization(),
                 job.getJobUuid(),
                 job.getContractNumber(),
                 progressTracker.getPatientsExpected(),

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -107,7 +107,7 @@ class ContractProcessorUnitTest {
         ReflectionTestUtils.setField(jobProgressImpl, "reportProgressLogFrequency", 3);
         jobChannelService = new JobChannelStubServiceImpl(jobProgressImpl);
         ThreadPoolTaskExecutor pool = new ThreadPoolTaskExecutor();
-        pool.initialize();;
+        pool.initialize();
 
         SearchConfig searchConfig = new SearchConfig(efsMountTmpDir.toFile().getAbsolutePath(),
                 STREAMING, FINISHED, 0, 0, 2, 1);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -314,7 +314,7 @@ class ContractProcessorUnitTest {
         job.setJobUuid(jobUuid);
         job.setStatusMessage("0%");
         job.setStatus(JobStatus.IN_PROGRESS);
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setFhirVersion(STU3);
         return job;
     }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -181,7 +181,7 @@ class JobPreProcessorIntegrationTest {
         oldJob.setJobUuid("AA-BB");
         oldJob.setStatus(JobStatus.SUCCESSFUL);
         oldJob.setStatusMessage("100%");
-        oldJob.setPdpClient(pdpClient);
+        oldJob.setOrganization(pdpClient.getOrganization());
         oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
@@ -194,7 +194,7 @@ class JobPreProcessorIntegrationTest {
         reallyOldJob.setJobUuid("CC-DD");
         reallyOldJob.setStatus(JobStatus.SUCCESSFUL);
         reallyOldJob.setStatusMessage("100%");
-        reallyOldJob.setPdpClient(pdpClient);
+        reallyOldJob.setOrganization(pdpClient.getOrganization());
         reallyOldJob.setStartedBy(DEVELOPER);
         reallyOldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime reallyOldldJobTime = OffsetDateTime.parse("2020-12-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
@@ -207,7 +207,7 @@ class JobPreProcessorIntegrationTest {
         newJob.setJobUuid("YY-ZZ");
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
-        newJob.setPdpClient(pdpClient);
+        newJob.setOrganization(pdpClient.getOrganization());
         newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         newJob.setCreatedAt(OffsetDateTime.now());
         newJob.setFhirVersion(R4);
@@ -230,7 +230,7 @@ class JobPreProcessorIntegrationTest {
         oldJob.setJobUuid("AA-BB");
         oldJob.setStatus(JobStatus.FAILED);
         oldJob.setStatusMessage("100%");
-        oldJob.setPdpClient(pdpClient);
+        oldJob.setOrganization(pdpClient.getOrganization());
         oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
@@ -242,7 +242,7 @@ class JobPreProcessorIntegrationTest {
         newJob.setJobUuid("YY-ZZ");
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
-        newJob.setPdpClient(pdpClient);
+        newJob.setOrganization(pdpClient.getOrganization());
         newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime newJobTime = OffsetDateTime.parse("2021-02-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         newJob.setCreatedAt(newJobTime);
@@ -265,7 +265,7 @@ class JobPreProcessorIntegrationTest {
         oldJob.setJobUuid("AA-BB");
         oldJob.setStatus(JobStatus.SUCCESSFUL);
         oldJob.setStatusMessage("100%");
-        oldJob.setPdpClient(pdpClient);
+        oldJob.setOrganization(pdpClient.getOrganization());
         oldJob.setStartedBy(DEVELOPER);
         oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
@@ -278,7 +278,7 @@ class JobPreProcessorIntegrationTest {
         newJob.setJobUuid("YY-ZZ");
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
-        newJob.setPdpClient(pdpClient);
+        newJob.setOrganization(pdpClient.getOrganization());
         newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         newJob.setCreatedAt(OffsetDateTime.now());
         newJob.setFhirVersion(R4);
@@ -301,7 +301,7 @@ class JobPreProcessorIntegrationTest {
         oldJob.setJobUuid("AA-BB");
         oldJob.setStatus(JobStatus.SUCCESSFUL);
         oldJob.setStatusMessage("100%");
-        oldJob.setPdpClient(pdpClient);
+        oldJob.setOrganization(pdpClient.getOrganization());
         oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
@@ -313,7 +313,7 @@ class JobPreProcessorIntegrationTest {
         newJob.setJobUuid("YY-ZZ");
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
-        newJob.setPdpClient(pdpClient);
+        newJob.setOrganization(pdpClient.getOrganization());
         newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         OffsetDateTime suppliedSince = OffsetDateTime.parse("2021-02-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         newJob.setSince(suppliedSince);
@@ -347,7 +347,7 @@ class JobPreProcessorIntegrationTest {
         job.setJobUuid("S0000");
         job.setStatus(JobStatus.SUBMITTED);
         job.setStatusMessage("0%");
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -376,7 +376,7 @@ class JobProcessorIntegrationTest {
         List<LoggableEvent> fileEvents = loggerEventRepository.load(FileEvent.class);
         // Since the max size of the file is not set here (so it's 0), every second write creates a new file since
         // the file is no longer empty after the first write. This means, there were 20 files created so 40 events
-        assertTrue((fileEvents.size() % 2) == 0);
+        assertEquals(0, fileEvents.size() % 2);
         assertEquals(fileEvents.size() / 2, fileEvents.stream().filter(e -> ((FileEvent) e).getStatus() == FileEvent.FileStatus.OPEN).count());
         assertEquals(fileEvents.size() / 2, fileEvents.stream().filter(e -> ((FileEvent) e).getStatus() == FileEvent.FileStatus.CLOSE).count());
         assertEquals(fileEvents.size() / 2, fileEvents.stream().filter(e -> ((FileEvent) e).getFileHash().length() > 0).count());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -424,7 +424,7 @@ class JobProcessorIntegrationTest {
         job.setJobUuid(JOB_UUID);
         job.setStatus(JobStatus.SUBMITTED);
         job.setStatusMessage("0%");
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -297,7 +297,7 @@ class JobProcessorUnitTest {
         job.setJobUuid(jobUuid);
         job.setStatusMessage("0%");
         job.setStatus(JobStatus.IN_PROGRESS);
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         return job;
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -57,7 +57,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_EPOCH;
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_ZONE;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
@@ -168,7 +168,7 @@ class CoverageDriverTest {
         job = new Job();
         job.setContractNumber(contract.getContractNumber());
         job.setJobUuid("unique");
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setStatus(gov.cms.ab2d.common.model.JobStatus.SUBMITTED);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -47,7 +47,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.SPONSOR_ROLE;
+import static gov.cms.ab2d.common.model.Role.SPONSOR_ROLE;
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_EPOCH;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static gov.cms.ab2d.fhir.IdentifierUtils.BENEFICIARY_ID;

--- a/worker/src/test/java/gov/cms/ab2d/worker/repository/StubJobRepository.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/repository/StubJobRepository.java
@@ -40,7 +40,7 @@ public class StubJobRepository implements JobRepository {
     }
 
     @Override
-    public List<Job> findActiveJobsByClient(PdpClient pdpClient) {
+    public List<Job> findActiveJobsByClient(String organization) {
         return null;
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/repository/StubJobRepository.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/repository/StubJobRepository.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.worker.repository;
 import gov.cms.ab2d.common.model.Job;
 import gov.cms.ab2d.common.model.JobStartedBy;
 import gov.cms.ab2d.common.model.JobStatus;
-import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.repository.JobRepository;
 import lombok.Getter;
 import org.springframework.data.domain.Example;
@@ -46,11 +45,6 @@ public class StubJobRepository implements JobRepository {
 
     @Override
     public List<Job> findByContractNumberEqualsAndStatusInAndStartedByOrderByCompletedAtDesc(String contractNumber, List<JobStatus> statuses, JobStartedBy startedBy) {
-        return null;
-    }
-
-    @Override
-    public JobStatus findJobStatus(String jobUuid) {
         return null;
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
@@ -146,7 +146,7 @@ class WorkerServiceDisengagementTest {
         job.setStatusMessage("0%");
         job.setResourceTypes(EOB);
         job.setCreatedAt(OffsetDateTime.now());
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         job.setContractNumber(pdpClient.getContract().getContractNumber());
         job.setFhirVersion(STU3);

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -24,8 +24,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-
-import static gov.cms.ab2d.common.model.JobStatus.SUCCESSFUL;
 import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
@@ -143,9 +141,4 @@ class WorkerServiceTest {
     private int getIntRandom() {
         return random.nextInt(100);
     }
-
-
-    private void checkResult(Job processedJob) {
-        assertEquals(SUCCESSFUL, processedJob.getStatus());
-        assertEquals("100%", processedJob.getStatusMessage());    }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -102,7 +102,7 @@ class WorkerServiceTest {
         job.setStatusMessage("0%");
         job.setResourceTypes(EOB);
         job.setCreatedAt(OffsetDateTime.now());
-        job.setPdpClient(pdpClient);
+        job.setOrganization(pdpClient.getOrganization());
         job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
         job.setContractNumber(pdpClient.getContract().getContractNumber());
         job.setFhirVersion(STU3);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4218](https://jira.cms.gov/browse/AB2D-4218) - Move PDP client out of the JobService

***Related Tickets***
 
### What Does This PR Do?

### What Should Reviewers Watch For?

Responsibility for validating whether a job can be run is now moved outside of the JobService.  The passed in DTO is assumed to be fully validated.

Dropping/re-adding the job_view.

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure