### PR TITLE
AB2D-5622 OptOut Filtering

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
@@ -33,4 +33,7 @@ public final class PropertyConstants {
 
     // Force a coverage update to run even when not scheduled
     public static final String COVERAGE_SEARCH_OVERRIDE = "coverage.update.override";
+
+    public static final String OPT_OUT_ON = "OptOutOn";
+
 }

--- a/common/src/test/java/gov/cms/ab2d/common/properties/PropertyServiceStub.java
+++ b/common/src/test/java/gov/cms/ab2d/common/properties/PropertyServiceStub.java
@@ -22,6 +22,7 @@ public class PropertyServiceStub implements PropertiesService {
         propertiesMapOrig.put("coverage.update.months.past", "1");
         propertiesMapOrig.put("coverage.update.override", "false");
         propertiesMapOrig.put("maintenance.mode", "false");
+        propertiesMapOrig.put("OptOutOn", "false");
     }
 
     public void reset() {

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -1,0 +1,112 @@
+package gov.cms.ab2d.coverage.repository;
+
+import gov.cms.ab2d.common.feign.ContractFeignClient;
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.coverage.model.CoveragePeriod;
+import gov.cms.ab2d.coverage.model.CoverageSearch;
+import gov.cms.ab2d.coverage.model.CoverageSearchEvent;
+import gov.cms.ab2d.coverage.model.Identifiers;
+import gov.cms.ab2d.coverage.service.CoverageService;
+import gov.cms.ab2d.coverage.util.AB2DCoverageLocalstackContainer;
+import gov.cms.ab2d.coverage.util.AB2DCoveragePostgressqlContainer;
+import gov.cms.ab2d.coverage.util.CoverageDataSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.util.*;
+
+import static gov.cms.ab2d.common.util.PropertyConstants.OPT_OUT_ON;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+@SpringBootTest
+@EntityScan(basePackages = {"gov.cms.ab2d.common.model", "gov.cms.ab2d.coverage.model"})
+@EnableJpaRepositories({"gov.cms.ab2d.common.repository", "gov.cms.ab2d.coverage.repository"})
+@Testcontainers
+@TestPropertySource(locations = "/application.coverage.properties")
+@EnableFeignClients(clients = {ContractFeignClient.class})
+class CoverageServiceRepositoryTest {
+
+    @Container
+    private static final PostgreSQLContainer postgreSQLContainer= new AB2DCoveragePostgressqlContainer();
+
+    @Container
+    private static final AB2DCoverageLocalstackContainer localstackContainer = new AB2DCoverageLocalstackContainer();
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    CoveragePeriodRepository coveragePeriodRepo;
+    @Autowired
+    CoverageSearchRepository coverageSearchRepo;
+    @Autowired
+    CoverageSearchEventRepository coverageSearchEventRepo;
+    @Autowired
+    CoverageService coverageService;
+    @Autowired
+    CoverageDataSetup dataSetup;
+    @Autowired
+    PropertiesService propertiesService;
+    @Mock
+    private PropertiesService mockPropertiesService;
+
+    private CoveragePeriod period1Jan;
+    private Set<Identifiers> results;
+
+    @BeforeEach
+    public void insertContractAndDefaultCoveragePeriod() {
+        // OptOut is disabled
+        Mockito.when(mockPropertiesService.isToggleOn(OPT_OUT_ON, false)).thenReturn(false);
+        period1Jan = dataSetup.createCoveragePeriod("TST-12", 1, 2020);
+
+        coverageService.submitSearch(period1Jan.getId(), "testing");
+        results = Set.of(createIdentifier(1231L),
+                createIdentifier(4561L), createIdentifier(7891L));
+
+        CoverageSearchEvent inProgress1 = startSearchAndPullEvent();
+        coverageService.insertCoverage(inProgress1.getId(), results);
+    }
+
+    @DisplayName("Calculate the number of beneficiaries when OptOut is disabled")
+    @Test
+    void countBeneficiariesByPeriodsWithoutOptOutTest() {
+        CoverageServiceRepository coverageServiceRepository = new CoverageServiceRepository(dataSource, coveragePeriodRepo, coverageSearchEventRepo, mockPropertiesService);
+
+        Assertions.assertEquals(3, coverageServiceRepository.countBeneficiariesByPeriods(List.of(period1Jan.getId()), "TST-12"));
+    }
+
+    @DisplayName("Calculate the number of beneficiaries when OptOut is enabled")
+    @Test
+    void countBeneficiariesByPeriodsWithOptOutTest() {
+        CoverageServiceRepository coverageServiceRepository = new CoverageServiceRepository(dataSource, coveragePeriodRepo, coverageSearchEventRepo, mockPropertiesService);
+
+        Mockito.when(mockPropertiesService.isToggleOn(OPT_OUT_ON, false)).thenReturn(true);
+       //The expected number is 3, and is the same as in previous test, since switching opt_out_flag from false to true is only available in OptOutLambda.
+        //Here all beneficiaries have opt_out_flag equals false by default.
+        Assertions.assertEquals(3, coverageServiceRepository.countBeneficiariesByPeriods(List.of(period1Jan.getId()), "TST-12"));
+    }
+
+    private Identifiers createIdentifier(Long suffix) {
+        return new Identifiers(suffix, "mbi-" + suffix, new LinkedHashSet<>());
+    }
+
+    private CoverageSearchEvent startSearchAndPullEvent() {
+        Optional<CoverageSearch> search = coverageSearchRepo.findFirstByOrderByCreatedAsc();
+        coverageSearchRepo.delete(search.get());
+        return coverageService.startSearch(search.get(), "testing").get().getCoverageSearchEvent();
+    }
+}


### PR DESCRIPTION
the database, there is logic to use the new columns and fields to programmatically filter out beneficiaries from the AB2D response

## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5622

## 🛠 Changes

Created Select and Count of beneficiaries statements to use values from opt_opt_flag column in public.coverage table.
Added ability to use statements with or without opt_out_flag based on OptOutOn property

## ℹ️ Context for reviewers

Step 2 for Opt-Out feature

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
