### PR TITLE
PLT-679 Tag commits to main for promotion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
           # Push to special tag for promotion if this is run on a push to main
           if [ "$GITHUB_REF" == "refs/heads/main" ]; then
-            docker tag $ECR_REPO_URI:ab2d-$DEPLOYMENT_ENV-$SHA_SHORT $ECR_REPO_URI:ab2d-main-$SHA_SHORT
+            docker tag $ECR_REPO_URI:ab2d-$DEPLOYMENT_ENV-$SHA_SHORT $ECR_REPO_URI:main-$SHA_SHORT
           fi
 
           echo "Pushing image"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,5 +81,11 @@ jobs:
           docker build \
             -t "${ECR_REPO_URI}:ab2d-${DEPLOYMENT_ENV}-$SHA_SHORT" \
             -t "${ECR_REPO_URI}:ab2d-${DEPLOYMENT_ENV}-latest" .
+
+          # Push to special tag for promotion if this is run on a push to main
+          if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+            docker tag $ECR_REPO_URI:ab2d-$DEPLOYMENT_ENV-$SHA_SHORT $ECR_REPO_URI:ab2d-main-$SHA_SHORT
+          fi
+
           echo "Pushing image"
           docker push "${ECR_REPO_URI}" --all-tags

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,4 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
 
       - name: Deploy ECS service to run on latest image in ECR
-        run: aws ecs update-service --cluster ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --service ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --force-new-deployment
+        run: aws ecs update-service --cluster ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --service ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --force-new-deployment > /dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
           - test
           - sbx
           - prod
-          - prod-test
+          - prod_test
       module:
         required: true
         type: choice
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     env:
       DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
-      ACCOUNT: ${{ inputs.environment == 'prod-test' && 'prod' || inputs.environment }}
+      ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,4 @@ jobs:
         run: |
           echo "Deploying service $SERVICE_NAME"
           aws ecs update-service --cluster "$SERVICE_NAME" --service "$SERVICE_NAME" --force-new-deployment > /dev/null
+          aws ecs wait services-stable --cluster "$SERVICE_NAME" --services "$SERVICE_NAME"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,15 +33,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
-      ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
-
     steps:
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        env:
+          ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
-
       - name: Deploy ECS service to run on latest image in ECR
-        run: aws ecs update-service --cluster ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --service ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --force-new-deployment > /dev/null
+        env:
+          SERVICE_NAME: ab2d-${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}-${{ inputs.module }}
+        run: |
+          echo "Deploying service $SERVICE_NAME"
+          aws ecs update-service --cluster "$SERVICE_NAME" --service "$SERVICE_NAME" --force-new-deployment > /dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,11 +38,10 @@ jobs:
       ACCOUNT: ${{ inputs.environment == 'prod-test' && 'prod' || inputs.environment }}
 
     steps:
-      - name: Assume role in AB2D ${{ env.ACCOUNT }} account
-        uses: aws-actions/configure-aws-credentials@v3
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
 
-      - name: Deploy latest image in ECR to ECS
+      - name: Deploy ECS service to run on latest image in ECR
         run: aws ecs update-service --cluster ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --service ab2d-${DEPLOYMENT_ENV}-${{ inputs.module }} --force-new-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v3
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           REPO="ab2d_${{ inputs.module }}"
           #SHA_SHORT=$(git rev-parse --short HEAD)
-          SHA_SHORT=82d2398 # TODO remove after testing
+          SHA_SHORT=7da005a # TODO remove after testing
 
           echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
           MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHA_SHORT --output text --query 'images[].imageManifest')

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -48,15 +48,15 @@ jobs:
           SHA_SHORT=7da005a # TODO remove after testing
           CONTENT_TYPE="application/vnd.docker.distribution.manifest.v2+json"
 
-          aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_REPO_DOMAIN"
+          TOKEN=$(aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken')
 
           echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
-          MANIFEST=$(curl -H "Accept: $CONTENT_TYPE" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/main-$SHA_SHORT")
+          MANIFEST=$(curl -sS -H "Authorization: Basic $TOKEN" -H "Accept: $CONTENT_TYPE" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/main-$SHA_SHORT")
 
           SHA_TAG="ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
           echo "Adding the tag for $SHA_TAG to main-$SHA_SHORT image"
-          curl -X PUT -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$SHA_TAG"
+          curl -sS -X PUT -H "Authorization: Basic $TOKEN" -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$SHA_TAG"
 
           LATEST_TAG="ab2d-$DEPLOYMENT_ENV-latest"
           echo "Adding the tag for $LATEST_TAG to main-$SHA_SHORT image"
-          curl -X PUT -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$LATEST_TAG"
+          curl -sS -X PUT -H "Authorization: Basic $TOKEN" -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$LATEST_TAG"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,62 +17,53 @@ on:
         options:
           - sbx
           - prod
-          - prod-test  
+          - prod-test
       module:
         required: true
         type: choice
         options:
-          - api 
-          - worker 
-          
+          - api
+          - worker
+
 permissions:
   contents: read
   id-token: write
-  
+
 jobs:
   promote:
     runs-on: ubuntu-latest
-    env:
-        AWS_REGION: ${{ vars.AWS_REGION }}
-        DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
-
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Assume role in AB2D Management account
-        uses: aws-actions/configure-aws-credentials@v3
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.MGMT_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-mgmt-github-actions    
-          
+          role-to-assume: arn:aws:iam::${{ secrets.MGMT_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-mgmt-github-actions
       - name: Retag images in ECR
+        env:
+          DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
         run: |
-          SHA_SHORT=$(git rev-parse --short HEAD)        
-          ECR_REPO_DOMAIN="${{ secrets.MGMT_ACCOUNT_ID }}.dkr.ecr.$AWS_REGION.amazonaws.com"
-          ECR_REPO_URI="$ECR_REPO_DOMAIN/ab2d_${{ inputs.module }}"
+          REPO="ab2d_${{ inputs.module }}"
+          SHA_SHORT=$(git rev-parse --short HEAD)
 
-          # Define target tags based on the environment
-          if [ "${{ inputs.environment }}" == "sbx" ]; then
-            TARGET_TAG="ab2d-sbx-sandbox-latest"
-          elif [ "${{ inputs.environment }}" == "prod" ]; then
-            TARGET_TAG="ab2d-east-prod-latest"
-          elif [ "${{ inputs.environment }}" == "prod-test" ]; then
-            TARGET_TAG="ab2d-east-prod-test-latest"
-          else
-            echo "Unsupported environment: ${{ inputs.environment }}"
-            exit 1
+          # Get the manifest of the image pushed for latest commit to main
+          MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHORT_SHA --output text --query 'images[].imageManifest')
+
+          # Add the tag for sha
+          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "ab2d-$DEPLOYMENT_ENV-$SHA_SHORT" --image-manifest "$MANIFEST"); then
+            if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
+              echo "Image for main-$SHORT_SHA has already been tagged with ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
+            else
+              >&2 echo "$OUT"
+              exit 1
+            fi
           fi
 
-          IMAGE_EXISTS=$(aws ecr describe-images --repository-name "ab2d_${{ inputs.module }}" --image-ids imageTag=$TARGET_TAG --query 'imageDetails' --output text)
-
-          if [ -n "$IMAGE_EXISTS" ]; then
-            echo "Image with tag $TARGET_TAG already exists. Skipping put-image."
-          else
-            # Get the manifest of the latest test image
-            MANIFEST=$(aws ecr batch-get-image --repository-name "ab2d_${{ inputs.module }}" --image-ids imageTag=ab2d-east-impl-latest --output text --query 'images[].imageManifest' --debug)
-
-          # Retag the image
-          aws ecr put-image --repository-name "ab2d_${{ inputs.module }}" --image-tag "$TARGET_TAG-$SHA_SHORTs" --image-manifest "$MANIFEST"
-          fi  
-
+          # Add the tag for latest
+          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "ab2d-$DEPLOYMENT_ENV-latest" --image-manifest "$MANIFEST"); then
+            if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
+              echo "Image for main-$SHORT_SHA has already been tagged with ab2d-$DEPLOYMENT_ENV-latest"
+            else
+              >&2 echo "$OUT"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Retag images in ECR
         env:
           DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
+          REPO: ab2d_${{ inputs.module }}
         run: |
-          REPO="ab2d_${{ inputs.module }}"
           #SHA_SHORT=$(git rev-parse --short HEAD)
           SHA_SHORT=7da005a # TODO remove after testing
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -41,33 +41,22 @@ jobs:
       - name: Retag images in ECR
         env:
           DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
-          REPO: ab2d_${{ inputs.module }}
+          ECR_REPO_DOMAIN: ${{ secrets.MGMT_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
+          ECR_REPO: ab2d_${{ inputs.module }}
         run: |
           #SHA_SHORT=$(git rev-parse --short HEAD)
           SHA_SHORT=7da005a # TODO remove after testing
+          CONTENT_TYPE="application/vnd.docker.distribution.manifest.v2+json"
+
+          aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_REPO_DOMAIN"
 
           echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
-          MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHA_SHORT --output text --query 'images[].imageManifest')
+          MANIFEST=$(curl -H "Accept: $CONTENT_TYPE" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/main-$SHA_SHORT")
 
           SHA_TAG="ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
           echo "Adding the tag for $SHA_TAG to main-$SHA_SHORT image"
-          # Avoid failure on existing image and tag
-          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$SHA_TAG" --image-manifest "$MANIFEST"); then
-            if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHA_SHORT has already been tagged with $SHA_TAG"
-            else
-              >&2 echo "$OUT"
-              exit 1
-            fi
-          fi
+          curl -X PUT -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$SHA_TAG"
 
           LATEST_TAG="ab2d-$DEPLOYMENT_ENV-latest"
           echo "Adding the tag for $LATEST_TAG to main-$SHA_SHORT image"
-          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$LATEST_TAG" --image-manifest "$MANIFEST"); then
-            if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHA_SHORT has already been tagged with $LATEST_TAG"
-            else
-              >&2 echo "$OUT"
-              exit 1
-            fi
-          fi
+          curl -X PUT -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$LATEST_TAG"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -33,8 +33,8 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v3
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.MGMT_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-mgmt-github-actions

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -44,19 +44,17 @@ jobs:
           ECR_REPO_DOMAIN: ${{ secrets.MGMT_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
           ECR_REPO: ab2d_${{ inputs.module }}
         run: |
-          #SHA_SHORT=$(git rev-parse --short HEAD)
-          SHA_SHORT=7da005a # TODO remove after testing
+          SHA_SHORT="$(git rev-parse --short HEAD)"
+          TOKEN="$(aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken')"
           CONTENT_TYPE="application/vnd.docker.distribution.manifest.v2+json"
 
-          TOKEN=$(aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken')
-
-          echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
-          MANIFEST=$(curl -sS -H "Authorization: Basic $TOKEN" -H "Accept: $CONTENT_TYPE" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/main-$SHA_SHORT")
+          echo "Getting the manifest of the image tagged main-$SHA_SHORT"
+          MANIFEST="$(curl -sS -H "Authorization: Basic $TOKEN" -H "Accept: $CONTENT_TYPE" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/main-$SHA_SHORT")"
 
           SHA_TAG="ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
-          echo "Adding the tag for $SHA_TAG to main-$SHA_SHORT image"
+          echo "Adding the $SHA_TAG tag to main-$SHA_SHORT image"
           curl -sS -X PUT -H "Authorization: Basic $TOKEN" -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$SHA_TAG"
 
           LATEST_TAG="ab2d-$DEPLOYMENT_ENV-latest"
-          echo "Adding the tag for $LATEST_TAG to main-$SHA_SHORT image"
+          echo "Adding the $LATEST_TAG tag to main-$SHA_SHORT image"
           curl -sS -X PUT -H "Authorization: Basic $TOKEN" -H "Content-Type: $CONTENT_TYPE" -d "$MANIFEST" "https://$ECR_REPO_DOMAIN/v2/$ECR_REPO/manifests/$LATEST_TAG"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -43,25 +43,29 @@ jobs:
           DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
         run: |
           REPO="ab2d_${{ inputs.module }}"
-          SHA_SHORT=$(git rev-parse --short HEAD)
+          #SHA_SHORT=$(git rev-parse --short HEAD)
+          SHA_SHORT=82d2398 # TODO remove after testing
 
-          # Get the manifest of the image pushed for latest commit to main
+          echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
           MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHORT_SHA --output text --query 'images[].imageManifest')
 
-          # Add the tag for sha
-          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "ab2d-$DEPLOYMENT_ENV-$SHA_SHORT" --image-manifest "$MANIFEST"); then
+          SHA_TAG="ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
+          echo "Adding the tag for $SHA_TAG to main-$SHORT_SHA image"
+          # Avoid failure on existing image and tag
+          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$SHA_TAG" --image-manifest "$MANIFEST"); then
             if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHORT_SHA has already been tagged with ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
+              echo "Image for main-$SHORT_SHA has already been tagged with $SHA_TAG"
             else
               >&2 echo "$OUT"
               exit 1
             fi
           fi
 
-          # Add the tag for latest
-          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "ab2d-$DEPLOYMENT_ENV-latest" --image-manifest "$MANIFEST"); then
+          LATEST_TAG="ab2d-$DEPLOYMENT_ENV-latest"
+          echo "Adding the tag for $LATEST_TAG to main-$SHORT_SHA image"
+          if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$LATEST_TAG" --image-manifest "$MANIFEST"); then
             if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHORT_SHA has already been tagged with ab2d-$DEPLOYMENT_ENV-latest"
+              echo "Image for main-$SHORT_SHA has already been tagged with $LATEST_TAG"
             else
               >&2 echo "$OUT"
               exit 1

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,7 +17,7 @@ on:
         options:
           - sbx
           - prod
-          - prod-test
+          - prod_test
       module:
         required: true
         type: choice
@@ -47,14 +47,14 @@ jobs:
           SHA_SHORT=82d2398 # TODO remove after testing
 
           echo "Getting the manifest of the image pushed with the latest commit to main at sha $SHA_SHORT"
-          MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHORT_SHA --output text --query 'images[].imageManifest')
+          MANIFEST=$(aws ecr batch-get-image --repository-name "$REPO" --image-ids imageTag=main-$SHA_SHORT --output text --query 'images[].imageManifest')
 
           SHA_TAG="ab2d-$DEPLOYMENT_ENV-$SHA_SHORT"
-          echo "Adding the tag for $SHA_TAG to main-$SHORT_SHA image"
+          echo "Adding the tag for $SHA_TAG to main-$SHA_SHORT image"
           # Avoid failure on existing image and tag
           if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$SHA_TAG" --image-manifest "$MANIFEST"); then
             if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHORT_SHA has already been tagged with $SHA_TAG"
+              echo "Image for main-$SHA_SHORT has already been tagged with $SHA_TAG"
             else
               >&2 echo "$OUT"
               exit 1
@@ -62,10 +62,10 @@ jobs:
           fi
 
           LATEST_TAG="ab2d-$DEPLOYMENT_ENV-latest"
-          echo "Adding the tag for $LATEST_TAG to main-$SHORT_SHA image"
+          echo "Adding the tag for $LATEST_TAG to main-$SHA_SHORT image"
           if ! OUT=$(2>&1 aws ecr put-image --repository-name "$REPO" --image-tag "$LATEST_TAG" --image-manifest "$MANIFEST"); then
             if echo "$OUT" | grep ImageAlreadyExistsException > /dev/null; then
-              echo "Image for main-$SHORT_SHA has already been tagged with $LATEST_TAG"
+              echo "Image for main-$SHA_SHORT has already been tagged with $LATEST_TAG"
             else
               >&2 echo "$OUT"
               exit 1

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,0 +1,46 @@
+name: push to main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-api:
+    uses: ./.github/workflows/build.yml
+    with:
+      environment: test
+      module: api
+    secrets: inherit
+  build-worker:
+    uses: ./.github/workflows/build.yml
+    with:
+      environment: test
+      module: worker
+    secrets: inherit
+  deploy-api:
+    needs: build-api
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: test
+      module: api
+    secrets: inherit
+  deploy-worker:
+    needs: build-worker
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: test
+      module: worker
+    secrets: inherit
+  e2e-test:
+    needs: [deploy-api, deploy-worker]
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      environment: test
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   release:
     types: [released]
   workflow_dispatch:
-  push: # TODO Remove after testing
 
 permissions:
   contents: read
@@ -27,65 +26,64 @@ jobs:
       module: worker
     secrets: inherit
 
-# TODO Uncomment after testing
-#  # Promote and Deploy to prod
-#  promote-prod-api:
-#    uses: ./.github/workflows/promote.yml
-#    with:
-#      environment: prod
-#      module: api
-#    secrets: inherit
-#
-#  promote-prod-worker:
-#    uses: ./.github/workflows/promote.yml
-#    with:
-#      environment: prod
-#      module: worker
-#    secrets: inherit
-#
-#  deploy-prod-api:
-#    needs: promote-prod-api
-#    uses: ./.github/workflows/deploy.yml
-#    with:
-#      environment: prod
-#      module: api
-#    secrets: inherit
-#
-#  deploy-prod-worker:
-#    needs: promote-prod-worker
-#    uses: ./.github/workflows/deploy.yml
-#    with:
-#      environment: prod
-#      module: worker
-#    secrets: inherit
-#
-#  # Promote and Deploy to sandbox
-#  promote-sbx-api:
-#    uses: ./.github/workflows/promote.yml
-#    with:
-#      environment: sbx
-#      module: api
-#    secrets: inherit
-#
-#  promote-sbx-worker:
-#    uses: ./.github/workflows/promote.yml
-#    with:
-#      environment: sbx
-#      module: worker
-#    secrets: inherit
-#
-#  deploy-sbx-api:
-#    needs: promote-sbx-api
-#    uses: ./.github/workflows/deploy.yml
-#    with:
-#      environment: sbx
-#      module: api
-#    secrets: inherit
-#
-#  deploy-sbx-worker:
-#    needs: promote-sbx-worker
-#    uses: ./.github/workflows/deploy.yml
-#    with:
-#      environment: sbx
-#      module: worker
-#    secrets: inherit
+  # Promote and Deploy to prod
+  promote-prod-api:
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: prod
+      module: api
+    secrets: inherit
+
+  promote-prod-worker:
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: prod
+      module: worker
+    secrets: inherit
+
+  deploy-prod-api:
+    needs: promote-prod-api
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: prod
+      module: api
+    secrets: inherit
+
+  deploy-prod-worker:
+    needs: promote-prod-worker
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: prod
+      module: worker
+    secrets: inherit
+
+  # Promote and Deploy to sandbox
+  promote-sbx-api:
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: sbx
+      module: api
+    secrets: inherit
+
+  promote-sbx-worker:
+    uses: ./.github/workflows/promote.yml
+    with:
+      environment: sbx
+      module: worker
+    secrets: inherit
+
+  deploy-sbx-api:
+    needs: promote-sbx-api
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: sbx
+      module: api
+    secrets: inherit
+
+  deploy-sbx-worker:
+    needs: promote-sbx-worker
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: sbx
+      module: worker
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   promote-prod-test-worker:
     uses: ./.github/workflows/promote.yml
     with:
-      environment: prod-test
+      environment: prod_test
       module: worker
     secrets: inherit
 
@@ -23,7 +23,7 @@ jobs:
     needs: promote-prod-test-worker
     uses: ./.github/workflows/deploy.yml
     with:
-      environment: prod-test
+      environment: prod_test
       module: worker
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+  push: # TODO Remove after testing
 
 permissions:
   contents: read
@@ -26,64 +27,65 @@ jobs:
       module: worker
     secrets: inherit
 
-   # Promote and Deploy to prod
-  promote-prod-api:
-    uses: ./.github/workflows/promote.yml
-    with:
-      environment: prod
-      module: api
-    secrets: inherit
-
-  promote-prod-worker:
-    uses: ./.github/workflows/promote.yml
-    with:
-      environment: prod
-      module: worker
-    secrets: inherit
-
-  deploy-prod-api:
-    needs: promote-prod-api
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: prod
-      module: api
-    secrets: inherit
-
-  deploy-prod-worker:
-    needs: promote-prod-worker
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: prod
-      module: worker
-    secrets: inherit
-
-  # Promote and Deploy to sandbox
-  promote-sbx-api:
-    uses: ./.github/workflows/promote.yml
-    with:
-      environment: sbx
-      module: api
-    secrets: inherit
-
-  promote-sbx-worker:
-    uses: ./.github/workflows/promote.yml
-    with:
-      environment: sbx
-      module: worker
-    secrets: inherit
-
-  deploy-sbx-api:
-    needs: promote-sbx-api
-    uses: ./.github/workflows/deploy.yml 
-    with:
-      environment: sbx
-      module: api
-    secrets: inherit
-
-  deploy-sbx-worker:
-    needs: promote-sbx-worker
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: sbx
-      module: worker
-    secrets: inherit
+# TODO Uncomment after testing
+#  # Promote and Deploy to prod
+#  promote-prod-api:
+#    uses: ./.github/workflows/promote.yml
+#    with:
+#      environment: prod
+#      module: api
+#    secrets: inherit
+#
+#  promote-prod-worker:
+#    uses: ./.github/workflows/promote.yml
+#    with:
+#      environment: prod
+#      module: worker
+#    secrets: inherit
+#
+#  deploy-prod-api:
+#    needs: promote-prod-api
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      environment: prod
+#      module: api
+#    secrets: inherit
+#
+#  deploy-prod-worker:
+#    needs: promote-prod-worker
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      environment: prod
+#      module: worker
+#    secrets: inherit
+#
+#  # Promote and Deploy to sandbox
+#  promote-sbx-api:
+#    uses: ./.github/workflows/promote.yml
+#    with:
+#      environment: sbx
+#      module: api
+#    secrets: inherit
+#
+#  promote-sbx-worker:
+#    uses: ./.github/workflows/promote.yml
+#    with:
+#      environment: sbx
+#      module: worker
+#    secrets: inherit
+#
+#  deploy-sbx-api:
+#    needs: promote-sbx-api
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      environment: sbx
+#      module: api
+#    secrets: inherit
+#
+#  deploy-sbx-worker:
+#    needs: promote-sbx-worker
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      environment: sbx
+#      module: worker
+#    secrets: inherit


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-679

## 🛠 Changes

Added workflow to trigger bulids on push to main and updated build workflow to push "main" tags to ECR.

## ℹ️ Context

We need images we can count on being around for a bit from each to push to main for promotion to prod on release. This allows us to set a lifecycle policy specific to tags with the "main" prefix. 

## 🧪 Validation

See runs at https://github.com/CMSgov/ab2d/actions/runs/11195118631, https://github.com/CMSgov/ab2d/actions/runs/11195323158, and https://github.com/CMSgov/ab2d/actions/runs/11202145951 for successful tests of the release and promote workflows. The push-main workflow (and expected tag updates in ECR) must be checked following merge of this PR.