### PR TITLE
Adding current mbi join for matching counts

### DIFF
--- a/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
@@ -85,8 +85,9 @@ public class CoverageServiceRepository {
      *
      * The contract and year must be included to take advantage of the partitions and prevent a table scan
      */
-    private static final String SELECT_COVERAGE_BY_SEARCH_COUNT = "SELECT COUNT(*) FROM coverage " +
-            " WHERE bene_coverage_search_event_id = :id AND contract = :contract AND year IN (:years) and current_mbi is not null";
+    private static final String SELECT_COVERAGE_BY_SEARCH_COUNT = "SELECT COUNT(*) FROM coverage c " +
+            " join current_mbi m on  c.current_mbi=m.mbi" +
+            " WHERE bene_coverage_search_event_id = :id AND contract = :contract AND year IN (:years) AND opt_out_flag is not false AND current_mbi is not null";
 
     /**
      * Return a count of all beneficiaries associated with an {@link CoveragePeriod}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6134

## 🛠 Changes

Updated the SQL's to include join with Current MBI

## ℹ️ Context for reviewers

Database retrieved and queued counts are mismatching most likely due to some missing joins with current MBIs for opt outs

## ✅ Acceptance Validation

No pipeline is broken and jobs still run fine

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
