### PR TITLE
[AB2D-6187] increase `api` test coverage

### DIFF
--- a/api/src/test/java/gov/cms/ab2d/api/log/LogstashHeaderFilterTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/log/LogstashHeaderFilterTest.java
@@ -21,6 +21,12 @@ class LogstashHeaderFilterTest {
       logstashHeaderFilter.getIncludes(),
       new HashSet<>(Arrays.asList("cats", "dogs"))
     );
+
+    logstashHeaderFilter.removeInclude("dogs");
+    assertEquals(
+      logstashHeaderFilter.getIncludes(),
+      new HashSet<>(Arrays.asList("cats"))
+    );
   }
 
   @Test
@@ -31,6 +37,12 @@ class LogstashHeaderFilterTest {
     assertEquals(
       logstashHeaderFilter.getExcludes(),
       new HashSet<>(Arrays.asList("lizards", "snakes"))
+    );
+
+    logstashHeaderFilter.removeExclude("snakes");
+    assertEquals(
+      logstashHeaderFilter.getExcludes(),
+      new HashSet<>(Arrays.asList("lizards"))
     );
   }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6187

## 🛠 Changes

Adds test coverage for `LogstashHeaderFilter`, specifically for a method that I missed yesterday with https://github.com/CMSgov/ab2d/pull/1386

## ℹ️ Context

This is a part of my journey to achieve 90% test coverage everywhere