### PR TITLE
[AB2D-6305] - Implement a fix for job cancel polling response

### DIFF
--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -56,10 +56,10 @@ jobs:
         run: |
           mvn -ntp -U clean
 
+      - name: Run unit and integration tests
+        run: |
+            mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL} test -pl common,job,coverage,api,worker
+
       - name: SonarQube analysis
         run: |
           mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} package sonar:sonar -Dsonar.projectKey=ab2d-project -Dsonar.qualitygate.wait=true -DskipTests -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
-
-      - name: Run unit and integration tests
-        run: |
-          mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL} test -pl common,job,coverage,api,worker

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: SonarQube analysis
         run: |
-          mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} sonar:sonar -Dsonar.projectKey=ab2d-project -Dsonar.qualitygate.wait=true -DskipTests -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
+          mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} package sonar:sonar -Dsonar.projectKey=ab2d-project -Dsonar.qualitygate.wait=true -DskipTests -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
 
       - name: Run unit and integration tests
         run: |

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: SonarQube analysis
         run: |
-          mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} compile sonar:sonar -Dsonar.projectKey=ab2d-project -Dsonar.qualitygate.wait=true -DskipTests -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
+          mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} sonar:sonar -Dsonar.projectKey=ab2d-project -Dsonar.qualitygate.wait=true -DskipTests -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL}
 
       - name: Run unit and integration tests
         run: |

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Get entire history for SonarQube
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/api/src/main/java/gov/cms/ab2d/api/config/OpenAPIConfig.java
+++ b/api/src/main/java/gov/cms/ab2d/api/config/OpenAPIConfig.java
@@ -142,7 +142,7 @@ public class OpenAPIConfig {
     @JsonPropertyOrder({
             "text"
     })
-    static class Details {
+    public static class Details {
 
         @JsonProperty("text")
         private String text;
@@ -177,7 +177,7 @@ public class OpenAPIConfig {
             "code",
             "details"
     })
-    static class Issue {
+    public static class Issue {
         @JsonProperty("severity")
         private String severity;
         @JsonProperty("code")

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -130,7 +130,7 @@ public class StatusCommon {
 
         OpenAPIConfig.OperationOutcome outcome = openApi.new OperationOutcome();
         outcome.setResourceType("OperationOutcome");
-        
+
         OpenAPIConfig.Details details = new OpenAPIConfig.Details();
         details.setText("Job is canceled.");
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -129,6 +129,8 @@ public class StatusCommon {
         responseHeaders.setContentType(APPLICATION_JSON);
 
         OpenAPIConfig.OperationOutcome outcome = openApi.new OperationOutcome();
+        outcome.setResourceType("OperationOutcome");
+        
         OpenAPIConfig.Details details = new OpenAPIConfig.Details();
         details.setText("Job is canceled.");
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -127,10 +127,10 @@ public class StatusCommon {
         responseHeaders.setContentType(APPLICATION_JSON);
 
         OperationOutcome outcome = new OperationOutcome();
-        
+
         OpenAPIConfig.Details details = new OpenAPIConfig.Details();
         details.setText("Job is canceled.");
-        
+
         OpenAPIConfig.Issue issue = new OpenAPIConfig.Issue();
         issue.setDetails(details);
         issue.setCode("deleted");

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -124,7 +124,7 @@ public class StatusCommon {
         return resp;
     }
 
-    private ResponseEntity getCanceledResponse(JobPollResult jobPollResult, String jobUuid, HttpServletRequest request) {
+    protected ResponseEntity<OpenAPIConfig.OperationOutcome> getCanceledResponse(JobPollResult jobPollResult, String jobUuid, HttpServletRequest request) {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.setContentType(APPLICATION_JSON);
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -137,7 +137,7 @@ public class StatusCommon {
         OpenAPIConfig.Issue issue = new OpenAPIConfig.Issue();
         issue.setDetails(details);
         issue.setCode("deleted");
-        issue.setSeverity("information");
+        issue.setSeverity("error");
 
         List<OpenAPIConfig.Issue> issuesList = new ArrayList<>();
         issuesList.add(issue);

--- a/api/src/test/java/gov/cms/ab2d/api/controller/common/StatusCommonTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/common/StatusCommonTest.java
@@ -101,9 +101,9 @@ class StatusCommonTest {
   @Test
   void testDoStatus5() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.CANCELLED);
-    assertThrows(JobProcessingException.class, () -> {
-      statusCommon.doStatus("1234", req, "prefix");
-    });
+    assertNotNull(
+      statusCommon.doStatus("1234", req, "prefix")
+    );
   }
 
   @Test
@@ -117,6 +117,13 @@ class StatusCommonTest {
   void testGetJobCompletedResponse() {
     assertNotNull(
       statusCommon.getJobCompletedResponse(jobPollResult, "1234", req, "prefix")
+    );
+  }
+
+  @Test
+  void testGetJobCanceledResponse() {
+    assertNotNull(
+      statusCommon.getCanceledResponse(jobPollResult, "1234", req)
     );
   }
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/common/StatusCommonTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/common/StatusCommonTest.java
@@ -67,7 +67,7 @@ class StatusCommonTest {
   }
 
   @Test
-  void testDoStatus1() {
+  void testDoStatusSuccessful() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.SUCCESSFUL);
     assertNotNull(
       statusCommon.doStatus("1234", req, "prefix")
@@ -75,7 +75,7 @@ class StatusCommonTest {
   }
 
   @Test
-  void testDoStatus2() {
+  void testDoStatusSubmitted() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.SUBMITTED);
     assertNotNull(
       statusCommon.doStatus("1234", req, "prefix")
@@ -83,7 +83,7 @@ class StatusCommonTest {
   }
 
   @Test
-  void testDoStatus3() {
+  void testDoStatusInProgress() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.IN_PROGRESS);
     assertNotNull(
       statusCommon.doStatus("1234", req, "prefix")
@@ -91,7 +91,7 @@ class StatusCommonTest {
   }
 
   @Test
-  void testDoStatus4() {
+  void testDoStatusFailed() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.FAILED);
     assertThrows(JobProcessingException.class, () -> {
       statusCommon.doStatus("1234", req, "prefix");
@@ -99,7 +99,7 @@ class StatusCommonTest {
   }
 
   @Test
-  void testDoStatus5() {
+  void testDoStatusCanceled() {
     when(jobPollResult.getStatus()).thenReturn(JobStatus.CANCELLED);
     assertNotNull(
       statusCommon.doStatus("1234", req, "prefix")


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6305

## 🛠 Changes

Added a case to the switch statement in StatusCommon for when a job is in **canceled** status. (Previously this just went to the default case which was returning a 500 error). 
Added a function to get and create a proper response object for when status is **canceled** as outlined in [FHIR bulk data export guidelines]https://build.fhir.org/ig/HL7/bulk-data/export.html


## ℹ️ Context
AB2D fails part of Version 0.10.0 of the Inferno [Bulk Data Access Test Kit](https://inferno.healthit.gov/test-kits/bulk-data/) Specificallly, test 2.3.3.02. We get a failure when requesting the status of a job which has been cancled. The test is looking for a 404 response, but we instead return a 500.

## 🧪 Validation

To be deployed and tested on IMPL (WIP)
