### PR TITLE
[AB2D-6141] Update API Accept Headers

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
@@ -1,7 +1,7 @@
 package gov.cms.ab2d.api.controller.common;
 
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 
 import lombok.experimental.UtilityClass;
@@ -25,6 +25,7 @@ public class ApiText {
     public static final String CAP_DESC = "A JSON FHIR capability statement matching ";
     public static final String CAP_REQ = "Request the FHIR capability statement detailing what operations this API supports ";
     public static final String APPLICATION_JSON = "application/json";
+    public static 
     public static final String DOWNLOAD_DESC = "Downloads a file produced by an export job.";
     public static final String CONTENT_TYPE_DESC = "Header which must match the file format being delivered: ";
     public static final String BULK_DNLD_DSC = "After creating a job, the API to download the generated bulk download files";
@@ -33,7 +34,7 @@ public class ApiText {
     public static final String STATUS_DES = "Returns a status of an export job.";
     public static final String JOB_ID = "A job identifier";
     public static final String FILE_NAME = "A file name";
-    public static final String DNLD_DESC = "Returns the requested file as " + NDJSON_FIRE_CONTENT_TYPE;
+    public static final String DNLD_DESC = "Returns the requested file as " + FHIR_NDJSON_CONTENT_TYPE;
     public static final String JOB_NOT_FOUND = "Job not found. " + GENERIC_FHIR_ERR_MSG;
     public static final String JOB_CANCELLED_MSG = "Job canceled";
     public static final String CAP_STMT = "FHIR capability statement";

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
@@ -1,7 +1,7 @@
 package gov.cms.ab2d.api.controller.common;
 
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 
 import lombok.experimental.UtilityClass;
@@ -33,7 +33,7 @@ public class ApiText {
     public static final String STATUS_DES = "Returns a status of an export job.";
     public static final String JOB_ID = "A job identifier";
     public static final String FILE_NAME = "A file name";
-    public static final String DNLD_DESC = "Returns the requested file as " + NDJSON_FIRE_CONTENT_TYPE;
+    public static final String DNLD_DESC = "Returns the requested file as " + FHIR_NDJSON_CONTENT_TYPE;
     public static final String JOB_NOT_FOUND = "Job not found. " + GENERIC_FHIR_ERR_MSG;
     public static final String JOB_CANCELLED_MSG = "Job canceled";
     public static final String CAP_STMT = "FHIR capability statement";

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
@@ -1,7 +1,7 @@
 package gov.cms.ab2d.api.controller.common;
 
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
-import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 
 import lombok.experimental.UtilityClass;
@@ -25,7 +25,6 @@ public class ApiText {
     public static final String CAP_DESC = "A JSON FHIR capability statement matching ";
     public static final String CAP_REQ = "Request the FHIR capability statement detailing what operations this API supports ";
     public static final String APPLICATION_JSON = "application/json";
-    public static 
     public static final String DOWNLOAD_DESC = "Downloads a file produced by an export job.";
     public static final String CONTENT_TYPE_DESC = "Header which must match the file format being delivered: ";
     public static final String BULK_DNLD_DSC = "After creating a job, the API to download the generated bulk download files";
@@ -34,7 +33,7 @@ public class ApiText {
     public static final String STATUS_DES = "Returns a status of an export job.";
     public static final String JOB_ID = "A job identifier";
     public static final String FILE_NAME = "A file name";
-    public static final String DNLD_DESC = "Returns the requested file as " + FHIR_NDJSON_CONTENT_TYPE;
+    public static final String DNLD_DESC = "Returns the requested file as " + NDJSON_FIRE_CONTENT_TYPE;
     public static final String JOB_NOT_FOUND = "Job not found. " + GENERIC_FHIR_ERR_MSG;
     public static final String JOB_CANCELLED_MSG = "Job canceled";
     public static final String CAP_STMT = "FHIR capability statement";

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 
 import static gov.cms.ab2d.common.util.Constants.FILE_LOG;
 import static gov.cms.ab2d.common.util.Constants.JOB_LOG;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 
@@ -46,7 +46,7 @@ public class FileDownloadCommon {
 
         String fileDownloadName = downloadResource.getFile().getName();
 
-        response.setHeader(HttpHeaders.CONTENT_TYPE, NDJSON_FIRE_CONTENT_TYPE);
+        response.setHeader(HttpHeaders.CONTENT_TYPE, FHIR_NDJSON_CONTENT_TYPE);
         response.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + fileDownloadName + "\"");
 
         try (OutputStream out = response.getOutputStream(); FileInputStream in = new FileInputStream(downloadResource.getFile())) {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
@@ -29,7 +29,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-
 import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.api.controller.common.ApiText.ASYNC;
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_RESPONSE;
@@ -50,6 +49,7 @@ import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_OUTPUT_FORMAT;
 import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_PREFER;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
@@ -64,7 +64,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Slf4j
 @Tag(name = "1. Export", description = BULK_MAIN)
 @RestController
-@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = {APPLICATION_JSON})
+@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
 public class BulkDataAccessAPIV1 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;
@@ -94,7 +94,7 @@ public class BulkDataAccessAPIV1 {
             ),
             @ApiResponse(responseCode = "429", description = MAX_JOBS,
                 headers = @Header(name = CONTENT_LOCATION, description = RUNNING_JOBIDS, schema = @Schema(type = "string")),
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )
@@ -137,7 +137,7 @@ public class BulkDataAccessAPIV1 {
             ),
             @ApiResponse(responseCode = "429", description = MAX_JOBS,
                 headers = @Header(name = CONTENT_LOCATION, description = RUNNING_JOBIDS, schema = @Schema(type = "string")),
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
@@ -64,7 +64,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Slf4j
 @Tag(name = "1. Export", description = BULK_MAIN)
 @RestController
-@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, consumes = FHIR_JSON_CONTENT_TYPE, produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
+@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = { FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON })
 public class BulkDataAccessAPIV1 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
@@ -51,7 +51,7 @@ import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_PREFER;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -82,7 +82,7 @@ public class BulkDataAccessAPIV1 {
             @Parameter(name = OUT_FORMAT, description = BULK_OUTPUT_FORMAT, in = ParameterIn.QUERY,
                 schema = @Schema(allowableValues = {
                     "application/fhir+ndjson", "application/ndjson", "ndjson"
-                }, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+                }, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @Parameter(name = SINCE, description = BULK_SINCE, schema = @Schema(type = "date-time", description = SINCE_EARLIEST_DATE))
 
@@ -104,7 +104,7 @@ public class BulkDataAccessAPIV1 {
             HttpServletRequest request,
             @RequestParam(name = TYPE_PARAM, required = false, defaultValue = EOB)
                 String resourceTypes,
-            @RequestParam(name = OUT_FORMAT, required = false, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+            @RequestParam(name = OUT_FORMAT, required = false, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
                 String outputFormat,
             @RequestParam(required = false, name = SINCE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                 OffsetDateTime since) {
@@ -126,7 +126,7 @@ public class BulkDataAccessAPIV1 {
             @Parameter(name = OUT_FORMAT, description = BULK_OUTPUT_FORMAT, in = ParameterIn.QUERY,
                 schema = @Schema(allowableValues = {
                     "application/fhir+ndjson", "application/ndjson", "ndjson"
-                }, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+                }, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @Parameter(name = SINCE, description = BULK_SINCE, example = SINCE_EARLIEST_DATE, schema = @Schema(type = "date-time"))
         }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
@@ -64,7 +64,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Slf4j
 @Tag(name = "1. Export", description = BULK_MAIN)
 @RestController
-@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = { FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON })
+@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = {FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON})
 public class BulkDataAccessAPIV1 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/BulkDataAccessAPIV1.java
@@ -64,7 +64,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Slf4j
 @Tag(name = "1. Export", description = BULK_MAIN)
 @RestController
-@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
+@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, consumes = FHIR_JSON_CONTENT_TYPE, produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
 public class BulkDataAccessAPIV1 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -40,7 +40,7 @@ import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 
 @AllArgsConstructor
 @Slf4j
@@ -57,8 +57,8 @@ public class FileDownloadAPIV1 {
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = DNLD_DESC,
-                    headers = {@Header(name = CONTENT_TYPE, description = CONTENT_TYPE_DESC + NDJSON_FIRE_CONTENT_TYPE)},
-                    content = @Content(mediaType = NDJSON_FIRE_CONTENT_TYPE)
+                    headers = {@Header(name = CONTENT_TYPE, description = CONTENT_TYPE_DESC + FHIR_NDJSON_CONTENT_TYPE)},
+                    content = @Content(mediaType = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @ApiResponse(responseCode = "404", description = NOT_FOUND + GENERIC_FHIR_ERR_MSG, content =
                 @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
@@ -66,7 +66,7 @@ public class FileDownloadAPIV1 {
         }
     )
     @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { NDJSON_FIRE_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { FHIR_NDJSON_CONTENT_TYPE })
     public ResponseEntity downloadFile(HttpServletRequest request,
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -66,7 +66,7 @@ public class FileDownloadAPIV1 {
         }
     )
     @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { FHIR_NDJSON_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = {FHIR_NDJSON_CONTENT_TYPE})
     public ResponseEntity downloadFile(HttpServletRequest request,
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -29,7 +29,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_DNLD_DSC;
 import static gov.cms.ab2d.api.controller.common.ApiText.DOWNLOAD_DESC;
-import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.api.controller.common.ApiText.DNLD_DESC;
 import static gov.cms.ab2d.api.controller.common.ApiText.CONTENT_TYPE_DESC;
 import static gov.cms.ab2d.api.controller.common.ApiText.NOT_FOUND;
@@ -39,6 +38,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.FILE_NAME;
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 
@@ -61,7 +61,7 @@ public class FileDownloadAPIV1 {
                     content = @Content(mediaType = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @ApiResponse(responseCode = "404", description = NOT_FOUND + GENERIC_FHIR_ERR_MSG, content =
-                @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
@@ -51,7 +51,7 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 @Slf4j
 @Tag(name = "2. Status", description = STATUS_API)
 @RestController
-@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = {APPLICATION_JSON})
+@RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX, produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
 @AllArgsConstructor
 public class StatusAPIV1 {
 
@@ -66,10 +66,10 @@ public class StatusAPIV1 {
             ),
             @ApiResponse(responseCode = "200", description = JOB_COMPLETE, headers = {
                 @Header(name = EXPIRES, description = FILE_EXPIRES, schema = @Schema(type = "string"))},
-                content = @Content(schema = @Schema(ref = "#/components/schemas/JobCompletedResponse"))
+                content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/JobCompletedResponse"))
             ),
             @ApiResponse(responseCode = "404", description = JOB_NOT_FOUND,
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )
@@ -85,7 +85,7 @@ public class StatusAPIV1 {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "202", description = JOB_CANCELLED_MSG),
             @ApiResponse(responseCode = "404", description = JOB_NOT_FOUND,
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
@@ -73,7 +73,7 @@ public class StatusAPIV1 {
             )
         }
     )
-    @GetMapping(value = "/Job/{jobUuid}/$status", produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/$status", produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
     @ResponseStatus(value = HttpStatus.OK)
     public ResponseEntity<JobCompletedResponse> getJobStatus(HttpServletRequest request,
             @PathVariable @NotBlank String jobUuid) {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/StatusAPIV1.java
@@ -40,6 +40,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.STILL_RUNNING;
 import static gov.cms.ab2d.api.controller.common.ApiText.X_PROG;
 import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_CANCEL;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static org.springframework.http.HttpHeaders.EXPIRES;
 import static org.springframework.http.HttpHeaders.RETRY_AFTER;
@@ -72,7 +73,7 @@ public class StatusAPIV1 {
             )
         }
     )
-    @GetMapping(value = "/Job/{jobUuid}/$status", produces = APPLICATION_JSON)
+    @GetMapping(value = "/Job/{jobUuid}/$status", produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
     @ResponseStatus(value = HttpStatus.OK)
     public ResponseEntity<JobCompletedResponse> getJobStatus(HttpServletRequest request,
             @PathVariable @NotBlank String jobUuid) {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
@@ -66,7 +66,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Tag(description = SwaggerConstants.BULK_MAIN, name = "Export")
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = { FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON })
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON})
 public class BulkDataAccessAPIV2 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
@@ -30,8 +30,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-
-import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.api.controller.common.ApiText.ASYNC;
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_RESPONSE;
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_RESPONSE_LONG;
@@ -51,6 +49,7 @@ import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_OUTPUT_FORMAT;
 import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_PREFER;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
@@ -66,7 +65,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Tag(description = SwaggerConstants.BULK_MAIN, name = "Export")
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_JSON_CONTENT_TYPE})
 public class BulkDataAccessAPIV2 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;
@@ -97,7 +96,7 @@ public class BulkDataAccessAPIV2 {
             ),
             @ApiResponse(responseCode = "429", description = MAX_JOBS, headers =
                 @Header(name = CONTENT_LOCATION, description = RUNNING_JOBIDS, schema = @Schema(type = "string")),
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )
@@ -144,7 +143,7 @@ public class BulkDataAccessAPIV2 {
             ),
             @ApiResponse(responseCode = "429", description = MAX_JOBS, headers =
                 @Header(name = CONTENT_LOCATION, description = RUNNING_JOBIDS, schema = @Schema(type = "string")),
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
@@ -66,7 +66,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Tag(description = SwaggerConstants.BULK_MAIN, name = "Export")
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, consumes = FHIR_JSON_CONTENT_TYPE, produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = { FHIR_JSON_CONTENT_TYPE, APPLICATION_JSON })
 public class BulkDataAccessAPIV2 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
@@ -52,7 +52,7 @@ import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_PREFER;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.CONTRACT_LOG;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -84,7 +84,7 @@ public class BulkDataAccessAPIV2 {
             @Parameter(name = OUT_FORMAT, description = BULK_OUTPUT_FORMAT, in = ParameterIn.QUERY,
                 schema = @Schema(allowableValues = {
                     "application/fhir+ndjson", "application/ndjson", "ndjson"
-                }, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+                }, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @Parameter(name = SINCE, description = BULK_SINCE_DEFAULT, schema = @Schema(type = "date-time", description = SINCE_EARLIEST_DATE))
 
@@ -107,7 +107,7 @@ public class BulkDataAccessAPIV2 {
             HttpServletRequest request,
             @RequestParam(name = TYPE_PARAM, required = false, defaultValue = EOB)
                     String resourceTypes,
-            @RequestParam(name = OUT_FORMAT, required = false, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+            @RequestParam(name = OUT_FORMAT, required = false, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
                     String outputFormat,
             @RequestParam(required = false, name = SINCE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                     OffsetDateTime since) {
@@ -130,7 +130,7 @@ public class BulkDataAccessAPIV2 {
             @Parameter(name = OUT_FORMAT, description = BULK_OUTPUT_FORMAT, in = ParameterIn.QUERY,
                     schema = @Schema(allowableValues = {
                             "application/fhir+ndjson", "application/ndjson", "ndjson"
-                    }, defaultValue = NDJSON_FIRE_CONTENT_TYPE)
+                    }, defaultValue = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @Parameter(name = SINCE, description = BULK_SINCE_DEFAULT, example = SINCE_EARLIEST_DATE, schema = @Schema(type = "date-time"))
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/BulkDataAccessAPIV2.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.api.controller.common.ApiText.ASYNC;
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_RESPONSE;
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_RESPONSE_LONG;
@@ -65,7 +66,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
 @Tag(description = SwaggerConstants.BULK_MAIN, name = "Export")
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_JSON_CONTENT_TYPE})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, consumes = FHIR_JSON_CONTENT_TYPE, produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
 public class BulkDataAccessAPIV2 {
     private final JobClient jobClient;
     private final ApiCommon apiCommon;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -32,10 +32,10 @@ import static gov.cms.ab2d.api.controller.common.ApiText.DNLD_DESC;
 import static gov.cms.ab2d.api.controller.common.ApiText.DOWNLOAD_DESC;
 import static gov.cms.ab2d.api.controller.common.ApiText.FILE_NAME;
 import static gov.cms.ab2d.api.controller.common.ApiText.JOB_ID;
-import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.api.controller.common.ApiText.NOT_FOUND;
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -45,7 +45,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @Tag(name = "Download", description = BULK_DNLD_DSC)
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON, FHIR_NDJSON_CONTENT_TYPE})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_NDJSON_CONTENT_TYPE, FHIR_JSON_CONTENT_TYPE})
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
 
@@ -60,7 +60,7 @@ public class FileDownloadAPIV2 {
                 content = @Content(mediaType = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @ApiResponse(responseCode = "404", description = NOT_FOUND + GENERIC_FHIR_ERR_MSG, content =
-                @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
      }
     )

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -65,7 +65,7 @@ public class FileDownloadAPIV2 {
      }
     )
     @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { FHIR_NDJSON_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = {FHIR_NDJSON_CONTENT_TYPE})
     public ResponseEntity downloadFile(HttpServletRequest request,
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -37,7 +37,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.NOT_FOUND;
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 @AllArgsConstructor
@@ -45,7 +45,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @Tag(name = "Download", description = BULK_DNLD_DSC)
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON, NDJSON_FIRE_CONTENT_TYPE})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON, FHIR_NDJSON_CONTENT_TYPE})
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
 
@@ -56,8 +56,8 @@ public class FileDownloadAPIV2 {
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = DNLD_DESC,
-                headers = {@Header(name = CONTENT_TYPE, description = CONTENT_TYPE_DESC + NDJSON_FIRE_CONTENT_TYPE)},
-                content = @Content(mediaType = NDJSON_FIRE_CONTENT_TYPE)
+                headers = {@Header(name = CONTENT_TYPE, description = CONTENT_TYPE_DESC + FHIR_NDJSON_CONTENT_TYPE)},
+                content = @Content(mediaType = FHIR_NDJSON_CONTENT_TYPE)
             ),
             @ApiResponse(responseCode = "404", description = NOT_FOUND + GENERIC_FHIR_ERR_MSG, content =
                 @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
@@ -65,7 +65,7 @@ public class FileDownloadAPIV2 {
      }
     )
     @ResponseStatus(value = HttpStatus.OK)
-    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { NDJSON_FIRE_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/file/{filename}", produces = { FHIR_NDJSON_CONTENT_TYPE })
     public ResponseEntity downloadFile(HttpServletRequest request,
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
@@ -53,7 +53,7 @@ import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 @Tag(name = "Status", description = STATUS_API)
 @RestController
 @ConditionalOnExpression("${v2.controller.enabled:true}")
-@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON})
+@RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
 @AllArgsConstructor
 public class StatusAPIV2 {
 
@@ -68,10 +68,10 @@ public class StatusAPIV2 {
             ),
             @ApiResponse(responseCode = "200", description = JOB_COMPLETE, headers = {
                 @Header(name = EXPIRES, description = FILE_EXPIRES, schema = @Schema(type = "string"))},
-                content = @Content(schema = @Schema(ref = "#/components/schemas/JobCompletedResponse"))
+                content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(ref = "#/components/schemas/JobCompletedResponse"))
             ),
             @ApiResponse(responseCode = "404", description = JOB_NOT_FOUND,
-                content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
+                content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome"))
             )
         }
     )
@@ -87,7 +87,7 @@ public class StatusAPIV2 {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "202", description = JOB_CANCELLED_MSG),
             @ApiResponse(responseCode = "404", description = JOB_NOT_FOUND,
-                    content = @Content(schema = @Schema(ref = "#/components/schemas/OperationOutcome")))}
+                    content = @Content(mediaType = FHIR_JSON_CONTENT_TYPE, schema = @Schema(ref = "#/components/schemas/OperationOutcome")))}
     )
     @DeleteMapping(value = "/Job/{jobUuid}/$status")
     @ResponseStatus(value = HttpStatus.ACCEPTED)

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
@@ -75,7 +75,7 @@ public class StatusAPIV2 {
             )
         }
     )
-    @GetMapping(value = "/Job/{jobUuid}/$status", produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
+    @GetMapping(value = "/Job/{jobUuid}/$status", produces = {APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE})
     @ResponseStatus(value = HttpStatus.OK)
     public ResponseEntity<JobCompletedResponse> getJobStatus(HttpServletRequest request,
             @PathVariable @NotBlank String jobUuid) {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2.java
@@ -42,6 +42,7 @@ import static gov.cms.ab2d.api.controller.common.ApiText.X_PROG;
 import static gov.cms.ab2d.api.util.SwaggerConstants.BULK_CANCEL;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
+import static gov.cms.ab2d.common.util.Constants.FHIR_JSON_CONTENT_TYPE;
 import static org.springframework.http.HttpHeaders.EXPIRES;
 import static org.springframework.http.HttpHeaders.RETRY_AFTER;
 
@@ -74,7 +75,7 @@ public class StatusAPIV2 {
             )
         }
     )
-    @GetMapping(value = "/Job/{jobUuid}/$status", produces = APPLICATION_JSON)
+    @GetMapping(value = "/Job/{jobUuid}/$status", produces = { APPLICATION_JSON, FHIR_JSON_CONTENT_TYPE })
     @ResponseStatus(value = HttpStatus.OK)
     public ResponseEntity<JobCompletedResponse> getJobStatus(HttpServletRequest request,
             @PathVariable @NotBlank String jobUuid) {

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -61,7 +61,7 @@ import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.MAX_DOWNLOADS;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.DataSetup.TEST_PDP_CLIENT;
 import static gov.cms.ab2d.common.util.DataSetup.VALID_CONTRACT_NUMBER;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -313,7 +313,7 @@ class BulkDataAccessAPIIntegrationTests {
                         .header("Authorization", "Bearer " + token)
                         .header("Accept-Encoding", "gzip, deflate, br"))
                 .andExpect(status().is(200))
-                .andExpect(content().contentType(NDJSON_FIRE_CONTENT_TYPE))
+                .andExpect(content().contentType(FHIR_NDJSON_CONTENT_TYPE))
                 .andReturn();
     }
 

--- a/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/Constants.java
@@ -6,7 +6,9 @@ public final class Constants {
 
     public static final String OPERATION_OUTCOME = "OperationOutcome";
 
-    public static final String NDJSON_FIRE_CONTENT_TYPE = "application/fhir+ndjson";
+    public static final String FHIR_NDJSON_CONTENT_TYPE = "application/fhir+ndjson";
+
+    public static final String FHIR_JSON_CONTENT_TYPE = "application/fhir+json";
 
     public static final String JOB_LOG = "job";
 

--- a/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
@@ -55,7 +55,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.OPERATION_OUTCOME;
 import static gov.cms.ab2d.common.util.DateUtil.AB2D_EPOCH;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
@@ -148,7 +148,7 @@ class JobServiceTest extends JobCleanup {
     }
 
     private StartJobDTO buildStartJobContract(String contractNumber) {
-        return buildStartJob(contractNumber, EOB, NDJSON_FIRE_CONTENT_TYPE);
+        return buildStartJob(contractNumber, EOB, FHIR_NDJSON_CONTENT_TYPE);
     }
 
     private StartJobDTO buildStartJobOutputFormat(String outputFormat) {
@@ -157,7 +157,7 @@ class JobServiceTest extends JobCleanup {
 
     private StartJobDTO buildStartJobResourceTypes(String resourceTypes) {
         return buildStartJob(contractService.getContractByContractId(pdpClientService.getCurrentClient().getContractId()).getContractNumber(),
-                resourceTypes, NDJSON_FIRE_CONTENT_TYPE);
+                resourceTypes, FHIR_NDJSON_CONTENT_TYPE);
     }
 
     private StartJobDTO buildStartJob(String contractNumber, String resourceTypes, String outputFormat) {
@@ -167,12 +167,12 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void createJob() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
         assertNotNull(job);
         assertNotNull(job.getId());
         assertNotNull(job.getJobUuid());
         assertNotNull(job.getOutputFormat());
-        assertEquals(NDJSON_FIRE_CONTENT_TYPE, job.getOutputFormat());
+        assertEquals(FHIR_NDJSON_CONTENT_TYPE, job.getOutputFormat());
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals(pdpClientRepository.findByClientId(CLIENTID).getOrganization(), job.getOrganization());
         assertEquals(EOB, job.getResourceTypes());
@@ -199,7 +199,7 @@ class JobServiceTest extends JobCleanup {
         assertNotNull(job.getId());
         assertNotNull(job.getJobUuid());
         assertNotNull(job.getOutputFormat());
-        assertEquals(NDJSON_FIRE_CONTENT_TYPE, job.getOutputFormat());
+        assertEquals(FHIR_NDJSON_CONTENT_TYPE, job.getOutputFormat());
         assertEquals(Integer.valueOf(0), job.getProgress());
         assertEquals(pdpClientRepository.findByClientId(CLIENTID).getOrganization(), job.getOrganization());
         assertEquals(EOB, job.getResourceTypes());
@@ -254,7 +254,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void cancelJob() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         jobService.cancelJob(job.getJobUuid(), pdpClientService.getCurrentClient().getOrganization());
 
@@ -272,7 +272,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void getJob() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         Job retrievedJob = jobService.getAuthorizedJobByJobUuid(job.getJobUuid(),
                 pdpClientService.getCurrentClient().getOrganization());
@@ -283,7 +283,7 @@ class JobServiceTest extends JobCleanup {
     @Test
     void getJobAdminRole() {
         // Job created by regular client
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         setupAdminClient();
 
@@ -298,7 +298,7 @@ class JobServiceTest extends JobCleanup {
         setupAdminClient();
 
         // Job created by admin client
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         setupRegularClientSecurityContext();
 
@@ -337,7 +337,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void testJobInSuccessfulState() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         job.setStatus(SUCCESSFUL);
         jobRepository.saveAndFlush(job);
@@ -348,7 +348,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void testJobInCancelledState() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         job.setStatus(JobStatus.CANCELLED);
         jobRepository.saveAndFlush(job);
@@ -360,7 +360,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void testJobInFailedState() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         job.setStatus(FAILED);
         jobRepository.saveAndFlush(job);
@@ -372,7 +372,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void updateJob() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime localDateTime = OffsetDateTime.now();
         job.setProgress(100);
@@ -406,7 +406,7 @@ class JobServiceTest extends JobCleanup {
         job.setJobOutputs(output);
 
         Job updatedJob = jobService.updateJob(job);
-        assertEquals(NDJSON_FIRE_CONTENT_TYPE, updatedJob.getOutputFormat());
+        assertEquals(FHIR_NDJSON_CONTENT_TYPE, updatedJob.getOutputFormat());
         assertEquals(Integer.valueOf(100), updatedJob.getProgress());
         assertEquals(now, updatedJob.getLastPollTime());
         assertEquals(JobStatus.IN_PROGRESS, updatedJob.getStatus());
@@ -498,7 +498,7 @@ class JobServiceTest extends JobCleanup {
     }
 
     private Job createJobForFileDownloads(String fileName, String errorFileName) {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime now = OffsetDateTime.now();
         OffsetDateTime localDateTime = OffsetDateTime.now();
         job.setProgress(100);
@@ -599,16 +599,16 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void checkIfClientCanAddJobTrueTest() {
-        createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         assertTrue(canRun());
     }
 
     @Test
     void checkIfClientCanAddJobPastLimitTest() {
-        createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
-        createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
-        createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
+        createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
+        createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
 
         assertFalse(canRun());
     }
@@ -630,7 +630,7 @@ class JobServiceTest extends JobCleanup {
 
     @Test
     void checkForExpirations() {
-        Job job = createJobAllContracts(NDJSON_FIRE_CONTENT_TYPE);
+        Job job = createJobAllContracts(FHIR_NDJSON_CONTENT_TYPE);
         job.setStatus(FAILED);
         jobRepository.save(job);
 

--- a/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
@@ -22,7 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static gov.cms.ab2d.job.service.JobServiceTest.CLIENTID;
@@ -79,7 +79,7 @@ class MaxJobsTest extends JobCleanup {
         Contract contract = contractServiceStub.getAllAttestedContracts().iterator().next();
         String organization = pdpClientService.getCurrentClient().getOrganization();
         startJobDTO = new StartJobDTO(contract.getContractNumber(), organization,
-                EOB, LOCAL_HOST, NDJSON_FIRE_CONTENT_TYPE, null, STU3);
+                EOB, LOCAL_HOST, FHIR_NDJSON_CONTENT_TYPE, null, STU3);
         for (int idx = 0; idx < MAX_JOBS_PER_CLIENT; idx++) {
             Job retJob = jobService.createJob(startJobDTO);
             assertNotNull(retJob);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -41,7 +41,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static gov.cms.ab2d.common.model.SinceSource.AB2D;
 import static gov.cms.ab2d.common.model.SinceSource.FIRST_RUN;
 import static gov.cms.ab2d.common.model.SinceSource.USER;
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.fhir.FhirVersion.R4;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static gov.cms.ab2d.job.model.JobStartedBy.DEVELOPER;
@@ -174,7 +174,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         oldJob.setStatus(JobStatus.SUCCESSFUL);
         oldJob.setStatusMessage("100%");
         oldJob.setOrganization(pdpClient.getOrganization());
-        oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        oldJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
         oldJob.setFhirVersion(STU3);
@@ -188,7 +188,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         reallyOldJob.setStatusMessage("100%");
         reallyOldJob.setOrganization(pdpClient.getOrganization());
         reallyOldJob.setStartedBy(DEVELOPER);
-        reallyOldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        reallyOldJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime reallyOldldJobTime = OffsetDateTime.parse("2020-12-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         reallyOldJob.setCreatedAt(reallyOldldJobTime);
         reallyOldJob.setFhirVersion(R4);
@@ -200,7 +200,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
         newJob.setOrganization(pdpClient.getOrganization());
-        newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        newJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         newJob.setCreatedAt(OffsetDateTime.now());
         newJob.setFhirVersion(R4);
         newJob.setContractNumber(contract.getContractNumber());
@@ -223,7 +223,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         oldJob.setStatus(JobStatus.FAILED);
         oldJob.setStatusMessage("100%");
         oldJob.setOrganization(pdpClient.getOrganization());
-        oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        oldJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
         oldJob.setFhirVersion(STU3);
@@ -235,7 +235,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
         newJob.setOrganization(pdpClient.getOrganization());
-        newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        newJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime newJobTime = OffsetDateTime.parse("2021-02-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         newJob.setCreatedAt(newJobTime);
         newJob.setFhirVersion(R4);
@@ -259,7 +259,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         oldJob.setStatusMessage("100%");
         oldJob.setOrganization(pdpClient.getOrganization());
         oldJob.setStartedBy(DEVELOPER);
-        oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        oldJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
         oldJob.setFhirVersion(STU3);
@@ -271,7 +271,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
         newJob.setOrganization(pdpClient.getOrganization());
-        newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        newJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         newJob.setCreatedAt(OffsetDateTime.now());
         newJob.setFhirVersion(R4);
         newJob.setContractNumber(contract.getContractNumber());
@@ -294,7 +294,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         oldJob.setStatus(JobStatus.SUCCESSFUL);
         oldJob.setStatusMessage("100%");
         oldJob.setOrganization(pdpClient.getOrganization());
-        oldJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        oldJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime oldJobTime = OffsetDateTime.parse("2021-01-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         oldJob.setCreatedAt(oldJobTime);
         oldJob.setFhirVersion(STU3);
@@ -306,7 +306,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         newJob.setStatus(JobStatus.SUBMITTED);
         newJob.setStatusMessage("0%");
         newJob.setOrganization(pdpClient.getOrganization());
-        newJob.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        newJob.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         OffsetDateTime suppliedSince = OffsetDateTime.parse("2021-02-01T00:00:00.000-05:00", DateTimeFormatter.ISO_DATE_TIME);
         newJob.setSince(suppliedSince);
         newJob.setCreatedAt(OffsetDateTime.now());
@@ -341,7 +341,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
         job.setStatus(JobStatus.SUBMITTED);
         job.setStatusMessage("0%");
         job.setOrganization(pdpClient.getOrganization());
-        job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        job.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);
         job.setContractNumber(contractNumber);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -59,7 +59,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.eventclient.events.ErrorEvent.ErrorType.TOO_MANY_SEARCH_ERRORS;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static gov.cms.ab2d.worker.TestUtil.getOpenRange;
@@ -437,7 +437,7 @@ class JobProcessorIntegrationTest extends JobCleanup {
         job.setStatus(JobStatus.SUBMITTED);
         job.setStatusMessage("0%");
         job.setOrganization(pdpClient.getOrganization());
-        job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        job.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(STU3);
         job.setContractNumber(contract.getContractNumber());

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceDisengagementTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.PropertyConstants.WORKER_ENGAGEMENT;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
@@ -144,7 +144,7 @@ class WorkerServiceDisengagementTest extends JobCleanup {
         job.setResourceTypes(EOB);
         job.setCreatedAt(OffsetDateTime.now());
         job.setOrganization(pdpClient.getOrganization());
-        job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        job.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         job.setContractNumber(contract.getContractNumber());
         job.setFhirVersion(STU3);
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/WorkerServiceTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static gov.cms.ab2d.common.util.Constants.NDJSON_FIRE_CONTENT_TYPE;
+import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.fhir.BundleUtils.EOB;
 import static gov.cms.ab2d.fhir.FhirVersion.STU3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,7 +108,7 @@ class WorkerServiceTest extends JobCleanup {
         job.setResourceTypes(EOB);
         job.setCreatedAt(OffsetDateTime.now());
         job.setOrganization(pdpClient.getOrganization());
-        job.setOutputFormat(NDJSON_FIRE_CONTENT_TYPE);
+        job.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         job.setContractNumber(contract.getContractNumber());
         job.setFhirVersion(STU3);
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6141

## 🛠 Changes

Rename constant from 'FIRE' to 'FHIR'
Update API Accept and Response values so that we are in-line with the FHIR specification:
https://build.fhir.org/ig/HL7/bulk-data/export.html#headers

## ℹ️ Context for reviewers

This PR changes our accept headers on the export endpoint to accept both Application/fhir+json (the default expected by the FHIR standard: https://build.fhir.org/ig/HL7/bulk-data/export.html#headers, and Application/json, which is what is currently supported by our API.

## ✅ Acceptance Validation

Changes were deployed to IMPL environment and requests with different accept headers were made:
Application/json:
<img width="979" alt="Screenshot 2024-06-17 at 11 15 59 AM" src="https://github.com/CMSgov/ab2d/assets/87499456/f6f87277-5e9f-4e65-b259-f3d8c005d8bb">

Application/fhir+json:
<img width="977" alt="Screenshot 2024-06-17 at 11 15 47 AM" src="https://github.com/CMSgov/ab2d/assets/87499456/82339fdd-228c-4c1a-bb6e-6929ce7f3b23">



## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
