### PR TITLE
Update SecurityConfig.java

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final String[] authExceptions = new String[]{"/swagger-ui/**", "/configuration/**",
             "/swagger-resources/**", "/v3/api-docs/**", "/webjars/**",
-            AKAMAI_TEST_OBJECT, "/favicon.ico", "/error", HEALTH_ENDPOINT, STATUS_ENDPOINT};
+            AKAMAI_TEST_OBJECT, "/favicon.ico", "/error", HEALTH_ENDPOINT, STATUS_ENDPOINT,
+            "/metadata"};
 
     @Override
     protected void configure(HttpSecurity security) throws Exception {


### PR DESCRIPTION
Add "/metadata" to authExceptions so that you don't need a bearer token to get a CapabilityStatement.

[## 🎫 Ticket](https://jira.cms.gov/browse/AB2D-6253)

## 🛠 Changes
Changed one file: SecurityConfig.java. Add "/metadata" to authExceptions.
This makes it so that a bearer token is not required to access the metadata endpoint.

## ℹ️ Context
The Inferno and Touchstone both try to access the /metadata endpoint in their bulk IG test suite. Currently this only works if you pass in a bearer token, which they don't. This change should make those conformance tests work.

## 🧪 Validation
Once this is deployed to the ab2d sandbox, see if a request to the metadata endpoint works without a bearer token. This will be addressed in https://jira.cms.gov/browse/AB2D-6286
