### PR TITLE
[AB2D-6187] increase `coverage` test coverage

### DIFF
--- a/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
@@ -217,6 +217,8 @@ public class CoverageServiceRepository {
             " ORDER BY coverage.contract, coverage.year, coverage.month, " +
                     " coverage.bene_coverage_period_id, coverage.bene_coverage_search_event_id ";
 
+    private static String vacuumCoverage = "VACUUM coverage";
+
     private final DataSource dataSource;
     private final CoveragePeriodRepository coveragePeriodRepo;
     private final CoverageSearchEventRepository coverageSearchEventRepo;
@@ -754,7 +756,7 @@ public class CoverageServiceRepository {
     @Trace
     public void vacuumCoverage() {
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = connection.prepareStatement("VACUUM coverage")) {
+             PreparedStatement statement = connection.prepareStatement(vacuumCoverage)) {
             statement.execute();
         } catch (SQLException exception) {
             throw new RuntimeException("Could not vacuum coverage table", exception);

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -2,7 +2,9 @@ package gov.cms.ab2d.coverage.repository;
 
 import gov.cms.ab2d.common.feign.ContractFeignClient;
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.coverage.model.ContractForCoverageDTO;
 import gov.cms.ab2d.coverage.model.CoverageMembership;
+import gov.cms.ab2d.coverage.model.CoveragePagingRequest;
 import gov.cms.ab2d.coverage.model.CoveragePeriod;
 import gov.cms.ab2d.coverage.model.CoverageSearch;
 import gov.cms.ab2d.coverage.model.CoverageSearchEvent;
@@ -31,6 +33,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import static gov.cms.ab2d.common.util.PropertyConstants.OPT_OUT_ON;
@@ -151,6 +155,20 @@ class CoverageServiceRepositoryTest {
         assertEquals(
             new LinkedHashSet<String>(Arrays.asList("historic", "mbi", "string")),
             coverageMembership.getIdentifiers().getHistoricMbis()
+        );
+    }
+
+    @Test
+    void testPageCoverage() {
+        OffsetDateTime now = OffsetDateTime.of(1999, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC);
+        ContractForCoverageDTO contract = new ContractForCoverageDTO(
+            "stuff", now, ContractForCoverageDTO.ContractType.NORMAL
+        );
+        CoveragePagingRequest page = new CoveragePagingRequest(1, 1L, contract, now);
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {coverageServiceRepository.pageCoverage(page);}
         );
     }
 

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -28,7 +28,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.sql.DataSource;
-
 import java.lang.reflect.Field;
 import java.util.*;
 

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -29,8 +29,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.sql.DataSource;
 
+import java.lang.reflect.Field;
 import java.util.*;
-import java.lang.reflect.*;
 
 import static gov.cms.ab2d.common.util.PropertyConstants.OPT_OUT_ON;
 import static org.junit.Assert.assertThrows;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6187

## 🛠 Changes

Adds tests for `CoverageServiceRepository`. Modifies the source code very slightly in the name of getting test coverage on the `vacuumCoverage` method.

## ℹ️ Context

This is a part of my journey to achieve 90% test coverage everywhere