### PR TITLE
PLT-467 downgrading docker compose & removing e2e test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,41 +143,6 @@ pipeline {
             }
         }
 
-
-        stage('Run e2e-test') {
-
-            steps {
-
-                withCredentials([file(credentialsId: 'SANDBOX_BFD_KEYSTORE', variable: 'SANDBOX_BFD_KEYSTORE'),
-                                 string(credentialsId: 'SANDBOX_BFD_KEYSTORE_PASSWORD', variable: 'AB2D_BFD_KEYSTORE_PASSWORD'),
-                                 usernamePassword(credentialsId: 'artifactoryuserpass', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) {
-
-                    sh '''
-                        export AB2D_BFD_KEYSTORE_LOCATION="/opt/ab2d/ab2d_bfd_keystore"
-
-                        export KEYSTORE_LOCATION="$WORKSPACE/opt/ab2d/ab2d_bfd_keystore"
-
-                        export JENKINS_UID=$(id -u)
-                        export JENKINS_GID=$(id -g)
-
-                        cp $SANDBOX_BFD_KEYSTORE $KEYSTORE_LOCATION
-
-                        test -f $KEYSTORE_LOCATION && echo "created keystore file"
-
-                        chmod 666 $KEYSTORE_LOCATION
-
-                        ls -la $KEYSTORE_LOCATION
-
-                        # Log into ECR for Docker Compose in e2e tests
-                        aws --region "${AWS_DEFAULT_REGION}" ecr get-login-password |
-                          docker login --username AWS --password-stdin "${ECR_REPO_ENV_AWS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-
-                        mvn test -s settings.xml -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
-                    '''
-                }
-            }
-        }
-
         stage('Run codeclimate tests') {
 
             steps {

--- a/docker-compose.jenkins.yml
+++ b/docker-compose.jenkins.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.4'
 
 ##################
 # Overrides specific properties of original compose for CI environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.4'
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,9 @@ services:
     image: 777200079629.dkr.ecr.us-east-1.amazonaws.com/ab2d-sbx-services:contracts-service
 #    Use if running locally. Build imqge in Contract Service repo first
 #    image: ab2d-contracts-contracts
+    volumes:
+      - ./start-contracts.sh:/var/lib/jenkins/jenkins_agent/start-contracts.sh
+    entrypoint: ["/bin/bash", "/var/lib/jenkins/jenkins_agent/start-contracts.sh"]    
     environment:
       - AB2D_DB_HOST=db
       - AB2D_DB_PORT=5432
@@ -157,15 +160,9 @@ services:
 #      - AWS_SECRET_KEY=null
     healthcheck:
       test: [ "CMD-SHELL", "curl -X GET http://localhost:8070/health --insecure" ]
-<<<<<<< HEAD
       interval: 1m
       timeout: 10s
       retries: 5
-=======
-      interval: 30s
-      timeout: 5s
-      retries: 10
->>>>>>> 30e03a71b196b70be1eccb7907420d7db4841a91
     ports:
       - '8070:8070'
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,8 +157,8 @@ services:
 #      - AWS_SECRET_KEY=null
     healthcheck:
       test: [ "CMD-SHELL", "curl -X GET http://localhost:8070/health --insecure" ]
-      interval: 30s
-      timeout: 5s
+      interval: 1m
+      timeout: 10s
       retries: 5
     ports:
       - '8070:8070'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,9 +137,6 @@ services:
     image: 777200079629.dkr.ecr.us-east-1.amazonaws.com/ab2d-sbx-services:contracts-service
 #    Use if running locally. Build imqge in Contract Service repo first
 #    image: ab2d-contracts-contracts
-    volumes:
-      - ./start-contracts.sh:/var/lib/jenkins/jenkins_agent/start-contracts.sh
-    entrypoint: ["/bin/bash", "/var/lib/jenkins/jenkins_agent/start-contracts.sh"]    
     environment:
       - AB2D_DB_HOST=db
       - AB2D_DB_PORT=5432
@@ -160,8 +157,8 @@ services:
 #      - AWS_SECRET_KEY=null
     healthcheck:
       test: [ "CMD-SHELL", "curl -X GET http://localhost:8070/health --insecure" ]
-      interval: 1m
-      timeout: 10s
+      interval: 30s
+      timeout: 5s
       retries: 5
     ports:
       - '8070:8070'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-467

## 🛠 Changes

Downgraded docker compose and disabled e2e test.

## ℹ️ Context for reviewers

Docker compose upgrade was reverted because newer versions of docker compose require changes to our configuration files and dependencies. The e2e test was disabled because it is outdated and we have the same coverage with integration tests, e2e-bfd, and smoke tests in the transition to GitHub Actions.

## ✅ Acceptance Validation

See builds at https://jenkins.ab2d.cms.gov/job/AB2D%20Repo/view/change-requests/job/PR-1332/.

## 🔒 Security Implications

None.