### PR TITLE
AB2D-6303 Get CapabilityStatement without bearer token

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/security/FilterChainExceptionHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/FilterChainExceptionHandler.java
@@ -24,8 +24,11 @@ public class FilterChainExceptionHandler extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
         try {
+            log.warn("AB2D-6303 doFilterInternal before doFilter. filterChain: {}", filterChain);
             filterChain.doFilter(request, response);
+            log.warn("AB2D-6303 doFilterInternal after doFilter");
         } catch (Exception e) {
+            log.warn("AB2D-6303 doFilterInternal in catch. Exception: {}", e);
             handlerExceptionResolver.resolveException(request, response, null, e);
         }
     }

--- a/api/src/main/java/gov/cms/ab2d/api/security/FilterChainExceptionHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/FilterChainExceptionHandler.java
@@ -24,11 +24,8 @@ public class FilterChainExceptionHandler extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
         try {
-            log.warn("AB2D-6303 doFilterInternal before doFilter. filterChain: {}", filterChain);
             filterChain.doFilter(request, response);
-            log.warn("AB2D-6303 doFilterInternal after doFilter");
         } catch (Exception e) {
-            log.warn("AB2D-6303 doFilterInternal in catch. Exception: {}", e);
             handlerExceptionResolver.resolveException(request, response, null, e);
         }
     }

--- a/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/JwtTokenAuthenticationFilter.java
@@ -100,7 +100,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        log.warn("AB2D-6303 Entering doFilterInternal");
 
         String jobId = UtilMethods.parseJobId(request.getRequestURI());
 
@@ -111,7 +110,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             chain.doFilter(request, response);
             return;
         }
-        log.warn("AB2D-6303 After shouldBePublic");
 
         String token = null;
         String client;
@@ -120,7 +118,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             token = getToken(request);
             client = getClientId(token);
         } catch (Exception ex) {
-            log.warn("AB2D-6303 Throwing exception after getToken");
             logApiRequestEvent(request, token, null, jobId);
             throw ex;
         }
@@ -163,7 +160,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
         pdpClientService.setupClientAndRolesInSecurityContext(pdpClient, request);
 
         // go to the next filter in the filter chain
-        log.warn("AB2D-6303 calling chain.doFilter");
         chain.doFilter(request, response);
     }
 
@@ -208,7 +204,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
      * @return true if it's public
      */
     private boolean shouldBePublic(String requestUri) {
-        log.warn("AB2D-6303 Entering shouldBePublic");
         if (SWAGGER_LIST.stream().anyMatch(requestUri::startsWith)) {
             log.debug("Swagger requested");
             return true;
@@ -232,7 +227,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             log.debug("metadata requested");
             return true;
         }
-        log.warn("AB2D-6303 Exiting shouldBePublic with false");
 
         return false;
     }
@@ -244,17 +238,14 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
      * @return - the value of the bearer token
      */
     private String getToken(HttpServletRequest request) {
-        log.warn("AB2D-6303 Entering getToken");
         String header = request.getHeader(jwtConfig.getHeader());
         if (header == null) {
             String noHeaderMsg = "Authorization header for token was not present";
-            log.warn("AB2D-6303 header not present");
             log.error(noHeaderMsg);
             throw new InvalidAuthHeaderException(noHeaderMsg);
         }
 
         if (!header.startsWith(jwtConfig.getPrefix())) {
-            log.warn("AB2D-6303 header wrong prefix");
             log.error("Header did not start with prefix {}", jwtConfig.getPrefix());
             throw new InvalidAuthHeaderException("Authorization header must start with " + jwtConfig.getPrefix());
         }
@@ -262,7 +253,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
         String token = header.replace(jwtConfig.getPrefix(), "");
 
         if (Strings.isNullOrEmpty(token)) {
-            log.warn("AB2D-6303 header wrong prefix");
             String emptyTokenMsg = "Did not receive a token for JWT authentication";
             log.error(emptyTokenMsg);
             throw new MissingTokenException(emptyTokenMsg);

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -81,6 +82,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     logSecurityException(request, authException, HttpServletResponse.SC_UNAUTHORIZED);
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 });
+        showSecurityContext(security);
     }
 
     @Override
@@ -112,5 +114,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         } catch (Exception exception) {
             log.error("Could not additional logs for exception: " + exception.getCause());
         }
+    }
+
+    private void showSecurityContext (HttpSecurity security) {
+        ApplicationContext ctx = (ApplicationContext) security.getSharedObject(ApplicationContext.class);
+        log.warn("AB2D-6303 HttpSecurity bean names: {}", ctx.getBeanDefinitionNames());
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -49,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final String[] authExceptions = new String[]{"/swagger-ui/**", "/configuration/**",
             "/swagger-resources/**", "/v3/api-docs/**", "/webjars/**",
             AKAMAI_TEST_OBJECT, "/favicon.ico", "/error", HEALTH_ENDPOINT, STATUS_ENDPOINT,
-            "/metadata"};
+            "/**/metadata"};
 
     @Override
     protected void configure(HttpSecurity security) throws Exception {
@@ -63,9 +62,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             // Add a filter to validate the tokens with every request.
             .addFilterAfter(jwtTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests()
+            .antMatchers(authExceptions).permitAll()
             .antMatchers(API_PREFIX_V1 + ADMIN_PREFIX + "/**").hasAuthority(ADMIN_ROLE)
             .antMatchers(API_PREFIX_V1 + FHIR_PREFIX + "/**").hasAnyAuthority(SPONSOR_ROLE)
-                .antMatchers(authExceptions).permitAll()
             .anyRequest().authenticated();
 
         // Override default behavior to add more informative logs
@@ -82,7 +81,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     logSecurityException(request, authException, HttpServletResponse.SC_UNAUTHORIZED);
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 });
-        showSecurityContext(security);
     }
 
     @Override
@@ -114,10 +112,5 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         } catch (Exception exception) {
             log.error("Could not additional logs for exception: " + exception.getCause());
         }
-    }
-
-    private void showSecurityContext (HttpSecurity security) {
-        ApplicationContext ctx = (ApplicationContext) security.getSharedObject(ApplicationContext.class);
-        log.warn("AB2D-6303 HttpSecurity bean names: {}", ctx.getBeanDefinitionNames());
     }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6303

## 🛠 Changes

Reordered antMatchers in SecurityConfig so that authExceptions come first.
Expanded the authExceptions for metadata from "/metadata" to "**/metadata" so that it works with v1 and v2. Added a /metadata clause to shouldBePublic.

## ℹ️ Context

In order to conform with the Bulk Data IG (and pretty much any server IG) it should be possible to get a CapabilityStatement from the /metadata endpoint without having a bearer token.

## 🧪 Validation

Deployed branch to IMPL and checked to see that you can get a CapabilityStatement from the /metadata endpoint for both v1 and v2 by using Postman.
