### PR TITLE
Rename current mbi  opt out column name

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -165,3 +165,5 @@ databaseChangeLog:
       file: db/changelog/v2024/misc_opt_out_attribution.sql
   - include:
       file: db/changelog/v2024/add_until_column.sql
+  - include:
+      file: db/changelog/v2024/ab2d_6151_rename_column.sql

--- a/common/src/main/resources/db/changelog/v2024/ab2d_6151_rename_column.sql
+++ b/common/src/main/resources/db/changelog/v2024/ab2d_6151_rename_column.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'current_mbi' AND
+column_name = 'opt_out_flag')
+    THEN
+ALTER TABLE public.current_mbi RENAME opt_out_flag TO share_data;
+END IF;
+END
+$$;

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepository.java
@@ -102,7 +102,7 @@ public class CoverageServiceRepository {
 
     private static final String SELECT_DISTINCT_OPTOUT_COVERAGE_BY_PERIOD_COUNT = "SELECT COUNT(DISTINCT beneficiary_id) FROM coverage c " +
             " join current_mbi m on  c.current_mbi=m.mbi" +
-            " WHERE bene_coverage_period_id IN(:ids) AND contract = :contract AND year IN (:years) AND opt_out_flag is not false and current_mbi is not null";
+            " WHERE bene_coverage_period_id IN(:ids) AND contract = :contract AND year IN (:years) AND share_data is not false and current_mbi is not null";
 
     /**
      * Delete all coverage associated with a single update from BFD {@link CoverageSearchEvent}
@@ -170,7 +170,7 @@ public class CoverageServiceRepository {
     private static final String SELECT_OPTOUT_COVERAGE_WITHOUT_CURSOR =
             "SELECT beneficiary_id, current_mbi, historic_mbis, year, month " +
                     " FROM coverage c join current_mbi m on  c.current_mbi=m.mbi " +
-                    " WHERE contract = :contract and year IN (:years) and opt_out_flag is not false and current_mbi is not null" +
+                    " WHERE contract = :contract and year IN (:years) and share_data is not false and current_mbi is not null" +
                     " ORDER BY beneficiary_id " +
                     " LIMIT :limit";
 
@@ -192,7 +192,7 @@ public class CoverageServiceRepository {
     private static final String SELECT_OPTOUT_COVERAGE_WITH_CURSOR =
             "SELECT beneficiary_id, current_mbi, historic_mbis, year, month " +
                     " FROM coverage c join current_mbi m on  c.current_mbi=m.mbi" +
-                    " WHERE contract = :contract and year IN (:years) and  current_mbi is not null and opt_out_flag is not false AND beneficiary_id >= :cursor " +
+                    " WHERE contract = :contract and year IN (:years) and  current_mbi is not null and share_data is not false AND beneficiary_id >= :cursor " +
                     " ORDER BY beneficiary_id " +
                     " LIMIT :limit";
 

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -108,8 +108,8 @@ class CoverageServiceRepositoryTest {
     @Test
     void countBeneficiariesByPeriodsWithOptOutTest() {
         Mockito.when(mockPropertiesService.isToggleOn(OPT_OUT_ON, false)).thenReturn(true);
-       //The expected number is 3, and is the same as in previous test, since switching opt_out_flag from false to true is only available in OptOutLambda.
-        //Here all beneficiaries have opt_out_flag equals false by default.
+       //The expected number is 3, and is the same as in previous test, since switching shared_data from false to true is only available in OptOutLambda.
+        //Here all beneficiaries have shared_data equals false by default.
         Assertions.assertEquals(0, coverageServiceRepository.countBeneficiariesByPeriods(List.of(period1Jan.getId()), "TST-12"));
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6151

## 🛠 Changes



We should update the column name to data_sharing or share_data:
column name of opt_out is updated to share_data
no reduction in test coverage
 

## ℹ️ Context

1-800 opt out was rolled out on 4/6. The data sharing preference field in ICD can be true or false (or blank): When it is true, it means the beneficiary has chosen to share their data; when it is false, it means beneficiary has chosen to not share their data. The data sharing preference (specific in ICD) field is currently mapped to opt_out, which causes confusion as the column name contradicts the meaning of the field. column name of opt_out is updated to share_data

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Verify to make sure that changes update the table column name .
<img width="209" alt="image" src="https://github.com/user-attachments/assets/f92d8e86-faab-4f37-b4f7-eda94e37a9e1">

