### PR TITLE
AB2D-6157 Update mismatch job failure to pass in slack alerts

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -255,7 +255,7 @@ public class ContractProcessorImpl implements ContractProcessor {
         int totalExpected = progressTracker.getPatientsExpected();
         //AB2D-6157 Update mismatch job failure to pass in slack alerts
         //Magic 35 is the biggest difference (April 2024) and alert threshold.
-        if ((totalQueued != totalExpected) && (Math.abs(totalQueued-totalExpected) > 35)) {
+        if ((totalQueued != totalExpected) && (Math.abs(totalQueued - totalExpected) > 35)) {
             throw new ContractProcessingException("expected " + totalExpected +
                     " patients from database but retrieved " + totalQueued);
         }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/ContractProcessorImpl.java
@@ -253,8 +253,9 @@ public class ContractProcessorImpl implements ContractProcessor {
         ProgressTracker progressTracker = jobProgressService.getStatus(jobUuid);
         int totalQueued = progressTracker.getPatientRequestQueuedCount();
         int totalExpected = progressTracker.getPatientsExpected();
-
-        if (totalQueued != totalExpected) {
+        //AB2D-6157 Update mismatch job failure to pass in slack alerts
+        //Magic 35 is the biggest difference (April 2024) and alert threshold.
+        if ((totalQueued != totalExpected) && (Math.abs(totalQueued-totalExpected) > 35)) {
             throw new ContractProcessingException("expected " + totalExpected +
                     " patients from database but retrieved " + totalQueued);
         }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/ContractProcessorUnitTest.java
@@ -215,7 +215,7 @@ class ContractProcessorUnitTest {
     void whenExpectedPatientsNotMatchActualPatientsFail() {
         when(coverageDriver.pageCoverage(any(CoveragePagingRequest.class)))
                 .thenReturn(new CoveragePagingResult(createPatientsByContractResponse(contractForCoverageDTO, 1), null));
-        when(coverageDriver.numberOfBeneficiariesToProcess(any(Job.class), any(ContractDTO.class))).thenReturn(3);
+        when(coverageDriver.numberOfBeneficiariesToProcess(any(Job.class), any(ContractDTO.class))).thenReturn(37);
 
         ContractProcessingException exception = assertThrows(ContractProcessingException.class, () -> cut.process(job));
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6157

## 🛠 Changes

Added threshold for the alert

## ℹ️ Context

Currently slack shows jobs have failed due to a mismatch in data that is cause by the Null MBI issue. 

We'd like to update the slack alert to only show a failure if the mis matches reach a threshold higher that 10. Otherwise the job should show as a success as the job does complete for the PDP to receive the data. 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
