### PR TITLE
6051- include all PDP's as part of attribution data share

### DIFF
--- a/common/src/main/resources/db/changelog/v2024/misc_opt_out_attribution.sql
+++ b/common/src/main/resources/db/changelog/v2024/misc_opt_out_attribution.sql
@@ -45,7 +45,7 @@ $$;
 DROP procedure public.insert_new_current_mbi(); --obsolete changed MBI update from insert_new_current_mbi to another
 -- view below due to time out issues and to address AB2D-6051
 
-CREATE OR REPLACE Procedure  proc_insert_mbi_to_table(
+CREATE OR REPLACE Procedure proc_insert_mbi_to_table(
 var_offset int,
 var_limit int default 0)
 AS


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6051

## 🛠 Changes

Changed the stored procedure to pull data from contracts and populate current_mbi table

## ℹ️ Context for reviewers

As part of the automated enrollee opt-out workflow, AB2D sends a weekly (Tuesday at night) request file that has beneficiaries aligned with AB2D. Currently the request file only includes PDPs that have run a production job (who we have shared beneficiary information with). We want to expand the list by including all PDPs that have attested, currently or in the past.


## ✅ Acceptance Validation

The request file includes beneficiaries that belong to PDPs who have attested, currently or in the past
There is no negative performance impact

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
