### PR TITLE
AB2D-5782 Database changes for AttributionDataShare Lambda

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -157,3 +157,7 @@ databaseChangeLog:
       file: db/changelog/v2023/add_columns_to_coverage.sql
   - include:
       file: db/changelog/v2023/add_optout_property.sql
+  - include:
+      file: db/changelog/v2023/create_current_mbi_table.sql
+  - include:
+      file: db/changelog/v2023/create_current_mbi_procedure.sql

--- a/common/src/main/resources/db/changelog/v2023/create_current_mbi_procedure.sql
+++ b/common/src/main/resources/db/changelog/v2023/create_current_mbi_procedure.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE update_current_mbi()
+CREATE OR REPLACE PROCEDURE update_current_mbi_2023()
 LANGUAGE plpgsql
 AS $$
 begin
@@ -33,3 +33,40 @@ SELECT DISTINCT current_mbi from sandbox_2023
 ON CONFLICT DO NOTHING;
 end;
 $$;
+--
+-- CREATE OR REPLACE PROCEDURE update_current_mbi_2024()
+--     LANGUAGE plpgsql
+-- AS $$
+-- begin
+--     INSERT INTO current_mbi
+--     SELECT DISTINCT current_mbi from coverage_anthem_united_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_bcbs_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_centene_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_cigna1_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_cigna2_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_cvs_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_centene_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_humana_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_misc_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_mutual_dean_clear_cambia_rite_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_united1_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_united_2024
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from coverage_default
+--     UNION DISTINCT
+--     SELECT DISTINCT current_mbi from sandbox_2024
+--     ON CONFLICT DO NOTHING;
+-- end;
+-- $$;
+--

--- a/common/src/main/resources/db/changelog/v2023/create_current_mbi_procedure.sql
+++ b/common/src/main/resources/db/changelog/v2023/create_current_mbi_procedure.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE PROCEDURE update_current_mbi()
+LANGUAGE plpgsql
+AS $$
+begin
+INSERT INTO current_mbi
+SELECT DISTINCT current_mbi from coverage_anthem_united_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_bcbs_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_centene_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cigna1_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cigna2_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cvs_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_centene_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_humana_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_misc_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_mutual_dean_clear_cambia_rite_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_united1_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_united_2023
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_default
+UNION DISTINCT
+SELECT DISTINCT current_mbi from sandbox_2023
+ON CONFLICT DO NOTHING;
+end;
+$$;

--- a/common/src/main/resources/db/changelog/v2023/create_current_mbi_table.sql
+++ b/common/src/main/resources/db/changelog/v2023/create_current_mbi_table.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS public.current_mbi (mbi VARCHAR(32) NOT NULL);
+CREATE UNIQUE INDEX unique_mbi ON public.current_mbi(mbi);
+
+INSERT INTO public.current_mbi
+SELECT DISTINCT current_mbi from coverage_anthem_united
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_bcbs
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_centene
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cigna1
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cigna2
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_cvs
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_centene
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_humana
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_misc
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_mutual_dean_clear_cambia_rite
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_united1
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_united2
+UNION DISTINCT
+SELECT DISTINCT current_mbi from coverage_default
+UNION DISTINCT
+SELECT DISTINCT current_mbi from sandbox
+ON CONFLICT DO NOTHING

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
@@ -239,7 +239,7 @@ public class CoverageCheckPredicatesIntegrationTest {
 
         assertFalse(stableCheck.test(contract));
 
-        int expectedIssues =  2;
+        int expectedIssues =  1;
 
         assertEquals(expectedIssues, issues.size());
         issues.forEach(issue -> assertTrue(issue.contains("enrollment changed")));

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
@@ -198,7 +198,7 @@ public class CoverageCheckPredicatesUnitTest {
 
         assertFalse(stableCheck.test(contract));
 
-        int expectedIssues = 2;
+        int expectedIssues = 1;
 
         assertEquals(expectedIssues, issues.size());
         issues.forEach(issue -> assertTrue(issue.contains("enrollment changed")));


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5782

## 🛠 Changes

- Added `create_current_mbi_table.sql` liquibase file where I create a new table `public.current_mbi` and insert unique current mbis from `public.coverage table`.
- Added `create_current_mbi_procedure.sql` liquibase file where I create a procedure to insert values from 2023 partition to  `public.current_mbi` table 

## ℹ️ Context for reviewers

Performance of the AttributionDataShare Lambda in production will need some kind of persistence. An easy way to do this based on our existing architecture that the engineering team has discussed is by utilizing a database procedure. 

## ✅ Acceptance Validation

Deployed the branch on dev:

 
<img width="985" alt="Screenshot 2023-11-06 at 12 26 09 PM" src="https://github.com/CMSgov/ab2d/assets/132938234/9bd7a85a-9758-4368-a180-23b53a6b5400">


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
