### PR TITLE
PLT-136 Allow override of okta and base URLs from env in e2etest

### DIFF
--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -691,6 +691,10 @@ class TestRunner {
         String oktaClientId = System.getenv("SECONDARY_USER_OKTA_CLIENT_ID");
         String oktaPassword = System.getenv("SECONDARY_USER_OKTA_CLIENT_PASSWORD");
 
+        if (StringUtils.isBlank(oktaClientId) || StringUtils.isBlank(oktaPassword)) {
+            fail("Both SECONDARY_USER_OKTA_CLIENT_ID and SECONDARY_USER_OKTA_CLIENT_PASSWORD must be set in env");
+        }
+
         return new APIClient(baseUrl, oktaUrl, oktaClientId, oktaPassword);
     }
 

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -222,6 +222,17 @@ class TestRunner {
             baseUrl += ":" + apiPort;
         }
 
+        String envOktaUrl = System.getenv("OKTA_URL");
+        if (!StringUtils.isBlank(envOktaUrl)) {
+            oktaUrl = envOktaUrl;
+        }
+
+        String envBaseUrl = System.getenv("AB2D_BASE_URL");
+        if (!StringUtils.isBlank(envBaseUrl)) {
+            baseUrl = envBaseUrl;
+        }
+        log.info("Using base URL {}", baseUrl);
+
         String oktaClientId = System.getenv("OKTA_CLIENT_ID");
         String oktaPassword = System.getenv("OKTA_CLIENT_PASSWORD");
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-136

## 🛠 Changes

Added checking shell environment for overriding Okta and base URLs in e2e tests. Also added a condition for erroring out more obviously when environment variables are missing for the secondary Okta client.

## ℹ️ Context for reviewers

We should move toward removing internal URLs from the codebase. This allows us to set URLs for tests in the environment rather than hardcoding.

## ✅ Acceptance Validation

Tests ran against IMPL URLs from local.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.