### PR TITLE
AB2D-5622 update database

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -153,3 +153,7 @@ databaseChangeLog:
       file: db/changelog/v2022/contract-service-database-migration.sql
   - include:
       file: db/changelog/v2023/drop-unused-tables.sql
+  - include:
+      file: db/changelog/v2023/add_columns_to_coverage.sql
+  - include:
+      file: db/changelog/v2023/add_optout_property.sql

--- a/common/src/main/resources/db/changelog/v2023/add_columns_to_coverage.sql
+++ b/common/src/main/resources/db/changelog/v2023/add_columns_to_coverage.sql
@@ -1,0 +1,7 @@
+--changeset 5567 sadibhatla
+-- adding additional columns to coverage table to support opt-out logic
+-- TODO : figure out the flat file structure and columns expected as part of the flat file that we need to ingest
+-- TODO : update more columns to add if needed
+
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS opt_out_flag BOOLEAN DEFAULT 'FALSE';
+ALTER TABLE coverage ADD COLUMN IF NOT EXISTS effective_date TIMESTAMP;

--- a/common/src/main/resources/db/changelog/v2023/add_optout_property.sql
+++ b/common/src/main/resources/db/changelog/v2023/add_optout_property.sql
@@ -1,0 +1,4 @@
+INSERT INTO property.properties(id, key, value, created, modified)
+VALUES (nextval('hibernate_sequence'), 'OptOutOn', 'false', current_timestamp, current_timestamp);
+
+--rollback DELETE FROM properties WHERE key = 'OptOutOn';


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5622

## 🛠 Changes

Added new columns opt_out boolean field and effective date timestamp field.
Add new row OptOutOn to property table
Changed the "changelog-master.yaml" to include newly includedSQL files for opt out.

## ℹ️ Context for reviewers

Opt-out :
STEP 1: On a weekly basis AB2D makes calls to BFD to retrieve contract bene mappings and store on AB2D database.. this end point already exists on BFD. That flat file will be written to BFD s3..
Step 2: Ab2d need to read that flat file with opted out bene data from BFD s3 update in AB2d database.

This PR addresses part 2 to create the fields necessary in DB to store the ingested data from s3.

## ✅ Acceptance Validation

Tested locally
<img width="261" alt="Screenshot 2023-08-17 at 2 17 09 PM" src="https://github.com/CMSgov/ab2d/assets/132938234/787c8ccd-afda-481b-8fd8-0822a5e5310e">


<img width="833" alt="Screenshot 2023-08-17 at 2 16 27 PM" src="https://github.com/CMSgov/ab2d/assets/132938234/021a70cb-c367-4a6e-bdbc-36821556cc35">


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
