### PR TITLE
AB2D-6157 Update mismatch job failure to pass in slack alerts

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -170,14 +170,16 @@ public class JobProcessorImpl implements JobProcessor {
         // Number of retrievals processed
         int processedPatients = progressTracker.getPatientRequestProcessedCount();
 
-        if (expectedPatients != queuedPatients) {
+        //AB2D-6157 Update mismatch job failure to pass in slack alerts
+        //Magic 35 is the biggest difference (April 2024) and alert threshold.
+        if ((expectedPatients != queuedPatients) && (Math.abs(expectedPatients - queuedPatients) > 35)) {
             String alertMessage = String.format(EOB_JOB_QUEUE_MISMATCH + " [%s] expected beneficiaries (%d) does not match queued beneficiaries (%d)",
                     job.getJobUuid(), expectedPatients, queuedPatients);
             log.error(alertMessage);
             eventLogger.alert(alertMessage, PROD_LIST);
         }
 
-        if (expectedPatients != processedPatients) {
+        if ((expectedPatients != processedPatients) && (Math.abs(expectedPatients - processedPatients) > 35)) {
             String alertMessage = String.format(EOB_JOB_CALL_FAILURE + " [%s] expected beneficiaries (%d) does not match processed beneficiaries (%d)",
                     job.getJobUuid(), expectedPatients, queuedPatients);
             log.error(alertMessage);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorUnitTest.java
@@ -219,7 +219,7 @@ class JobProcessorUnitTest {
     @DisplayName("When verifying that progress tracker numbers do not match, then alert")
     void whenProgressTrackerVerificationFails_thenAlerts() {
 
-        jobChannelService.sendUpdate(job.getJobUuid(), JobMeasure.PATIENTS_EXPECTED, 10);
+        jobChannelService.sendUpdate(job.getJobUuid(), JobMeasure.PATIENTS_EXPECTED, 60);
         jobChannelService.sendUpdate(job.getJobUuid(), JobMeasure.PATIENT_REQUEST_QUEUED, 9);
         jobChannelService.sendUpdate(job.getJobUuid(), JobMeasure.PATIENT_REQUESTS_PROCESSED, 9);
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6157

## 🛠 Changes

Disabled mismatch alert if threshold > 35

## ℹ️ Context

Follow up for https://github.com/CMSgov/ab2d/pull/1351

Currently slack shows jobs have failed due to a mismatch in data that is cause by the Null MBI issue.

We'd like to update the slack alert to only show a failure if the mis matches reach a threshold higher that 10. Otherwise the job should show as a success as the job does complete for the PDP to receive the data.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
 
Unit tests passed
