### PR TITLE
Fixed issue with stale coverage periods not able to add to search queue

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
@@ -293,7 +293,6 @@ public class CoverageDriverImpl implements CoverageDriver {
         Set<CoveragePeriod> stalePeriods = new LinkedHashSet<>();
         long monthsInPast = 0;
         OffsetDateTime dateTime = OffsetDateTime.now(AB2D_ZONE);
-        log.info("Current time computed as {}", dateTime);
 
         OffsetDateTime lastSunday;
         if (dateTime.getDayOfWeek() == DayOfWeek.SUNDAY) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/quartz/CoveragePeriodQuartzJob.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/quartz/CoveragePeriodQuartzJob.java
@@ -79,7 +79,7 @@ public class CoveragePeriodQuartzJob extends QuartzJobBean {
                 // Start this job every day on Tuesday at midnight
                 // or override and force start
                 OffsetDateTime now = OffsetDateTime.now(AB2D_ZONE);
-                if ((now.getDayOfWeek() == DayOfWeek.TUESDAY && now.getHour() == 0) || override) {
+                if ((now.getDayOfWeek() == DayOfWeek.TUESDAY) || override) {
                     driver.queueStaleCoveragePeriods();
                 }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/quartz/CoveragePeriodQuartzJobTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/quartz/CoveragePeriodQuartzJobTest.java
@@ -163,7 +163,7 @@ class CoveragePeriodQuartzJobTest {
 
             OffsetDateTime date = OffsetDateTime.now(AB2D_ZONE);
 
-            if (date.getDayOfWeek() == DayOfWeek.TUESDAY && date.getHour() == 0) {
+            if (date.getDayOfWeek() == DayOfWeek.TUESDAY) {
                 assertTrue(coverageDriverStub.queueingCalled);
             } else {
                 assertFalse(coverageDriverStub.queueingCalled);


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4745](https://jira.cms.gov/browse/AB2D-4745) - Diagnose issue with coverage data not updating

### What Does This PR Do?

Fix the issue with stale coverage data not being searched.

On 6/1/2022 we received an alert saying that coverage data was out of date. The incident is covered [here](https://confluence.cms.gov/display/AB2D/2022-06-01+AB2D+Missing+Enrollment+Data).

After some investigation (and adding debug statements), it appears that the application is running out of time to add stale data to the search queue. Originally, it was only allowed 1 hour to add items to the queue. Because it has a maximum queue size before it considered it "full", and the queue has to open up some space before another item is added, many period searches weren't being added to the search queue before that hour was over.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

- [ ] All QuickSight impacts have been identified

### Limitations

This is not the best solution. There probably is a better way to handle queueing stale periods. Because we already control how many simultaneous threads are running, controlling the queue like this is probably not necessary. That being said, doing re-engineering brings some risks and there is no doubt that 24 hours is sufficient to load and process the search queue. This is a candidate for refactoring as we move this into its own service.

Next steps include pushing to master, then production and verify on Tuesday that the entire list of stale periods are processed. If they are, we can close the incident. If they are not, they can be loaded manually and we will continue to track down the issue.

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure