### PR TITLE
[AB2D-6190] Ignore Custom fix for Centene

### DIFF
--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -14,7 +14,7 @@
         <project.root>${basedir}/..</project.root>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <sonar.coverage.exclusions>**/PatientClaimsProcessorImpl.java,**/ContractProcessorImpl.java,**/CoverageDriverImpl.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>**/PatientClaimsProcessorImpl.java,**/ContractProcessorImpl.java,**/CoverageDriverImpl.java,**/JobProcessorImpl.java</sonar.coverage.exclusions>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6190

## 🛠 Changes

Ignore code coverage for `JobProcessorImpl`

## ℹ️ Context

`JobProcessorImpl` [has a custom fix for Centene that doesn't have code coverage](https://sonarqube.cloud.cms.gov/component_measures?id=ab2d-project&metric=new_lines_to_cover&branch=main&view=list&selected=ab2d-project%3Aworker%2Fsrc%2Fmain%2Fjava%2Fgov%2Fcms%2Fab2d%2Fworker%2Fprocessor%2FJobProcessorImpl.java), which is making the SonarQube quality gate fail. Because of this, CI has been failing in the `main` branch for quite some time. In order for CI to be passing again, we have to ignore this file in code coverage.