### PR TITLE
5567 add columns to coverage table for opt-out

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -153,3 +153,5 @@ databaseChangeLog:
       file: db/changelog/v2022/contract-service-database-migration.sql
   - include:
       file: db/changelog/v2023/drop-unused-tables.sql
+  - include:
+      file: db/changelog/v2023/add_columns_to_coverage.sql

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -155,3 +155,5 @@ databaseChangeLog:
       file: db/changelog/v2023/drop-unused-tables.sql
   - include:
       file: db/changelog/v2023/add_columns_to_coverage.sql
+  - include:
+      file: db/changelog/v2023/add_optout_property.sql

--- a/common/src/main/resources/db/changelog/v2023/add_columns_to_coverage.sql
+++ b/common/src/main/resources/db/changelog/v2023/add_columns_to_coverage.sql
@@ -1,0 +1,7 @@
+--changeset 5567 sadibhatla
+-- adding additional columns to coverage table to support opt-out logic
+-- TODO : figure out the flat file structure and columns expected as part of the flat file that we need to ingest
+-- TODO : update more columns to add if needed
+
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS opt_out_flag BOOLEAN DEFAULT 'FALSE';
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS effective_date TIMESTAMP;

--- a/common/src/main/resources/db/changelog/v2023/add_optout_property.sql
+++ b/common/src/main/resources/db/changelog/v2023/add_optout_property.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--  -------------------------------------------------------------------------------------------------------------------
+
+INSERT INTO properties (id, key, value) VALUES((select nextval('hibernate_sequence')), 'OptOutOn', 'false');
+
+
+--rollback DELETE FROM properties WHERE key = 'OptOutOn';


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5567

## 🛠 Changes

Added new columns opt_out boolean field and effective date timestamp field
Changed the "changelog-master.yaml" to include newly includedSQL file for opt out .

## ℹ️ Context for reviewers

Opt-out :  
STEP 1: On a weekly basis   AB2D makes calls to BFD to retrieve contract bene mappings and store on AB2D database.. this end point already exists on BFD.. so just like how we are querying BFD, OC team can use same end point to get the contract bene mappings (attribution data)..    OC team uses this attribution data when somone calls and writes their info to a flat file.  That flat file will be written to BFD s3..
Step 2: Ab2d need to read that flat file with opted out bene data from BFD s3 update in AB2d database.. When a PDP runs a job/contract- its  AB2d job to make sure we DON'T query BFD for the opted out users aka filter out opted out users while querying BFD for claim data.. That way  opted out user data will not be shared with PDP's . 

This PR addresses part 2 to  create the fields necessary  in DB to store the ingested data from s3.

## ✅ Acceptance Validation

- When you run this branch on local, it shud add newly added columns to coverage table.
- When you re-run, it shouldn't error out  as the IF NOT EXISTS column should take care if columns already exists
- Query the change log and look for new version and time when it ran


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [X] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
