### PR TITLE
Add details for 'coverage period missing or year,month query incorrect' log statements

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
@@ -562,6 +562,7 @@ public class CoverageDriverImpl implements CoverageDriver {
         }
 
         ZonedDateTime startDateTime = getStartDateTime(contract);
+        // Additional details to log in the event of exception
         Optional<String> additionalDetails = Optional.empty();
         try {
             // Check that all coverage periods necessary are present before beginning to page

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
@@ -555,15 +555,15 @@ public class CoverageDriverImpl implements CoverageDriver {
     @Trace(metricName = "EnrollmentLoadFromDB", dispatcher = true)
     @Override
     public CoveragePagingResult pageCoverage(Job job, ContractDTO contract) {
+        ZonedDateTime now = getEndDateTime();
 
         if (contract == null) {
             throw new CoverageDriverException("cannot retrieve metadata for job missing contract");
         }
 
+        ZonedDateTime startDateTime = getStartDateTime(contract);
         Optional<String> additionalDetails = Optional.empty();
         try {
-            ZonedDateTime now = getEndDateTime();
-            ZonedDateTime startDateTime = getStartDateTime(contract);
             // Check that all coverage periods necessary are present before beginning to page
             while (startDateTime.isBefore(now)) {
                 additionalDetails = Optional.of(String.format("contract='%s' month='%s', year='%s'",

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverUnitTest.java
@@ -234,7 +234,7 @@ class CoverageDriverUnitTest {
 
     @DisplayName("Paging coverage fails when coverage periods are missing")
     @Test
-    void failPagingWhenCoveragePeriodMissing() {
+    void failPagingWhenCoveragePeriodMissing(CapturedOutput output) {
 
         when(coverageService.getCoveragePeriod(any(), anyInt(), anyInt())).thenThrow(new EntityNotFoundException());
 
@@ -243,6 +243,8 @@ class CoverageDriverUnitTest {
 
         CoverageDriverException startDateInFuture = assertThrows(CoverageDriverException.class, () -> driver.pageCoverage(job, contract));
         assertEquals(EntityNotFoundException.class, startDateInFuture.getCause().getClass());
+        assertTrue(output.getOut().contains("coverage period missing or year,month query incorrect, driver should have resolved earlier - contract='null' month='1', year='2020'"));
+
     }
 
     @DisplayName("Paging coverage periods")


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-6418
- https://jira.cms.gov/browse/AB2D-6425

## 🛠 Changes

Add details to log message for `coverage period missing or year,month query incorrect` error messages. 

## ℹ️ Context

When we receive a Slack notification of a failed job, the relevant details (e.g. coverage month and year) are not present in Splunk. This PR adds those details for debugging purposes. 
![image](https://github.com/user-attachments/assets/87cfcea5-c673-4198-a65d-fb6315cb5f9b)

## 🧪 Validation

Added unit tests that verified additional statements were printed to the logs
![image](https://github.com/user-attachments/assets/b7b29df6-7cf8-46e7-8128-846537ed2a99)

