### PR TITLE
Override postgresql version defined by spring-boot-dependencies

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgres.version}</version>
+            <version>${postgresql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgres.version}</version>
+            <version>${postgresql.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <logback-encoder.version>7.3</logback-encoder.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <newrelic.version>8.15.0</newrelic.version>
-        <postgresql.version>42.7.3</postgresql.version>
+        <postgresql.version>42.7.4</postgresql.version>
         <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version>
 
         <!-- Maven plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <logback-encoder.version>7.3</logback-encoder.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <newrelic.version>8.15.0</newrelic.version>
-        <postgres.version>42.7.3</postgres.version>
+        <postgresql.version>42.7.3</postgresql.version>
         <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version>
 
         <!-- Maven plugin versions -->


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6397

## 🛠 Changes
- In the parent POM, rename property from `postgres.version` to `postgresql.version` to properly override version defined in `spring-boot-dependencies`.
- Bump postgresql version to 42.7.4 to be consistent with #1412

## ℹ️ Context

The postgres version defined by `spring-boot-dependencies` is 42.3.8. Snyk flags this version as vulnerable. 

Modules **common** and **job** override this version to 42.7.3. However, when another module imports one of these modules, Maven does not select this overridden version and instead selects the version defined by `spring-boot-dependencies`.

## 🧪 Validation

Running `mvn dependency:tree` on **main** shows different versions being used for different modules. 
On the feature branch, the same version is used across all modules. 

![image](https://github.com/user-attachments/assets/720540df-5485-4f97-ad1f-17df44319aab)
