### PR TITLE
AB2D-6168 Do not throw mismatch slack alerts for S4802

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -157,6 +157,9 @@ public class JobProcessorImpl implements JobProcessor {
                     job.getJobUuid(), job.getContractNumber());
             return;
         }
+        //Custom fix for Centene
+        if(job.getContractNumber().equals("S4802"))
+            return;
 
         // Number in database
         int expectedPatients = progressTracker.getPatientsExpected();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -158,7 +158,7 @@ public class JobProcessorImpl implements JobProcessor {
             return;
         }
         //Custom fix for Centene
-        if(job.getContractNumber().equals("S4802"))
+        if (job.getContractNumber().equals("S4802"))
             return;
 
         // Number in database


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6168

## 🛠 Changes

Disabled mismatch alert for S4802

## ℹ️ Context

Currently slack shows mismatch alert like 

EOB_JOB_CALL_FAILURE [d6620aa3-cc09-4cfd-bdaf-0fb10eb5cc2e] expected beneficiaries (8783362) does not match processed beneficiaries (9155611)ab2d-east-prod

EOB_JOB_QUEUE_MISMATCH [d6620aa3-cc09-4cfd-bdaf-0fb10eb5cc2e] expected beneficiaries (8783362) does not match queued beneficiaries (9155611)

We'd like do not see these types of slack alert for S4802 contract because of custom 1 month solution

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
