### PR TITLE
Add dropped max job tets

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -1149,6 +1149,9 @@ public class BulkDataAccessAPIIntegrationTests {
         };
     }
 
+    /*
+     * Be more accepting of a one-second difference in timestamps when running a test.
+     */
     private ResultMatcher buildTxTimeMatcher() {
         return result -> {
             OffsetDateTime buildTime = OffsetDateTime.now();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -70,7 +70,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Testcontainers
 /* When checking in, comment out print statements. They are very helpful, but fill up the logs */
-public class BulkDataAccessAPIIntegrationTests {
+class BulkDataAccessAPIIntegrationTests {
 
     @Autowired
     private MockMvc mockMvc;
@@ -1156,12 +1156,12 @@ public class BulkDataAccessAPIIntegrationTests {
         return result -> {
             OffsetDateTime buildTime = OffsetDateTime.now();
             String buildTimeStr = new org.hl7.fhir.dstu3.model.DateTimeType(buildTime.toString()).toHumanDisplay();
-            String buildPlusOneStr = new org.hl7.fhir.dstu3.model.DateTimeType(buildTime.plusSeconds(1).toString()).toHumanDisplay();
+            String buildPlusOneStr = new org.hl7.fhir.dstu3.model.DateTimeType(buildTime.minusSeconds(1).toString()).toHumanDisplay();
             List<String> elementsToMatch = new ArrayList<>();
             elementsToMatch.add(buildTimeStr);
             elementsToMatch.add(buildPlusOneStr);
 
-            jsonPath("$.transactionTime", IsIn.in(elementsToMatch));
+            jsonPath("$.transactionTime", IsIn.in(elementsToMatch)).match(result);
         };
     }
 }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -17,6 +17,7 @@ import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import gov.cms.ab2d.job.model.JobOutput;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.collection.IsIn;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -526,8 +528,7 @@ public class BulkDataAccessAPIIntegrationTests {
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().is(200))
                 .andExpect(buildExpiresMatcher())
-                .andExpect(jsonPath("$.transactionTime",
-                        Is.is(new org.hl7.fhir.dstu3.model.DateTimeType(OffsetDateTime.now().toString()).toHumanDisplay())))
+                .andExpect(buildTxTimeMatcher())
                 .andExpect(jsonPath("$.request", Is.is(startJobDTO.getUrl())))
                 .andExpect(jsonPath("$.requiresAccessToken", Is.is(true)))
                 .andExpect(jsonPath("$.output[0].type", Is.is(EOB)))
@@ -574,8 +575,7 @@ public class BulkDataAccessAPIIntegrationTests {
                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().is(200))
                 .andExpect(buildExpiresMatcher())
-                .andExpect(jsonPath("$.transactionTime",
-                        Is.is(new org.hl7.fhir.dstu3.model.DateTimeType(OffsetDateTime.now().toString()).toHumanDisplay())))
+                .andExpect(buildTxTimeMatcher())
                 .andExpect(jsonPath("$.request", Is.is(startJobDTO.getUrl())))
                 .andExpect(jsonPath("$.requiresAccessToken", Is.is(true)))
                 .andExpect(jsonPath("$.output[0].type", Is.is(EOB)))
@@ -1146,6 +1146,19 @@ public class BulkDataAccessAPIIntegrationTests {
             OffsetDateTime minExpected = expected.minusSeconds(7);
             assertTrue(actual.isAfter(minExpected), "Expire header time mismatch: actual - " + actual +
                     " should be greater than expected - " + minExpected);
+        };
+    }
+
+    private ResultMatcher buildTxTimeMatcher() {
+        return result -> {
+            OffsetDateTime buildTime = OffsetDateTime.now();
+            String buildTimeStr = new org.hl7.fhir.dstu3.model.DateTimeType(buildTime.toString()).toHumanDisplay();
+            String buildPlusOneStr = new org.hl7.fhir.dstu3.model.DateTimeType(buildTime.plusSeconds(1).toString()).toHumanDisplay();
+            List<String> elementsToMatch = new ArrayList<>();
+            elementsToMatch.add(buildTimeStr);
+            elementsToMatch.add(buildPlusOneStr);
+
+            jsonPath("$.transactionTime", IsIn.in(elementsToMatch));
         };
     }
 }

--- a/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
@@ -143,7 +143,7 @@ class JobServiceTest extends JobCleanup {
         dataSetup.cleanup();
     }
 
-    private void setupRegularClientSecurityContext() {
+    static void setupRegularClientSecurityContext() {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(
                         new org.springframework.security.core.userdetails.User(CLIENTID,

--- a/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
@@ -1,0 +1,119 @@
+package gov.cms.ab2d.job.service;
+
+import gov.cms.ab2d.common.model.Contract;
+import gov.cms.ab2d.common.repository.ContractRepository;
+import gov.cms.ab2d.common.service.PdpClientService;
+import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.job.JobTestSpringBootApp;
+import gov.cms.ab2d.job.dto.StartJobDTO;
+import gov.cms.ab2d.job.model.Job;
+import gov.cms.ab2d.job.model.JobStatus;
+import gov.cms.ab2d.job.repository.JobRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.fhir.BundleUtils.EOB;
+import static gov.cms.ab2d.fhir.FhirVersion.STU3;
+import static gov.cms.ab2d.job.service.JobServiceTest.CLIENTID;
+import static gov.cms.ab2d.job.service.JobServiceTest.CONTRACT_NUMBER;
+import static gov.cms.ab2d.job.service.JobServiceTest.LOCAL_HOST;
+import static gov.cms.ab2d.job.service.JobServiceTest.setupRegularClientSecurityContext;
+import static java.util.List.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = JobTestSpringBootApp.class)
+@Testcontainers
+class MaxJobsTest extends JobCleanup {
+
+    private static final int MAX_JOBS_PER_CLIENT = 3;
+
+    @Autowired
+    private ContractRepository contractRepository;
+
+    @Autowired
+    private JobService jobService;
+
+    @Autowired
+    private PdpClientService pdpClientService;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private DataSetup dataSetup;
+
+    private StartJobDTO startJobDTO;
+
+    @SuppressWarnings({"rawtypes", "unused"})
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
+
+    @BeforeEach
+    public void setup() {
+        createMaxJobs();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        jobCleanup();
+        dataSetup.cleanup();
+    }
+
+    private void createMaxJobs() {
+        dataSetup.setupNonStandardClient(CLIENTID, CONTRACT_NUMBER, of());
+        setupRegularClientSecurityContext();
+
+
+        Contract contract = contractRepository.findAll(Sort.by(Sort.Direction.DESC, "id")).iterator().next();
+        String organization = pdpClientService.getCurrentClient().getOrganization();
+        startJobDTO = new StartJobDTO(contract.getContractNumber(), organization,
+                EOB, LOCAL_HOST, NDJSON_FIRE_CONTENT_TYPE, null, STU3);
+        for (int idx = 0; idx < MAX_JOBS_PER_CLIENT; idx++) {
+            Job retJob = jobService.createJob(startJobDTO);
+            assertNotNull(retJob);
+            addJobForCleanup(retJob);
+        }
+    }
+
+    @Test
+    void testPatientExportDuplicateSubmissionWithCancelledStatus() {
+        int maxJobs = pdpClientService.getCurrentClient().getMaxParallelJobs();
+        assertEquals(MAX_JOBS_PER_CLIENT, maxJobs);
+        assertEquals(MAX_JOBS_PER_CLIENT, jobService.activeJobs(startJobDTO.getOrganization()));
+
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        for (Job job : jobs) {
+            job.setStatus(JobStatus.CANCELLED);
+            jobRepository.saveAndFlush(job);
+        }
+
+        // With no active jobs, new submissions would be allowed.
+        assertEquals(0, jobService.activeJobs(startJobDTO.getOrganization()));
+    }
+
+    @Test
+    void testPatientExportDuplicateSubmissionWithDifferentClient() {
+
+        List<Job> jobs = jobRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+
+        for (Job job : jobs) {
+            job.setOrganization("bogus_org");
+            jobRepository.saveAndFlush(job);
+            dataSetup.queueForCleanup(job);
+        }
+
+        assertEquals(0, jobService.activeJobs(startJobDTO.getOrganization()));
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/ShutdownServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/ShutdownServiceTest.java
@@ -4,34 +4,27 @@ import gov.cms.ab2d.eventlogger.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.job.model.Job;
-import gov.cms.ab2d.job.model.JobStartedBy;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.job.repository.JobRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.query.FluentQuery;
 
-import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ShutdownServiceTest {
 
     @Test
     void testEmptyReset() {
         List<String> activeJobs = Collections.emptyList();
-        ShutDownService sds = new ShutDownServiceImpl(new MockJobRepository(), new MockEventLogger());
+        ShutDownService sds = new ShutDownServiceImpl(buildJobRepository(), new MockEventLogger());
         sds.resetInProgressJobs(activeJobs);
         //noinspection ConstantConditions
         assertTrue(activeJobs.isEmpty());
@@ -40,7 +33,7 @@ class ShutdownServiceTest {
     @Test
     void testResetInProgress() {
         List<String> activeJobs = Arrays.asList("jobone", "jobtwo");
-        ShutDownService sds = new ShutDownServiceImpl(new MockJobRepository(), new MockEventLogger());
+        ShutDownService sds = new ShutDownServiceImpl(buildJobRepository(), new MockEventLogger());
         sds.resetInProgressJobs(activeJobs);
         assertEquals(2, activeJobs.size());
     }
@@ -48,7 +41,7 @@ class ShutdownServiceTest {
     @Test
     void testException() {
         List<String> activeJobs = Collections.singletonList("bogus");
-        ShutDownService sds = new ShutDownServiceImpl(null, null);
+        ShutDownService sds = new ShutDownServiceImpl(buildJobRepository(), null);
         // Hit the log service
         sds.resetInProgressJobs(activeJobs);
         //noinspection ConstantConditions - having one test case makes SonarLint happier.
@@ -66,204 +59,17 @@ class ShutdownServiceTest {
         }
     }
 
-    /*
-     * TODO - definitely not pretty and the only implemented method that we care about is findByJobUuid.
-     *
-     * The use of a mock library could reduce this to just the override method.
-     */
-    @SuppressWarnings("all")
-    static class MockJobRepository implements JobRepository {
-        @Override
-        public void cancelJobByJobUuid(String jobUuid) {
+    private JobRepository buildJobRepository() {
+        JobRepository retJobRepository = mock(JobRepository.class);
+        when(retJobRepository.findByJobUuid(anyString()))
+                .thenAnswer(jobId -> buildJob(jobId.getArgument(0).toString()));
+        return retJobRepository;
+    }
 
-        }
-
-        @Override
-        public Job findByJobUuid(String jobUuid) {
-            Job retJob = new Job();
-            retJob.setJobUuid(jobUuid);
-            retJob.setStatus(JobStatus.SUBMITTED);
-            return retJob;
-        }
-
-        @Override
-        public List<Job> findActiveJobsByClient(String organization) {
-            return null;
-        }
-
-        @Override
-        public List<Job> findByContractNumberEqualsAndStatusInAndStartedByOrderByCompletedAtDesc(String contractNumber, List<JobStatus> statuses, JobStartedBy startedBy) {
-            return null;
-        }
-
-        @Override
-        public List<Job> findStuckJobs(OffsetDateTime createdAt) {
-            return null;
-        }
-
-        @Override
-        public void resetJobsToSubmittedStatus(List<String> jobUuids) {
-
-        }
-
-        @Override
-        public void updatePercentageCompleted(String jobUuid, int percentageCompleted) {
-
-        }
-
-        @Override
-        public int countJobByContractNumberAndStatus(String contractNumber, List<JobStatus> statuses) {
-            return 0;
-        }
-
-        @Override
-        public List<Job> findByJobUuidIn(List<String> jobUuids) {
-            return null;
-        }
-
-        @Override
-        public List<Job> findAll() {
-            return null;
-        }
-
-        @Override
-        public List<Job> findAll(Sort sort) {
-            return null;
-        }
-
-        @Override
-        public List<Job> findAllById(Iterable<Long> longs) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> List<S> saveAll(Iterable<S> entities) {
-            return null;
-        }
-
-        @Override
-        public void flush() {
-
-        }
-
-        @Override
-        public <S extends Job> S saveAndFlush(S entity) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> List<S> saveAllAndFlush(Iterable<S> entities) {
-            return null;
-        }
-
-        @Override
-        public void deleteAllInBatch(Iterable<Job> entities) {
-
-        }
-
-        @Override
-        public void deleteAllByIdInBatch(Iterable<Long> longs) {
-
-        }
-
-        @Override
-        public void deleteAllInBatch() {
-
-        }
-
-        @Override
-        public Job getOne(Long aLong) {
-            return null;
-        }
-
-        @Override
-        public Job getById(Long aLong) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> List<S> findAll(Example<S> example) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> List<S> findAll(Example<S> example, Sort sort) {
-            return null;
-        }
-
-        @Override
-        public Page<Job> findAll(Pageable pageable) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> S save(S entity) {
-            return null;
-        }
-
-        @Override
-        public Optional<Job> findById(Long aLong) {
-            return Optional.empty();
-        }
-
-        @Override
-        public boolean existsById(Long aLong) {
-            return false;
-        }
-
-        @Override
-        public long count() {
-            return 0;
-        }
-
-        @Override
-        public void deleteById(Long aLong) {
-
-        }
-
-        @Override
-        public void delete(Job entity) {
-
-        }
-
-        @Override
-        public void deleteAllById(Iterable<? extends Long> longs) {
-
-        }
-
-        @Override
-        public void deleteAll(Iterable<? extends Job> entities) {
-
-        }
-
-        @Override
-        public void deleteAll() {
-
-        }
-
-        @Override
-        public <S extends Job> Optional<S> findOne(Example<S> example) {
-            return Optional.empty();
-        }
-
-        @Override
-        public <S extends Job> Page<S> findAll(Example<S> example, Pageable pageable) {
-            return null;
-        }
-
-        @Override
-        public <S extends Job> long count(Example<S> example) {
-            return 0;
-        }
-
-        @Override
-        public <S extends Job> boolean exists(Example<S> example) {
-            return false;
-        }
-
-        @Override
-        public <S extends Job, R> R findBy(Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
-            return null;
-        }
+    private Job buildJob(String jobUuid) {
+        Job retJob = new Job();
+        retJob.setJobUuid(jobUuid);
+        retJob.setStatus(JobStatus.SUBMITTED);
+        return retJob;
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4449](https://jira.cms.gov/browse/AB2D-4449) - Add job max tests previously dropped.

***Related Tickets***
 
### What Does This PR Do?

Given the separation of JobService into it's own module and the fact that the api module now works through a job client, there were a couple of tests that were no longer appropriate in the api module.  Due to the massive size of an earlier refactoring they were moved into a JIRA ticket to be re-added later when the JobService was moved into its own module.

This PR restores the tests but in a more narrow focus specifically testing JobService features, not the overall MockMVC calls.

Also, noticed that build #141 on master failed which turned out to be a timing issue with comparing timestamps.  Created a custom matcher that can tolerate the test running across a one second boundary.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure