### PR TITLE
Feature/ab2 d 4882 send event when hpms call fails

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -84,5 +84,5 @@ public final class Constants {
 
     public static final String ZIPFORMAT = "application/zip";
 
-    public static final String HPMS_AUTHORIZATION = "HPMS_AUTHORIZATION";
+    public static final String HPMS_AUTHORIZATION = "HPMS_AUTH";
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -84,5 +84,5 @@ public final class Constants {
 
     public static final String ZIPFORMAT = "application/zip";
 
-    public static final String HPMS_AUTHORIZATION = "HPMS_AUTH";
+    public static final String HPMS_ORGANIZATION = "HPMS_AUTH";
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -83,6 +83,4 @@ public final class Constants {
     public static final String SINCE_EARLIEST_DATE = "2020-02-13T00:00:00.000-05:00";
 
     public static final String ZIPFORMAT = "application/zip";
-
-    public static final String HPMS_ORGANIZATION = "HPMS_AUTH";
 }

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -83,4 +83,6 @@ public final class Constants {
     public static final String SINCE_EARLIEST_DATE = "2020-02-13T00:00:00.000-05:00";
 
     public static final String ZIPFORMAT = "application/zip";
+
+    public static final String HPMS_AUTHORIZATION = "HPMS_AUTHORIZATION";
 }

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
@@ -18,7 +18,7 @@ public class ErrorEvent extends LoggableEvent {
         UNAUTHORIZED_CONTRACT,
         TOO_MANY_STATUS_REQUESTS,
         TOO_MANY_SEARCH_ERRORS,
-        HpMS_AUTH_ERROR
+        HPMS_AUTH_ERROR
     }
     // The type of error we're reporting
     private ErrorType errorType;

--- a/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
+++ b/eventlogger/src/main/java/gov/cms/ab2d/eventlogger/events/ErrorEvent.java
@@ -17,7 +17,8 @@ public class ErrorEvent extends LoggableEvent {
         CONTRACT_NOT_FOUND,
         UNAUTHORIZED_CONTRACT,
         TOO_MANY_STATUS_REQUESTS,
-        TOO_MANY_SEARCH_ERRORS
+        TOO_MANY_SEARCH_ERRORS,
+        HpMS_AUTH_ERROR
     }
     // The type of error we're reporting
     private ErrorType errorType;

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -108,7 +108,7 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
             eventLogger.log(LogManager.LogType.SQL,
                     new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, prepareErrorMessage(exception, curTime)));
             throw exception;
-        } catch (IllegalStateException exception) {
+        } catch (IllegalStateException | NullPointerException exception) {
             String message = "HPMS auth call failed with no response waited for " + (curTime / 1000) + " seconds.";
             eventLogger.log(LogManager.LogType.SQL,
                     new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, message));

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static gov.cms.ab2d.common.util.Constants.HPMS_AUTHORIZATION;
+import static gov.cms.ab2d.common.util.Constants.HPMS_ORGANIZATION;
 import static gov.cms.ab2d.eventlogger.events.ErrorEvent.ErrorType.HpMS_AUTH_ERROR;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.COOKIE;
@@ -150,7 +150,7 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     }
 
     private void logErrors(String errorMessage, long curTime) {
-        eventLogger.log(new ErrorEvent(HPMS_AUTHORIZATION, "", HpMS_AUTH_ERROR, errorMessage));
+        eventLogger.log(new ErrorEvent(HPMS_ORGANIZATION, "", HpMS_AUTH_ERROR, errorMessage));
         long elapsedTime = System.currentTimeMillis() - curTime;
         throw new RemoteTimeoutException("Failed to procure Auth Token, response: " + errorMessage +
                 " waited for " + (elapsedTime / 1000) + " seconds.");
@@ -159,16 +159,15 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     private String prepareErrorMessage(WebClientResponseException exception) {
         String explication;
         switch (exception.getStatusCode().value()) {
-            case (403) -> {
+            case (403):
                 explication = "HPMS auth key/secret have expired and must be updated";
-            }
-            case (500) -> {
+                break;
+            case (500):
                 explication = "HPMS auth key/secret are invalid or HPMS is down";
-            }
-            default -> {
+                break;
+            default:
                 explication = "HPMS returned an unknown error" + ": "
                         + exception.getResponseBodyAsString();
-            }
         }
 
         return explication;

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static gov.cms.ab2d.common.util.Constants.HPMS_ORGANIZATION;
-import static gov.cms.ab2d.eventlogger.events.ErrorEvent.ErrorType.HpMS_AUTH_ERROR;
+import static gov.cms.ab2d.eventlogger.events.ErrorEvent.ErrorType.HPMS_AUTH_ERROR;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.COOKIE;
 import static org.springframework.http.HttpStatus.OK;
@@ -103,12 +103,12 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
             authToken = authResponse.getAccessToken();
         } catch (WebClientResponseException exception) {
             eventLogger.log(LogManager.LogType.SQL,
-                    new ErrorEvent(HPMS_ORGANIZATION, "", HpMS_AUTH_ERROR, prepareErrorMessage(exception, curTime)));
+                    new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, prepareErrorMessage(exception, curTime)));
             throw exception;
         } catch (IllegalStateException | NullPointerException exception) {
             String message = "HPMS auth call failed with no response waited for " + (curTime / 1000) + " seconds.";
             eventLogger.log(LogManager.LogType.SQL,
-                    new ErrorEvent(HPMS_ORGANIZATION, "", HpMS_AUTH_ERROR, message));
+                    new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, message));
             throw new RemoteTimeoutException(message);
         }
     }

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -99,13 +99,16 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
             authResponse = orgInfoMono.block(Duration.ofMinutes(1));
             // Convert seconds to millis at a 90% level to pad refreshing of a token so that we are not in the middle of
             // a significant operation when the token expires.
+            if (authResponse == null) {
+                throw new IllegalStateException();
+            }
             tokenExpires = currentTimestamp + authResponse.getExpires() * 900L;
             authToken = authResponse.getAccessToken();
         } catch (WebClientResponseException exception) {
             eventLogger.log(LogManager.LogType.SQL,
                     new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, prepareErrorMessage(exception, curTime)));
             throw exception;
-        } catch (IllegalStateException | NullPointerException exception) {
+        } catch (IllegalStateException exception) {
             String message = "HPMS auth call failed with no response waited for " + (curTime / 1000) + " seconds.";
             eventLogger.log(LogManager.LogType.SQL,
                     new ErrorEvent(HPMS_ORGANIZATION, "", HPMS_AUTH_ERROR, message));

--- a/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
+++ b/hpms/src/main/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceImpl.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.hpms.service;
 
+import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.events.ErrorEvent;
 import gov.cms.ab2d.hpms.hmsapi.HPMSAuthResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +12,7 @@ import org.springframework.remoting.RemoteTimeoutException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import javax.annotation.PostConstruct;
@@ -18,8 +21,11 @@ import java.time.Duration;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static gov.cms.ab2d.common.util.Constants.HPMS_AUTHORIZATION;
+import static gov.cms.ab2d.eventlogger.events.ErrorEvent.ErrorType.HpMS_AUTH_ERROR;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.COOKIE;
+import static org.springframework.http.HttpStatus.OK;
 
 @Service
 public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuthService {
@@ -35,6 +41,9 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
 
     @Autowired
     private WebClient webClient;
+
+    @Autowired
+    private LogManager eventLogger;
 
     private URI fullAuthURI;
 
@@ -59,6 +68,7 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     private String retrieveAuthToken() {
         final long currentTimestamp = System.currentTimeMillis();
         if (authToken == null || currentTimestamp >= tokenExpires) {
+
             refreshToken(currentTimestamp);
         }
 
@@ -74,23 +84,30 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
                 .bodyValue(retrieveAuthRequestPayload())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchangeToMono(response -> {
-                    cookies = extractCookies(response.cookies());
-                    return response.bodyToMono(HPMSAuthResponse.class);
+                    if (response.statusCode().equals(OK)) {
+                        cookies = extractCookies(response.cookies());
+                        return response.bodyToMono(HPMSAuthResponse.class);
+                    } else {
+                        return response.createException().flatMap(Mono::error);
+                    }
                 });
 
         // Cough up blood if we can't get an Auth response in a minute.
         long curTime = System.currentTimeMillis();
-        HPMSAuthResponse authResponse = orgInfoMono.block(Duration.ofMinutes(1));
-        if (authResponse == null || authResponse.getAccessToken() == null) {
-            long elapsedTime = System.currentTimeMillis() - curTime;
-            throw new RemoteTimeoutException("Failed to procure Auth Token, response: " + authResponse +
-                    "waited for " + (elapsedTime / 1000) + " seconds.");
+        HPMSAuthResponse authResponse;
+        try {
+            authResponse = orgInfoMono.block(Duration.ofMinutes(1));
+            if (authResponse == null) {
+                logErrors("HPMS auth call failed with no response", curTime);
+                return;
+            }
+            // Convert seconds to millis at a 90% level to pad refreshing of a token so that we are not in the middle of
+            // a significant operation when the token expires.
+            tokenExpires = currentTimestamp + authResponse.getExpires() * 900L;
+            authToken = authResponse.getAccessToken();
+        } catch (WebClientResponseException exception) {
+            logErrors(prepareErrorMessage(exception), curTime);
         }
-
-        // Convert seconds to millis at a 90% level to pad refreshing of a token so that we are not in the middle of
-        // a significant operation when the token expires.
-        tokenExpires = currentTimestamp + authResponse.getExpires() * 900;
-        authToken = authResponse.getAccessToken();
     }
 
     private String extractCookies(MultiValueMap<String, ResponseCookie> entries) {
@@ -130,5 +147,30 @@ public class HPMSAuthServiceImpl extends AbstractHPMSService implements HPMSAuth
     void cleanup() {
         clearTokenExpires();
         authToken = null;
+    }
+
+    private void logErrors(String errorMessage, long curTime) {
+        eventLogger.log(new ErrorEvent(HPMS_AUTHORIZATION, "", HpMS_AUTH_ERROR, errorMessage));
+        long elapsedTime = System.currentTimeMillis() - curTime;
+        throw new RemoteTimeoutException("Failed to procure Auth Token, response: " + errorMessage +
+                " waited for " + (elapsedTime / 1000) + " seconds.");
+    }
+
+    private String prepareErrorMessage(WebClientResponseException exception) {
+        String explication;
+        switch (exception.getStatusCode().value()) {
+            case (403) -> {
+                explication = "HPMS auth key/secret have expired and must be updated";
+            }
+            case (500) -> {
+                explication = "HPMS auth key/secret are invalid or HPMS is down";
+            }
+            default -> {
+                explication = "HPMS returned an unknown error" + ": "
+                        + exception.getResponseBodyAsString();
+            }
+        }
+
+        return explication;
     }
 }

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -22,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")
 @Testcontainers
+// HPMSAuthServiceImpl holds some state that's useful normally but can break tests. Reset the bean after each test.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class HPMSAuthServiceTest {
 
     @Autowired

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSMockedAuthTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSMockedAuthTest.java
@@ -1,16 +1,20 @@
 package gov.cms.ab2d.hpms.service;
 
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventlogger.LogManager;
+import gov.cms.ab2d.eventlogger.LoggableEvent;
 import gov.cms.ab2d.hpms.SpringBootTestApp;
 import gov.cms.ab2d.hpms.hmsapi.HPMSAuthResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.remoting.RemoteTimeoutException;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -21,7 +25,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.COOKIE;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.REQUEST_TIMEOUT;
 
 @SpringBootTest(classes = SpringBootTestApp.class)
 @TestPropertySource(locations = "/application.hpms.properties")
@@ -40,6 +51,9 @@ class HPMSMockedAuthTest {
     MockWebClient mockWebClient;
 
     @MockBean
+    private LogManager eventLogger;
+
+    @MockBean
     private WebClient mockedWebClient;
 
     @Test
@@ -47,7 +61,7 @@ class HPMSMockedAuthTest {
         HPMSAuthResponse hpmsAuthResponse = new HPMSAuthResponse();
         hpmsAuthResponse.setAccessToken("TOKEN");
         try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
-            client.authRequest(mockedWebClient, webClientStatic, hpmsAuthResponse);
+            client.authRequest(mockedWebClient, webClientStatic, OK, hpmsAuthResponse);
             HttpHeaders headers = new HttpHeaders();
             authService.buildAuthHeaders(headers);
             assertNotNull(headers.get(COOKIE));
@@ -58,13 +72,33 @@ class HPMSMockedAuthTest {
     @Test
     void authNoKey() {
         try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
-            client.authRequest(mockedWebClient, webClientStatic, new HPMSAuthResponse());
-            assertThrows(RuntimeException.class, () -> authService.buildAuthHeaders(new HttpHeaders()));
+            client.authRequest(mockedWebClient, webClientStatic, INTERNAL_SERVER_ERROR, new HPMSAuthResponse());
+            assertThrows(RemoteTimeoutException.class, () -> authService.buildAuthHeaders(new HttpHeaders()));
+            verify(eventLogger, times(1)).log(any(LoggableEvent.class));
+        }
+    }
+
+    @Test
+    void authInvalidKey() {
+        try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
+            client.authRequest(mockedWebClient, webClientStatic, FORBIDDEN, new HPMSAuthResponse());
+            assertThrows(RemoteTimeoutException.class, () -> authService.buildAuthHeaders(new HttpHeaders()));
+            verify(eventLogger, times(1)).log(any(LoggableEvent.class));
+        }
+    }
+
+    @Test
+    void authUnknownError() {
+        try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
+            client.authRequest(mockedWebClient, webClientStatic, REQUEST_TIMEOUT, new HPMSAuthResponse());
+            assertThrows(RemoteTimeoutException.class, () -> authService.buildAuthHeaders(new HttpHeaders()));
+            verify(eventLogger, times(1)).log(any(LoggableEvent.class));
         }
     }
 
     @AfterEach
     public void shutdown() {
+        Mockito.reset(mockedWebClient);
         authService.cleanup();
     }
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4882](https://jira.cms.gov/browse/AB2D-4882) - Description

When HPMS fails authentication send an alert to the AB2D event error table.

### What Does This PR Do?

Adds error handling to HPMS auth code. Previously status code wasn't taken into account when extracting the request's body. These change check for 200 and return an error otherwise. The error is then checked against some know failure scenarios. Uncommon errors get a generic error message and the request's body is logged. 

### What Should Reviewers Watch For?

Opportunities to simplify this code. 

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

- [X] All QuickSight impacts have been identified

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure