### PR TITLE
Update logging lever for e2e tests

### DIFF
--- a/e2e-test/src/test/resources/logback.xml
+++ b/e2e-test/src/test/resources/logback.xml
@@ -4,8 +4,8 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.testcontainers.containers" level="DEBUG"/>
-    <logger name="com.github.dockerjava" level="DEBUG"/>
+    <logger name="org.testcontainers.containers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5704

## 🛠 Changes

Revert logging level from DEBUG to INFO level in e2e tests

## ℹ️ Context for reviewers

After the PR1202 merge, the environments experienced logging errors with the DEBUG level.
We want errors to be only with INFO level


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
