### PR TITLE
Feature/ab2d 4925 Reduces use of localstac

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,6 @@ pipeline {
                     echo $WORKSPACE
 
                     mvn clean
-                    
-                    mvn -e -U clean install --settings settings.xml -DskipTests
                 '''
             }
         }
@@ -78,7 +76,7 @@ pipeline {
         stage('Package without tests') {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'artifactoryuserpass', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) {
-                    sh 'mvn -U -X clean package --settings settings.xml -DskipTests -Dartifactory.username=${ARTIFACTORY_USER} -Dartifactory.password=${ARTIFACTORY_PASSWORD}'
+                    sh 'mvn clean package --settings settings.xml -DskipTests -Dartifactory.username=${ARTIFACTORY_USER} -Dartifactory.password=${ARTIFACTORY_PASSWORD}'
                 }
             }
         }

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import com.okta.jwt.JwtVerificationException;
@@ -8,6 +9,7 @@ import gov.cms.ab2d.api.remote.JobClientMock;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventclient.events.ApiRequestEvent;
 import gov.cms.ab2d.eventclient.events.ApiResponseEvent;
@@ -22,8 +24,10 @@ import gov.cms.ab2d.eventlogger.utils.UtilMethods;
 import gov.cms.ab2d.job.model.JobOutput;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -48,6 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class AdminAPIMaintenanceModeTests {
 
     @Autowired
@@ -56,8 +61,9 @@ public class AdminAPIMaintenanceModeTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+    @Autowired
+    @Qualifier("mockAmazonSQS")
+    AmazonSQS amazonSqs;
 
     @Autowired
     private TestUtil testUtil;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -69,8 +69,8 @@ public class AdminAPIPdpClientTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+//    @Container
+//    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Autowired
     private PdpClientRepository pdpClientRepository;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -69,9 +69,6 @@ public class AdminAPIPdpClientTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-//    @Container
-//    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Autowired
     private PdpClientRepository pdpClientRepository;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPropertiesTests.java
@@ -57,9 +57,6 @@ public class AdminAPIPropertiesTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     private static final String PROPERTIES_URL = "/properties";
 
     private String token;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -42,7 +42,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Testcontainers
 @Import(AB2DSQSMockConfig.class)
 public class AuthenticationTests {
-
     @Autowired
     private MockMvc mockMvc;
 
@@ -62,10 +61,8 @@ public class AuthenticationTests {
     @Qualifier("mockAmazonSQS")
     AmazonSQS amazonSqs;
 
-
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
-
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -1,11 +1,14 @@
 package gov.cms.ab2d.api.controller;
 
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventclient.events.ApiRequestEvent;
 import gov.cms.ab2d.eventclient.events.ApiResponseEvent;
@@ -13,8 +16,10 @@ import gov.cms.ab2d.eventclient.events.LoggableEvent;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class AuthenticationTests {
 
     @Autowired
@@ -51,6 +57,11 @@ public class AuthenticationTests {
 
     @Autowired
     private LoggerEventRepository loggerEventRepository;
+
+    @Autowired
+    @Qualifier("mockAmazonSQS")
+    AmazonSQS amazonSqs;
+
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -55,8 +55,6 @@ public class AuthenticationTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -19,6 +19,7 @@ import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.repository.PdpClientRepository;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventclient.events.ApiRequestEvent;
 import gov.cms.ab2d.eventclient.events.ApiResponseEvent;
@@ -39,6 +40,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -99,6 +102,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+//@EnableAutoConfiguration(exclude= AB2DSQSMockConfig.class)
 @AutoConfigureMockMvc
 @Testcontainers
         /* When checking in, comment out print statements. They are very helpful, but fill up the logs */

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -102,7 +102,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-//@EnableAutoConfiguration(exclude= AB2DSQSMockConfig.class)
 @AutoConfigureMockMvc
 @Testcontainers
         /* When checking in, comment out print statements. They are very helpful, but fill up the logs */

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.api.controller;
 
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.remote.JobClientMock;
+import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.eventclient.events.ApiRequestEvent;
 import gov.cms.ab2d.eventclient.events.ApiResponseEvent;
 import gov.cms.ab2d.eventclient.events.ContractSearchEvent;
@@ -69,6 +70,9 @@ public class BulkDataAccessAPIUnusualDataTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
+    @Container
+    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+    
     @AfterEach
     public void cleanup() {
         dataSetup.cleanup();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -72,7 +72,7 @@ public class BulkDataAccessAPIUnusualDataTests {
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-    
+
     @AfterEach
     public void cleanup() {
         dataSetup.cleanup();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -53,9 +53,6 @@ public class InvalidTokenTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     private String token;
 
     @BeforeEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -6,12 +6,14 @@ import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.repository.*;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -30,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class InvalidTokenTest {
 
     @Autowired

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -5,12 +5,14 @@ import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -29,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Import(AB2DSQSMockConfig.class)
 public class MaintenanceModeAPITests {
 
     @Container

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -34,9 +34,6 @@ public class MaintenanceModeAPITests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Autowired
     private MockMvc mockMvc;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -49,9 +49,6 @@ public class RoleTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     private String token;
 
     @BeforeEach

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -1,9 +1,11 @@
 package gov.cms.ab2d.api.controller;
 
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.eventlogger.reports.sql.LoggerEventRepository;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -13,9 +15,11 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -44,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = SpringBootApp.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class TLSTest {
 
     @LocalServerPort
@@ -64,11 +69,13 @@ public class TLSTest {
     @Autowired
     private LoggerEventRepository loggerEventRepository;
 
+    @Autowired
+    @Qualifier("mockAmazonSQS")
+    AmazonSQS amazonSqs;
+
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @AfterEach
     public void cleanup() {

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -76,7 +76,6 @@ public class TLSTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-
     @AfterEach
     public void cleanup() {
         dataSetup.cleanup();

--- a/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
@@ -60,9 +60,6 @@ class JwtAuthenticationFilterTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @AfterEach
     public void cleanup() {
         dataSetup.cleanup();

--- a/audit/src/test/java/gov/cms/ab2d/audit/SpringBootApp.java
+++ b/audit/src/test/java/gov/cms/ab2d/audit/SpringBootApp.java
@@ -1,8 +1,10 @@
 package gov.cms.ab2d.audit;
 
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
@@ -11,6 +13,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model", "gov.cms.ab2d.job.model"})
 @EnableJpaRepositories({"gov.cms.ab2d.common.repository", "gov.cms.ab2d.job.repository"})
 @PropertySource("classpath:application.common.properties")
+@Import(AB2DSQSMockConfig.class)
 public class SpringBootApp {
 
     public static void main(String[] args) {

--- a/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
+++ b/audit/src/test/java/gov/cms/ab2d/audit/cleanup/FileDeletionServiceTest.java
@@ -79,9 +79,6 @@ class FileDeletionServiceTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Autowired
     private JobAuditClientMock jobAuditClientMock;
 

--- a/common/src/test/java/gov/cms/ab2d/common/SpringBootApp.java
+++ b/common/src/test/java/gov/cms/ab2d/common/SpringBootApp.java
@@ -1,11 +1,14 @@
 package gov.cms.ab2d.common;
 
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.eventlogger", "gov.cms.ab2d.common", "gov.cms.ab2d.eventclient.clients"})
 @PropertySource("classpath:application.common.properties")
+@Import(AB2DSQSMockConfig.class)
 public class SpringBootApp {
 
     public static void main(String [] args) {

--- a/common/src/test/java/gov/cms/ab2d/common/health/DatabaseAvailableTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/health/DatabaseAvailableTest.java
@@ -1,8 +1,8 @@
 package gov.cms.ab2d.common.health;
 
 import gov.cms.ab2d.common.SpringBootApp;
-import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(classes = SpringBootApp.class)
 @TestPropertySource(locations = "/application.common.properties")
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class DatabaseAvailableTest {
     @Autowired
     private DataSource dataSource;
@@ -36,10 +38,6 @@ class DatabaseAvailableTest {
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
-
 
     @Test
     void testDatasource() throws SQLException {

--- a/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/ContractUpdateModeTest.java
@@ -1,7 +1,6 @@
 package gov.cms.ab2d.common.model;
 
 import gov.cms.ab2d.common.repository.ContractRepository;
-import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import org.junit.jupiter.api.AfterEach;
@@ -27,9 +26,6 @@ class ContractUpdateModeTest {
     @SuppressWarnings({"rawtypes", "unused"})
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
 
     @Autowired
     private ContractRepository contractRepository;

--- a/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/model/CreateUpdateTimestampTest.java
@@ -1,7 +1,6 @@
 package gov.cms.ab2d.common.model;
 
 import gov.cms.ab2d.common.repository.ContractRepository;
-import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import org.junit.jupiter.api.AfterEach;
@@ -25,9 +24,6 @@ class CreateUpdateTimestampTest {
     @SuppressWarnings({"rawtypes", "unused"})
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Autowired
     private DataSetup dataSetup;

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
@@ -31,7 +31,7 @@ public class AB2DSQSMockConfig {
     return mock(QueueMessageHandler.class);
   }
 
-  @Bean
+  @Bean("mockAmazonSQS")
   public AmazonSQSAsync amazonSQSAsync() {
     return mock(AmazonSQSAsync.class);
   }

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
@@ -1,0 +1,38 @@
+package gov.cms.ab2d.common.util;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.messaging.MessagingAutoConfiguration;
+import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import static org.mockito.Mockito.mock;
+
+@TestConfiguration
+@EnableAutoConfiguration(exclude = {MessagingAutoConfiguration.class, ContextStackAutoConfiguration.class})
+public class AB2DSQSMockConfig {
+  @MockBean
+  AmazonSQSAsync amazonSQSAsync;
+
+  @Bean
+  @Primary
+  public SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory() {
+    SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+    factory.setAutoStartup(false);
+    return factory;
+  }
+
+  @Bean
+  public QueueMessageHandler messageHandler() {
+    return mock(QueueMessageHandler.class);
+  }
+
+  @Bean
+  public AmazonSQSAsync amazonSQSAsync() {
+    return mock(AmazonSQSAsync.class);
+  }
+}

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -22,5 +22,3 @@ cloud.aws.credentials.secret-key:${AWS_SQS_SECRET_ACCESS_KEY:#{'EXAMPLEKEY'}}
 cloud.aws.end-point.uri:${AWS_SQS_URL:#{'http://localhost:4566'}}
 cloud.aws.stack.auto=false
 cloud.aws.region.static=us-east-1
-
-spring.main.allow-bean-definition-overriding=true

--- a/common/src/test/resources/application.common.properties
+++ b/common/src/test/resources/application.common.properties
@@ -22,3 +22,5 @@ cloud.aws.credentials.secret-key:${AWS_SQS_SECRET_ACCESS_KEY:#{'EXAMPLEKEY'}}
 cloud.aws.end-point.uri:${AWS_SQS_URL:#{'http://localhost:4566'}}
 cloud.aws.stack.auto=false
 cloud.aws.region.static=us-east-1
+
+spring.main.allow-bean-definition-overriding=true

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/AB2DSQSMockConfig.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/AB2DSQSMockConfig.java
@@ -1,0 +1,40 @@
+package gov.cms.ab2d.eventlogger;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.messaging.MessagingAutoConfiguration;
+import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
+import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+
+import static org.mockito.Mockito.mock;
+
+@TestConfiguration
+@EnableAutoConfiguration(exclude = {MessagingAutoConfiguration.class, ContextStackAutoConfiguration.class})
+public class AB2DSQSMockConfig {
+  @MockBean
+  AmazonSQSAsync amazonSQSAsync;
+
+  @Bean
+  @Primary
+  public SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory() {
+    SimpleMessageListenerContainerFactory factory = new SimpleMessageListenerContainerFactory();
+    factory.setAutoStartup(false);
+    return factory;
+  }
+
+  @Bean
+  public QueueMessageHandler messageHandler() {
+    return mock(QueueMessageHandler.class);
+  }
+
+  @Bean("mockAmazonSQS")
+  public AmazonSQSAsync amazonSQSAsync() {
+    return mock(AmazonSQSAsync.class);
+  }
+}

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/LogManagerTest.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.eventlogger;
 
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import gov.cms.ab2d.eventclient.clients.SQSConfig;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
 import gov.cms.ab2d.eventclient.events.LoggableEvent;
@@ -15,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -34,6 +37,9 @@ class LogManagerTest {
     private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
 
     private LogManager logManager;
+
+    @Autowired
+    AmazonSQSAsync amazonSQSAsync;
 
     @Mock
     private KinesisEventLogger kinesisEventLogger;

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/SpringBootApp.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/SpringBootApp.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.eventlogger;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.eventlogger", "gov.cms.ab2d.eventclient.clients"})
 public class SpringBootApp {

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/SpringBootApp.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/SpringBootApp.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.eventlogger;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.eventlogger", "gov.cms.ab2d.eventclient.clients"})
 public class SpringBootApp {

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/kinesis/KinesisEventLoggerTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
 import gov.cms.ab2d.eventlogger.AB2DLocalstackContainer;
 import gov.cms.ab2d.eventlogger.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventlogger.AB2DSQSMockConfig;
 import gov.cms.ab2d.eventlogger.SpringBootApp;
 import gov.cms.ab2d.eventclient.events.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,12 +41,10 @@ import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class KinesisEventLoggerTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Autowired
     private Ab2dEnvironment environment;

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/eventloggers/sql/AllMapperEventTest.java
@@ -11,6 +11,7 @@ import gov.cms.ab2d.eventclient.events.LoggableEvent;
 import gov.cms.ab2d.eventclient.events.ReloadEvent;
 import gov.cms.ab2d.eventlogger.AB2DLocalstackContainer;
 import gov.cms.ab2d.eventlogger.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventlogger.AB2DSQSMockConfig;
 import gov.cms.ab2d.eventlogger.EventLoggingException;
 import gov.cms.ab2d.eventlogger.SpringBootApp;
 import gov.cms.ab2d.eventclient.events.*;
@@ -25,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -48,11 +50,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class AllMapperEventTest {
     public static final int ONE_MillSEC_IN_NANO = 1000000;
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();

--- a/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/reports/sql/LoggerEventSummaryTest.java
+++ b/eventlogger/src/test/java/gov/cms/ab2d/eventlogger/reports/sql/LoggerEventSummaryTest.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.eventlogger.reports.sql;
 
 import gov.cms.ab2d.eventlogger.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventlogger.AB2DSQSMockConfig;
 import gov.cms.ab2d.eventlogger.SpringBootApp;
 import gov.cms.ab2d.eventlogger.eventloggers.sql.SqlEventLogger;
 import gov.cms.ab2d.eventclient.events.*;
@@ -11,6 +12,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class LoggerEventSummaryTest {
     public static final int ONE_MillSEC_IN_NANO = 1000000;
 

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/SpringBootTestApp.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/SpringBootTestApp.java
@@ -1,9 +1,11 @@
 package gov.cms.ab2d.hpms;
 
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
@@ -12,6 +14,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model"})
 @EnableJpaRepositories("gov.cms.ab2d.common.repository")
 @PropertySource("classpath:application.common.properties")
+@Import(AB2DSQSMockConfig.class)
 public class SpringBootTestApp {
 
     public static void main(String [] args) {

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/AttestationUpdaterServiceTest.java
@@ -39,9 +39,6 @@ public class AttestationUpdaterServiceTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Qualifier("for_testing")
     @Autowired
     private AttestationUpdaterServiceImpl aus;

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSAuthServiceTest.java
@@ -33,9 +33,6 @@ class HPMSAuthServiceTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Test
     public void tokenTest() {
         assertNotNull(authService);

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherExceptionTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherExceptionTest.java
@@ -33,9 +33,6 @@ class HPMSFetcherExceptionTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Test
     void invalidSponsorUrl() {
         Assertions.assertThrows(WebClientRequestException.class, () -> {

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSFetcherTest.java
@@ -50,9 +50,6 @@ class HPMSFetcherTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Test
     void retrieveSponsorInfo() {
         retrieveTop6Contracts();

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSManualModeTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSManualModeTest.java
@@ -36,9 +36,6 @@ class HPMSManualModeTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Qualifier("for_testing")
     @Autowired
     private AttestationUpdaterServiceImpl aus;

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSMockedAuthTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/HPMSMockedAuthTest.java
@@ -35,9 +35,6 @@ class HPMSMockedAuthTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Autowired
     HPMSAuthServiceImpl authService;
     @Autowired

--- a/hpms/src/test/java/gov/cms/ab2d/hpms/service/MockedFetchTest.java
+++ b/hpms/src/test/java/gov/cms/ab2d/hpms/service/MockedFetchTest.java
@@ -39,10 +39,6 @@ class MockedFetchTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
-
     @Mock
     private WebClient mockedWebClient;
 

--- a/job/src/test/java/gov/cms/ab2d/job/JobTestSpringBootApp.java
+++ b/job/src/test/java/gov/cms/ab2d/job/JobTestSpringBootApp.java
@@ -1,11 +1,14 @@
 package gov.cms.ab2d.job;
 
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.eventlogger", "gov.cms.ab2d.job", "gov.cms.ab2d.common"})
 @PropertySource("classpath:job-test.properties")
+@Import(AB2DSQSMockConfig.class)
 public class JobTestSpringBootApp {
 
     public static void main(String [] args) {

--- a/job/src/test/java/gov/cms/ab2d/job/service/JobOutputServiceTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/JobOutputServiceTest.java
@@ -57,9 +57,6 @@ class JobOutputServiceTest extends JobCleanup {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
-
     private static final String JOB_OUTPUT_CONTRACT_NUMBER = "JJ112233";
 
     // Be safe and make sure nothing from another test will impact current test

--- a/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
@@ -138,9 +138,6 @@ class JobServiceTest extends JobCleanup {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
-
     // Be safe and make sure nothing from another test will impact current test
     @BeforeEach
     public void setup() {

--- a/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
@@ -61,9 +61,6 @@ class MaxJobsTest extends JobCleanup {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer  = new AB2DLocalstackContainer();
-
     @BeforeEach
     public void setup() {
         createMaxJobs();

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jacoco.version>0.8.8</jacoco.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
-        <events-client.version>1.3.4</events-client.version>
+        <events-client.version>1.3</events-client.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jacoco.version>0.8.8</jacoco.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
-        <events-client.version>1.3</events-client.version>
+        <events-client.version>1.3.4</events-client.version>
     </properties>
 
     <dependencies>

--- a/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
@@ -5,6 +5,7 @@ import gov.cms.ab2d.common.model.Properties;
 import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.eventlogger.LogManager;
 import gov.cms.ab2d.worker.SpringBootApp;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -29,13 +31,11 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = SpringBootApp.class)
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class BFDHealthCheckTest {
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     private BFDHealthCheck bfdHealthCheck;
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/config/AutoScalingServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/config/AutoScalingServiceTest.java
@@ -4,6 +4,7 @@ package gov.cms.ab2d.worker.config;
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.coverage.util.AB2DCoveragePostgressqlContainer;
 import java.time.Duration;
 import java.time.Instant;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(properties = {"pcp.core.pool.size=3", "pcp.max.pool.size=20", "pcp.scaleToMax.time=20", "property.change.detection=false"})
 @Testcontainers
 @Slf4j
+@Import(AB2DSQSMockConfig.class)
 public class AutoScalingServiceTest {
 
     public static final int QUEUE_SIZE = 25;
@@ -51,9 +54,6 @@ public class AutoScalingServiceTest {
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DCoveragePostgressqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     private int originalMaxPoolSize;
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/AggregatorJobTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/AggregatorJobTest.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.bfd.client.BFDClient;
 import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.coverage.model.ContractForCoverageDTO;
 import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.coverage.model.Identifiers;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -48,13 +50,10 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class AggregatorJobTest {
     @Container
     private static final PostgreSQLContainer postgres = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer LOCALSTACK_CONTAINER = new AB2DLocalstackContainer();
-
 
     PatientClaimsProcessor processor;
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -8,6 +8,7 @@ import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.common.model.PdpClient;
 import gov.cms.ab2d.common.repository.ContractRepository;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.job.repository.JobRepository;
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -80,6 +82,7 @@ import static org.mockito.Mockito.when;
 // Never run internal coverage processor so this coverage processor runs unimpeded
 @SpringBootTest(properties = "coverage.update.initial.delay=1000000")
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class CoverageDriverTest extends JobCleanup {
 
     private static final int PAST_MONTHS = 3;
@@ -89,9 +92,6 @@ class CoverageDriverTest extends JobCleanup {
 
     @Container
     private static final PostgreSQLContainer postgres = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Autowired
     private ContractRepository contractRepo;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageLockWrapperTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageLockWrapperTest.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.worker.processor.coverage;
 
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.coverage.util.AB2DCoveragePostgressqlContainer;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -9,6 +10,7 @@ import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -19,13 +21,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class CoverageLockWrapperTest {
     @SuppressWarnings({"rawtypes", "unused"})
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DCoveragePostgressqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Autowired
     private CoverageLockWrapper coverageLockWrapper;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -11,6 +11,7 @@ import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.common.service.PropertiesService;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.Constants;
 import gov.cms.ab2d.common.util.DateUtil;
 import gov.cms.ab2d.coverage.model.CoverageJobStatus;
@@ -41,6 +42,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -68,6 +70,7 @@ import static org.mockito.Mockito.when;
 // Never run internal coverage processor so this coverage processor runs unimpeded
 @SpringBootTest(properties = "coverage.update.initial.delay=1000000")
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class CoverageUpdateAndProcessorTest {
 
     private static final int PAST_MONTHS = 3;
@@ -77,9 +80,6 @@ class CoverageUpdateAndProcessorTest {
 
     @Container
     private static final PostgreSQLContainer postgres = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer LOCALSTACK_CONTAINER = new AB2DLocalstackContainer();
 
     @Value("${coverage.update.max.attempts}")
     private int maxRetries;

--- a/worker/src/test/java/gov/cms/ab2d/worker/properties/PropertiesChangeDetectionTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/properties/PropertiesChangeDetectionTest.java
@@ -4,10 +4,12 @@ import gov.cms.ab2d.common.model.Properties;
 import gov.cms.ab2d.common.repository.PropertiesRepository;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.worker.config.AutoScalingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -18,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 public class PropertiesChangeDetectionTest {
 
     @Autowired
@@ -34,9 +37,6 @@ public class PropertiesChangeDetectionTest {
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @Test
     public void testChangeInProperties() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.worker.service;
 
 import gov.cms.ab2d.common.dto.PropertiesDTO;
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.common.model.PdpClient;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -43,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @SpringBootTest
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class WorkerServiceDisengagementTest extends JobCleanup {
     private final Random random = new Random();
 
@@ -60,9 +63,6 @@ class WorkerServiceDisengagementTest extends JobCleanup {
     @SuppressWarnings("rawtypes")
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     @BeforeEach
     public void init() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.worker.service;
 
 import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
+import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.common.model.PdpClient;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @SpringBootTest
 @Testcontainers
+@Import(AB2DSQSMockConfig.class)
 class WorkerServiceTest extends JobCleanup {
     private final Random random = new Random();
 
@@ -51,9 +54,6 @@ class WorkerServiceTest extends JobCleanup {
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
-
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
     private WorkerServiceStub workerServiceStub;
 


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-4554](https://jira.cms.gov/browse/AB2D-4554) - Reduces use of localstack and replaces it with amazonSQS mocks

 
### What Does This PR Do? 
Reduces use of localstack and replaces it with amazonSQS mocks

### What Should Reviewers Watch For?
Any better way of doing this. Also areas we should use localstack or mock

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [x] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [x] Code checked for PHI/PII exposure