### PR TITLE
[AB2D-5916] AWS Cloud Dependency Upgrade

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -56,7 +56,6 @@ public class AdminAPIMaintenanceModeTests {
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @Autowired
-    @Qualifier("mockAmazonSQS")
     AmazonSQS amazonSqs;
 
     @Autowired

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -65,7 +65,6 @@ public class TLSTest {
     DataSetup dataSetup;
 
     @Autowired
-    @Qualifier("mockAmazonSQS")
     AmazonSQS amazonSqs;
 
     @Container

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -109,15 +109,23 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
-            <version>2.2.6.RELEASE</version>
+          <groupId>io.awspring.cloud</groupId>
+          <artifactId>spring-cloud-aws-autoconfigure</artifactId>
+          <version>${spring-cloud-aws.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
+            <version>${spring-cloud-aws.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
             <version>3.1.5</version>
         </dependency>
+
         <dependency>
             <groupId>gov.cms.ab2d</groupId>
             <artifactId>ab2d-contracts-client</artifactId>

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
@@ -1,21 +1,19 @@
 package gov.cms.ab2d.common.util;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
-import org.springframework.cloud.aws.autoconfigure.messaging.MessagingAutoConfiguration;
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
-import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.listener.QueueMessageHandler;
+
 import static org.mockito.Mockito.mock;
 
 @TestConfiguration
-@EnableAutoConfiguration(exclude = {MessagingAutoConfiguration.class, ContextStackAutoConfiguration.class})
 public class AB2DSQSMockConfig {
 
   static {
@@ -42,7 +40,14 @@ public class AB2DSQSMockConfig {
   }
 
   @Bean("mockAmazonSQS")
+  @Primary
   public AmazonSQSAsync amazonSQSAsync() {
     return mock(AmazonSQSAsync.class);
+  }
+
+  @Bean
+  @Primary
+  public AWSCredentialsProvider awsCredentialsProvider() {
+    return new DefaultAWSCredentialsProviderChain();
   }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
@@ -4,6 +4,8 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +16,7 @@ import io.awspring.cloud.messaging.listener.QueueMessageHandler;
 import static org.mockito.Mockito.mock;
 
 @TestConfiguration
+@EnableAutoConfiguration
 public class AB2DSQSMockConfig {
 
   static {
@@ -39,10 +42,11 @@ public class AB2DSQSMockConfig {
     return mock(QueueMessageHandler.class);
   }
 
-  @Bean("mockAmazonSQS")
-  @Primary
+  // @Bean("mockAmazonSQS")
+  // @Primary
   public AmazonSQSAsync amazonSQSAsync() {
-    return mock(AmazonSQSAsync.class);
+    // return mock(AmazonSQSAsync.class);
+    return amazonSQSAsync;
   }
 
   @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,13 @@
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
 
         <!-- AB2D lib versions -->
-        <events-client.version>1.12.0</events-client.version>
-        <bfd-lib.version>2.1.0</bfd-lib.version>
-        <fhir-lib.version>1.2.0</fhir-lib.version>
-        <aggregator-lib.version>1.3.0</aggregator-lib.version>
-        <filters-lib.version>1.9.0</filters-lib.version>
-        <properties-client.version>1.2.0</properties-client.version>
-        <contract-client.version>1.2.0</contract-client.version>
+        <events-client.version>1.12.1</events-client.version>
+        <bfd-lib.version>2.1.1</bfd-lib.version>
+        <fhir-lib.version>1.2.1</fhir-lib.version>
+        <aggregator-lib.version>1.3.1</aggregator-lib.version>
+        <filters-lib.version>1.9.1</filters-lib.version>
+        <properties-client.version>1.2.1</properties-client.version>
+        <contract-client.version>1.2.1</contract-client.version>
     </properties>
 
     <!-- <dependencyManagement>
@@ -95,22 +95,6 @@
             <artifactId>localstack</artifactId>
             <version>1.18.3</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-aws-dependencies</artifactId>
-            <version>${spring-cloud-aws.version}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-aws-autoconfigure</artifactId>
-            <version>${spring-cloud-aws.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
-            <version>${spring-cloud-aws.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <testcontainers.version>1.18.3</testcontainers.version>
         <newrelic.version>8.4.0</newrelic.version>
         <postgres.version>42.6.0</postgres.version>
+        <!-- <spring-cloud.version>2021.0.8</spring-cloud.version> -->
+        <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version>
 
         <!-- Maven plugin versions -->
         <jacoco.version>0.8.10</jacoco.version>
@@ -43,14 +45,26 @@
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
 
         <!-- AB2D lib versions -->
-        <events-client.version>1.11.8</events-client.version>
-        <bfd-lib.version>2.0.16</bfd-lib.version>
-        <fhir-lib.version>1.1.11</fhir-lib.version>
-        <aggregator-lib.version>1.2.12</aggregator-lib.version>
-        <filters-lib.version>1.8.7</filters-lib.version>
-        <properties-client.version>1.1.9</properties-client.version>
-        <contract-client.version>1.1.4</contract-client.version>
+        <events-client.version>1.12.0</events-client.version>
+        <bfd-lib.version>2.1.0</bfd-lib.version>
+        <fhir-lib.version>1.2.0</fhir-lib.version>
+        <aggregator-lib.version>1.3.0</aggregator-lib.version>
+        <filters-lib.version>1.9.0</filters-lib.version>
+        <properties-client.version>1.2.0</properties-client.version>
+        <contract-client.version>1.2.0</contract-client.version>
     </properties>
+
+    <!-- <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement> -->
 
     <dependencies>
         <dependency>
@@ -81,6 +95,22 @@
             <artifactId>localstack</artifactId>
             <version>1.18.3</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-dependencies</artifactId>
+            <version>${spring-cloud-aws.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-autoconfigure</artifactId>
+            <version>${spring-cloud-aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws-messaging</artifactId>
+            <version>${spring-cloud-aws.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,6 @@
             <version>1.18.3</version>
             <scope>test</scope>
         </dependency>
-        <!-- <dependency>
-            <groupId>io.awspring.cloud</groupId>
-            <artifactId>spring-cloud-aws-dependencies</artifactId>
-            <version>${spring-cloud-aws.version}</version>
-            <type>pom</type>
-        </dependency> -->
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <testcontainers.version>1.18.3</testcontainers.version>
         <newrelic.version>8.4.0</newrelic.version>
         <postgres.version>42.6.0</postgres.version>
-        <!-- <spring-cloud.version>2021.0.8</spring-cloud.version> -->
         <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version>
 
         <!-- Maven plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,12 @@
             <version>1.18.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>io.awspring.cloud</groupId>
             <artifactId>spring-cloud-aws-dependencies</artifactId>
             <version>${spring-cloud-aws.version}</version>
             <type>pom</type>
-        </dependency>
+        </dependency> -->
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
 
         <!-- AB2D lib versions -->
-        <events-client.version>1.12.1</events-client.version>
+        <events-client.version>1.12.2</events-client.version>
         <bfd-lib.version>2.1.1</bfd-lib.version>
         <fhir-lib.version>1.2.1</fhir-lib.version>
         <aggregator-lib.version>1.3.1</aggregator-lib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,18 +54,6 @@
         <contract-client.version>1.2.1</contract-client.version>
     </properties>
 
-    <!-- <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement> -->
-
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -95,6 +83,12 @@
             <artifactId>localstack</artifactId>
             <version>1.18.3</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-dependencies</artifactId>
+            <version>${spring-cloud-aws.version}</version>
+            <type>pom</type>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5916

## 🛠 Changes
WIP - Still might need some cleanup

Remove dependency on org.springframework.cloud
Update Spring AWS Cloud dependency from 2.2.6 to 2.4.4 by migrating to io.awspring.cloud.
Update AB2D Libs versions

## ℹ️ Context for reviewers

This is required to potentially use IMDSV2 to fix EC2 issues.

## ✅ Acceptance Validation

Built locally, to be deployed and tested on IMPL environment

## 🔒 Security Implications

- [x] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
