### PR TITLE
PLT-136 Run e2e tests on impl environment

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,6 +15,7 @@ jobs:
       AWS_DEFAULT_REGION: "us-east-1"
       WORKSPACE: ${{ github.workspace }}
       AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,10 @@ on:
   workflow_call:
   workflow_dispatch: # Allow manual trigger
 
+# Ensure we have only one e2e test running at a time
+concurrency:
+  group: e2e-test
+
 jobs:
   test:
     runs-on: self-hosted

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -85,10 +85,10 @@ jobs:
           cp /tmp/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
           chmod 666 $AB2D_BFD_KEYSTORE_LOCATION
-          mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL
+          mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress
 
       - name: Run e2e-test
         env:
           E2E_ENVIRONMENT: 'IMPL'
         run: |
-          mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL
+          mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,81 @@
+name: end-to-end tests
+
+on:
+  workflow_call:
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  test:
+    runs-on: self-hosted
+
+    env:
+      E2E_ENVIRONMENT: 'IMPL'
+      AB2D_V2_ENABLED: 'true'
+      AWS_DEFAULT_REGION: "us-east-1"
+      WORKSPACE: ${{ github.workspace }}
+      AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Assume role in AB2D impl account
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AB2D_DEV_ROLE }}
+
+      - name: Download bfd keystore
+        run: |
+          aws s3 cp s3://bcda-opensbx-access-logs/ab2d_sbx_keystore /tmp/ab2d_sbx_keystore
+
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            AB2D_BFD_KEYSTORE_PASSWORD=/bfd/password
+
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        with:
+          params: |
+            OKTA_CLIENT_ID=/okta/client-id
+            OKTA_CLIENT_PASSWORD=/okta/client-secret
+            SECONDARY_USER_OKTA_CLIENT_ID=/secondary-okta/client-id
+            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/secondary-okta/client-secret
+
+      - name: Install Maven 3.2.5
+        run: |
+          wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
+          tar xzvf apache-maven-3.2.5-bin.tar.gz
+          sudo mv apache-maven-3.2.5 /opt/maven
+          echo "PATH=$PATH:/opt/maven/bin" >> $GITHUB_ENV
+
+      - name: Set Maven path
+        run: echo "PATH=$PATH:/opt/maven/bin" >> $GITHUB_ENV
+
+      - name: Create ab2d workspace directory and copy in keystore
+        run: mkdir -p "$WORKSPACE/opt/ab2d"
+
+      - name: Set directory permissions
+        run: |
+          sudo chmod -R 777 /opt/actions-runner/_work/ab2d/ab2d/common/
+          # Add other commands if necessary
+
+      - name: Run e2e-bfd-test
+        run: |
+          cp /tmp/ab2d_sbx_keystore ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
+          test -f ${{ env.AB2D_BFD_KEYSTORE_LOCATION }} && echo "created keystore file"
+          chmod 666 ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
+          mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
+
+      - name: Run e2e-test
+        run: |
+          export KEYSTORE_LOCATION="${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
+          cp /tmp/ab2d_sbx_keystore ${{ env.KEYSTORE_LOCATION }}
+          test -f ${{ env.KEYSTORE_LOCATION }} && echo "created keystore file"
+          chmod 666 ${{ env.KEYSTORE_LOCATION }}
+          aws --region "${{ env.AWS_DEFAULT_REGION }}" ecr get-login-password | docker login --username AWS --password-stdin "${{ env.ECR_REPO_ENV_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com"
+          mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=${{ secrets.ARTIFACTORY_USER }} -Dpassword=${{ secrets.ARTIFACTORY_PASSWORD }} -Drepository_url=${{ secrets.ARTIFACTORY_URL }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,17 +27,24 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set env vars from AWS params in management account
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            ARTIFACTORY_URL=/artifactory/url
+            ARTIFACTORY_USER=/artifactory/user
+            ARTIFACTORY_PASSWORD=/artifactory/password
+
       - name: Assume role in AB2D impl account
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.IMPL_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-test-github-actions
 
-      - name: Download bfd keystore
-        run: |
-          aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
-
-      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+      - name: Set env vars from AWS params in impl account
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
@@ -58,9 +65,6 @@ jobs:
           sudo rm -rf /opt/maven
           sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
 
-      - name: Set Maven path
-        run: echo "PATH=$PATH:/opt/maven/bin" >> $GITHUB_ENV
-
       - name: Create ab2d workspace directory and copy in keystore
         run: mkdir -p "$WORKSPACE/opt/ab2d"
 
@@ -68,6 +72,10 @@ jobs:
         run: |
           sudo chmod -R 777 /opt/actions-runner/_work/ab2d/ab2d/common/
           # Add other commands if necessary
+
+      - name: Download bfd keystore
+        run: |
+          aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
 
       - name: Run e2e-bfd-test
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Assume role in AB2D impl account
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: self-hosted
 
     env:
-      E2E_ENVIRONMENT: 'IMPL'
       AB2D_V2_ENABLED: 'true'
       AWS_DEFAULT_REGION: "us-east-1"
       WORKSPACE: ${{ github.workspace }}
@@ -82,8 +81,10 @@ jobs:
           cp /tmp/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
           chmod 666 $AB2D_BFD_KEYSTORE_LOCATION
-          mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
+          mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL
 
       - name: Run e2e-test
+        env:
+          E2E_ENVIRONMENT: 'IMPL'
         run: |
-          mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=${{ secrets.ARTIFACTORY_USER }} -Dpassword=${{ secrets.ARTIFACTORY_PASSWORD }} -Drepository_url=${{ secrets.ARTIFACTORY_URL }}
+          mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,9 +15,7 @@ jobs:
 
     env:
       AB2D_V2_ENABLED: 'true'
-      AWS_DEFAULT_REGION: "us-east-1"
-      WORKSPACE: ${{ github.workspace }}
-      AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
+      AB2D_BFD_KEYSTORE_LOCATION: "opt/ab2d/ab2d_bfd_keystore"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
@@ -29,6 +27,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
 
       - name: Set env vars from AWS params in management account
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
@@ -58,33 +66,18 @@ jobs:
             SECONDARY_USER_OKTA_CLIENT_ID=/okta/test-pdp-1000-id
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/okta/test-pdp-1000-secret
 
-      - name: Install Maven 3.6.3
-        run: |
-          export PATH="$PATH:/opt/maven/bin"
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-          tmpdir="$(mktemp -d)"
-          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-          sudo rm -rf /opt/maven
-          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-
-      - name: Create ab2d workspace directory and copy in keystore
-        run: mkdir -p "$WORKSPACE/opt/ab2d"
-
-      - name: Set directory permissions
-        run: |
-          sudo chmod -R 777 /opt/actions-runner/_work/ab2d/ab2d/common/
-          # Add other commands if necessary
-
       - name: Download bfd keystore
         run: |
           aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
 
-      - name: Run e2e-bfd-test
+      - name: Create ab2d directory and copy in keystore
         run: |
+          mkdir -p "opt/ab2d"
           cp /tmp/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
-          chmod 666 $AB2D_BFD_KEYSTORE_LOCATION
+
+      - name: Run e2e-bfd-test
+        run: |
           mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress
 
       - name: Run e2e-test

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,11 +30,11 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: ${{ vars.AB2D_DEV_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.IMPL_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-test-github-actions
 
       - name: Download bfd keystore
         run: |
-          aws s3 cp s3://bcda-opensbx-access-logs/ab2d_sbx_keystore /tmp/ab2d_sbx_keystore
+          aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
 
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: self-hosted
 
     env:
-      AB2D_V2_ENABLED: 'true'
+      # Keystore location must be full path for spring framework
       AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
+      AB2D_V2_ENABLED: 'true'
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     env:
       AB2D_V2_ENABLED: 'true'
-      AB2D_BFD_KEYSTORE_LOCATION: "opt/ab2d/ab2d_bfd_keystore"
+      AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
@@ -66,14 +66,10 @@ jobs:
             SECONDARY_USER_OKTA_CLIENT_ID=/okta/test-pdp-1000-id
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/okta/test-pdp-1000-secret
 
-      - name: Download bfd keystore
+      - name: Create opt/ab2d directory and download keystore
         run: |
-          aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
-
-      - name: Create ab2d directory and copy in keystore
-        run: |
-          mkdir -p "opt/ab2d"
-          cp /tmp/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
+          mkdir -p opt/ab2d
+          aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
 
       - name: Run e2e-bfd-test

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -79,16 +79,11 @@ jobs:
 
       - name: Run e2e-bfd-test
         run: |
-          cp /tmp/ab2d_imp_keystore ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
-          test -f ${{ env.AB2D_BFD_KEYSTORE_LOCATION }} && echo "created keystore file"
-          chmod 666 ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
+          cp /tmp/ab2d_imp_keystore $AB2D_BFD_KEYSTORE_LOCATION
+          test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
+          chmod 666 $AB2D_BFD_KEYSTORE_LOCATION
           mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
 
       - name: Run e2e-test
         run: |
-          export KEYSTORE_LOCATION="${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
-          cp /tmp/ab2d_imp_keystore ${{ env.KEYSTORE_LOCATION }}
-          test -f ${{ env.KEYSTORE_LOCATION }} && echo "created keystore file"
-          chmod 666 ${{ env.KEYSTORE_LOCATION }}
-          aws --region "${{ env.AWS_DEFAULT_REGION }}" ecr get-login-password | docker login --username AWS --password-stdin "${{ env.ECR_REPO_ENV_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com"
           mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=${{ secrets.ARTIFACTORY_USER }} -Dpassword=${{ secrets.ARTIFACTORY_PASSWORD }} -Drepository_url=${{ secrets.ARTIFACTORY_URL }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -43,7 +43,7 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            AB2D_BFD_KEYSTORE_PASSWORD=/bfd/password
+            AB2D_BFD_KEYSTORE_PASSWORD=/bfd/keystore-password
 
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,12 +48,15 @@ jobs:
             SECONDARY_USER_OKTA_CLIENT_ID=/okta/test-pdp-1000-id
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/okta/test-pdp-1000-secret
 
-      - name: Install Maven 3.2.5
+      - name: Install Maven 3.6.3
         run: |
-          wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
-          tar xzvf apache-maven-3.2.5-bin.tar.gz
-          sudo mv apache-maven-3.2.5 /opt/maven
-          echo "PATH=$PATH:/opt/maven/bin" >> $GITHUB_ENV
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
 
       - name: Set Maven path
         run: echo "PATH=$PATH:/opt/maven/bin" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,7 @@
 name: end-to-end tests
 
 on:
+  pull_request:
   workflow_call:
   workflow_dispatch: # Allow manual trigger
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run e2e-bfd-test
         run: |
-          cp /tmp/ab2d_sbx_keystore ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
+          cp /tmp/ab2d_imp_keystore ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
           test -f ${{ env.AB2D_BFD_KEYSTORE_LOCATION }} && echo "created keystore file"
           chmod 666 ${{ env.AB2D_BFD_KEYSTORE_LOCATION }}
           mvn test -s settings.xml -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
@@ -79,7 +79,7 @@ jobs:
       - name: Run e2e-test
         run: |
           export KEYSTORE_LOCATION="${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
-          cp /tmp/ab2d_sbx_keystore ${{ env.KEYSTORE_LOCATION }}
+          cp /tmp/ab2d_imp_keystore ${{ env.KEYSTORE_LOCATION }}
           test -f ${{ env.KEYSTORE_LOCATION }} && echo "created keystore file"
           chmod 666 ${{ env.KEYSTORE_LOCATION }}
           aws --region "${{ env.AWS_DEFAULT_REGION }}" ecr get-login-password | docker login --username AWS --password-stdin "${{ env.ECR_REPO_ENV_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,22 +37,16 @@ jobs:
         run: |
           aws s3 cp s3://ab2d-east-impl-main/ab2d_imp_keystore /tmp/ab2d_imp_keystore
 
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
             AB2D_BFD_KEYSTORE_PASSWORD=/bfd/keystore-password
-
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        with:
-          params: |
-            OKTA_CLIENT_ID=/okta/client-id
-            OKTA_CLIENT_PASSWORD=/okta/client-secret
-            SECONDARY_USER_OKTA_CLIENT_ID=/secondary-okta/client-id
-            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/secondary-okta/client-secret
+            OKTA_CLIENT_ID=/okta/test-pdp-100-id
+            OKTA_CLIENT_PASSWORD=/okta/test-pdp-100-secret
+            SECONDARY_USER_OKTA_CLIENT_ID=/okta/test-pdp-1000-id
+            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/okta/test-pdp-1000-secret
 
       - name: Install Maven 3.2.5
         run: |

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -2,6 +2,9 @@ name: Run unit and integration tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'e2e-bfd-test/**'
+      - 'e2e-test/**'
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -8,6 +8,9 @@ jobs:
   test:
     runs-on: self-hosted
 
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -2,9 +2,6 @@ name: Run unit and integration tests
 
 on:
   pull_request:
-    paths-ignore:
-      - 'e2e-bfd-test/**'
-      - 'e2e-test/**'
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -40,14 +40,14 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AB2D_DEV_ROLE }}
 
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        with:
-          params: |
-            OKTA_CLIENT_ID=/okta/client-id
-            OKTA_CLIENT_PASSWORD=/okta/client-secret
-            SECONDARY_USER_OKTA_CLIENT_ID=/secondary-okta/client-id
-            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/secondary-okta/client-secret
+      #- name: Set env vars from AWS params
+      #  uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+      #  with:
+      #    params: |
+      #      OKTA_CLIENT_ID=/okta/client-id
+      #      OKTA_CLIENT_PASSWORD=/okta/client-secret
+      #      SECONDARY_USER_OKTA_CLIENT_ID=/secondary-okta/client-id
+      #      SECONDARY_USER_OKTA_CLIENT_PASSWORD=/secondary-okta/client-secret
 
       - name: Install Maven 3.6.3
         run: |

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -40,15 +40,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AB2D_DEV_ROLE }}
 
-      #- name: Set env vars from AWS params
-      #  uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-      #  with:
-      #    params: |
-      #      OKTA_CLIENT_ID=/okta/client-id
-      #      OKTA_CLIENT_PASSWORD=/okta/client-secret
-      #      SECONDARY_USER_OKTA_CLIENT_ID=/secondary-okta/client-id
-      #      SECONDARY_USER_OKTA_CLIENT_PASSWORD=/secondary-okta/client-secret
-
       - name: Install Maven 3.6.3
         run: |
           export PATH="$PATH:/opt/maven/bin"

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -675,6 +675,10 @@ class TestRunner {
         String oktaClientId = System.getenv("SECONDARY_USER_OKTA_CLIENT_ID");
         String oktaPassword = System.getenv("SECONDARY_USER_OKTA_CLIENT_PASSWORD");
 
+        if (StringUtils.isBlank(oktaClientId) || StringUtils.isBlank(oktaPassword)) {
+            fail("Both SECONDARY_USER_OKTA_CLIENT_ID and SECONDARY_USER_OKTA_CLIENT_PASSWORD must be set in env");
+        }
+
         return new APIClient(baseUrl, oktaUrl, oktaClientId, oktaPassword);
     }
 

--- a/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
+++ b/e2e-test/src/test/java/gov/cms/ab2d/e2etest/TestRunner.java
@@ -518,6 +518,7 @@ class TestRunner {
 
         if (statusResponseAgain.statusCode() == 500) {
             // No values returned if 500
+            log.info("500 response body: " + statusResponseAgain.body());
             return null;
         }
         assertEquals(200, statusResponseAgain.statusCode());

--- a/e2e-test/src/test/resources/impl-config.yml
+++ b/e2e-test/src/test/resources/impl-config.yml
@@ -1,2 +1,2 @@
 okta-url: 'https://test.idp.idm.cms.gov/oauth2/aus2r7y3gdaFMKBol297/v1/token'
-base-url: 'https://internal-ab2d-east-impl-460119366.us-east-1.elb.amazonaws.com'
+base-url: 'https://impl.ab2d.cms.gov'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-136

## 🛠 Changes

Added workflow for running e2e tests on the impl environment.

## ℹ️ Context for reviewers

This e2e-test workflow should allow us to gain confidence in deploying while simplifying our test pipelines by running tests directly against resources in the impl environment.

## ✅ Acceptance Validation

We may need to merge this before we can test running the workflow.

## 🔒 Security Implications

None, these tests are run on self-hosted runners within our internal network.