### PR TITLE
ignored coverage check for S3147-2021-12

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -80,7 +80,6 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
 
     private void logIssue(ContractDTO contract, int year, int month, List<String> noEnrollment) {
         if (ignoreMissing(contract.getContractNumber(), year, month)) {
-            // the check for this combination of contract/year/month is expected to fail and should be ignored
             return;
         }
         String issue = String.format("%s-%d-%d no enrollment found", contract.getContractNumber(), year, month);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -58,8 +58,6 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
             int year = attestationTime.getYear();
             int month = attestationTime.getMonthValue();
 
-
-
             // If nothing in the iterator
             if (!countIterator.hasNext()) {
                 logIssue(contract, year, month, noEnrollment);
@@ -91,7 +89,6 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
      * Block alert for S3147-2021-12 as it is expected to always fail
      * */
     private boolean ignoreMissing(@NotNull String contractNumber, int year, int month) {
-        log.info("{},{},{}", contractNumber, year, month);
         return contractNumber.equals("S3147") && year == 2021 && month == 12;
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -4,13 +4,14 @@ import gov.cms.ab2d.common.dto.ContractDTO;
 import gov.cms.ab2d.coverage.model.CoverageCount;
 import gov.cms.ab2d.coverage.service.CoverageService;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
-
 
 import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getAttestationTime;
 import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getEndDateTime;
@@ -57,6 +58,8 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
             int year = attestationTime.getYear();
             int month = attestationTime.getMonthValue();
 
+
+
             // If nothing in the iterator
             if (!countIterator.hasNext()) {
                 logIssue(contract, year, month, noEnrollment);
@@ -76,8 +79,20 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
     }
 
     private void logIssue(ContractDTO contract, int year, int month, List<String> noEnrollment) {
+        if (ignoreMissing(contract.getContractNumber(), year, month)) {
+            // the check for this combination of contract/year/month is expected to fail and should be ignored
+            return;
+        }
         String issue = String.format("%s-%d-%d no enrollment found", contract.getContractNumber(), year, month);
         log.warn(issue);
         noEnrollment.add(issue);
+    }
+
+    /*
+     * Block alert for S3147-2021-12 as it is expected to always fail
+     * */
+    private boolean ignoreMissing(@NotNull String contractNumber, int year, int month) {
+        log.info("{},{},{}", contractNumber, year, month);
+        return contractNumber.equals("S3147") && year == 2021 && month == 12;
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
@@ -49,7 +49,7 @@ class CoverageCheckPredicatesDisableAlertTest {
                 .findFirst()
                 .orElse(null);
         method.setAccessible(true);
-        assertSame(ReflectionUtils.invokeMethod(method, check, "S3147", 2021, 12), Boolean.TRUE);
+        assertTrue((Boolean) ReflectionUtils.invokeMethod(method, check, "S3147", 2021, 12));
     }
 
     @DisplayName("Coverage ignored")

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
@@ -1,0 +1,31 @@
+package gov.cms.ab2d.worker.processor.coverage.check;
+
+import gov.cms.ab2d.coverage.model.CoverageCount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class CoverageCheckPredicatesDisableAlertTest {
+
+    @DisplayName("Coverage periods have no coverage present for S3147 2021 12")
+    @Test
+    void whenCoveragePeriodsMissingAndContractS3147And2021_12_passCoverageCheck() {
+
+        Map<String, List<CoverageCount>> coverageCounts =
+                Map.of("S3147",
+                        List.of(new CoverageCount("S3147", 2021, 12, 1, 1, 0)));
+
+        List<String> issues = new ArrayList<>();
+        new CoveragePresentCheck(null, coverageCounts, issues);
+
+        assertTrue(issues.stream()
+                .noneMatch(issue -> issue.equals("S3147,2021,12")));
+    }
+
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
@@ -1,9 +1,14 @@
 package gov.cms.ab2d.worker.processor.coverage.check;
 
+import gov.cms.ab2d.common.dto.ContractDTO;
+import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.coverage.model.CoverageCount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,18 +16,21 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-public class CoverageCheckPredicatesDisableAlertTest {
+class CoverageCheckPredicatesDisableAlertTest {
 
     @DisplayName("Coverage periods have no coverage present for S3147 2021 12")
     @Test
     void whenCoveragePeriodsMissingAndContractS3147And2021_12_passCoverageCheck() {
-
+        ContractDTO contractDTO = new ContractDTO("S3147", "Test",
+                OffsetDateTime.of(2021, 12, 30, 1, 1, 1, 1, ZoneOffset.UTC)
+                        .minus(2, ChronoUnit.YEARS), Contract.ContractType.NORMAL);
         Map<String, List<CoverageCount>> coverageCounts =
                 Map.of("S3147",
                         List.of(new CoverageCount("S3147", 2021, 12, 1, 1, 0)));
 
         List<String> issues = new ArrayList<>();
-        new CoveragePresentCheck(null, coverageCounts, issues);
+        new CoveragePresentCheck(null, coverageCounts, issues)
+                .test(contractDTO);
 
         assertTrue(issues.stream()
                 .noneMatch(issue -> issue.equals("S3147,2021,12")));

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesDisableAlertTest.java
@@ -5,14 +5,18 @@ import gov.cms.ab2d.common.model.Contract;
 import gov.cms.ab2d.coverage.model.CoverageCount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
 
+import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -34,6 +38,33 @@ class CoverageCheckPredicatesDisableAlertTest {
 
         assertTrue(issues.stream()
                 .noneMatch(issue -> issue.equals("S3147,2021,12")));
+    }
+
+    @DisplayName("Coverage ignored")
+    @Test
+    void whenCoveragePeriodsMissing_ignore() throws NoSuchMethodException {
+        CoveragePresentCheck check = new CoveragePresentCheck(null, null, null);
+        Method method = Arrays.stream(CoveragePresentCheck.class.getDeclaredMethods())
+                .filter(m -> "ignoreMissing".equals(m.getName()))
+                .findFirst()
+                .orElse(null);
+        method.setAccessible(true);
+        assertSame(ReflectionUtils.invokeMethod(method, check, "S3147", 2021, 12), Boolean.TRUE);
+    }
+
+    @DisplayName("Coverage ignored")
+    @Test
+    void whenCoveragePeriodsMissing_log() throws NoSuchMethodException {
+        ContractDTO contractDTO = new ContractDTO("S3147", "Test",
+                OffsetDateTime.of(2021, 12, 30, 1, 1, 1, 1, ZoneOffset.UTC)
+                        .minus(2, ChronoUnit.YEARS), Contract.ContractType.NORMAL);
+        CoveragePresentCheck check = new CoveragePresentCheck(null, null, null);
+        Method method = Arrays.stream(CoveragePresentCheck.class.getDeclaredMethods())
+                .filter(m -> "logIssue".equals(m.getName()))
+                .findFirst()
+                .orElse(null);
+        method.setAccessible(true);
+        assertSame(ReflectionUtils.invokeMethod(method, check, contractDTO, 2021, 12, null), null);
     }
 
 }


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-AB2D-5089](https://jira.cms.gov/browse/AB2D-5089) - Description

Disable coverage alert for S3147-2021-12.
 
### What Does This PR Do?

Adds a new method that tests if the current coverage check is for S3147-2021-12. If it is, don't send an alert. 

### What Should Reviewers Watch For?

Possible regressions. 

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

- [ ] All QuickSight impacts have been identified

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [X] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [X] Code checked for PHI/PII exposure