### PR TITLE
Add deploy lambda workflow

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -63,7 +63,6 @@ jobs:
   publish_lambdas:
     uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
     with:
-      environment: dev
       ref: ${{ inputs.ab2dLambdasBranch }}
     if: ${{ inputs.runBuildJob == true }}
 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
         run: |
-          mkdir -p terraform/modules/lambda/event-service || true
+          mkdir -p terraform/modules/lambda/event-service 
           cd terraform/modules/lambda/event-service
           
           declare -a lambdas=(
@@ -146,23 +146,15 @@ jobs:
           echo "$(ls -lah)"
           cd -
 
-      # without this step, terraform fails with `/usr/bin/env: ‘node’: No such file or directory`
-      - name: Setup node for terraform
-        uses: actions/setup-node@v2
-        with:
-          node-version: '20'
-
-      - name: Setup terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.1.2'
+      - name: Install terraform
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/setup-tfenv-terraform@main
 
       - name: Terraform init and plan
         run: |
           set -x
           cd terraform/environments/ab2d/lambda/
-          terraform init -no-color -reconfigure -backend-config=backend/${AB2D_ENV}.conf
-          terraform plan -no-color -var env=${AB2D_ENV} -out=lambda.tfplan
+          terraform init -reconfigure -backend-config=backend/${AB2D_ENV}.conf
+          terraform plan -var env=${AB2D_ENV} -out=lambda.tfplan
 
       - name: Terraform apply
         if: ${{ inputs.apply == true }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Determine lambdas build version
         run: |
-          BUILD_VERSION=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
+          BUILD_VERSION=$(echo "${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }}" | tr -d ' ')
           echo "BUILD_VERSION=${BUILD_VERSION}"
           if [ -z "${BUILD_VERSION}" ]; then
             echo "Unable to determine build version"
@@ -126,7 +126,7 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
-          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${BUILD_VERSION}/metrics-lambda-${BUILD_VERSION}.zip" --output metrics-lambda.zip
+          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${ env.BUILD_VERSION }/metrics-lambda-${ env.BUILD_VERSION }.zip" --output metrics-lambda.zip
           echo "$(ls -lah)"
 #          mkdir -p terraform/modules/lambda/event-service || true
 #          cd terraform/modules/lambda/event-service

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
+          token: ${{ env.OPS_GITHUB_TOKEN }}
           repository: 'cmsgov/ab2d-ops'
           ref: ${{ inputs.ab2dOpsBranch }}
 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,14 +1,8 @@
 name: deploy-lambdas
 
-#  booleanParam(defaultValue: false, name: 'APPLY', description: "Apply output from plan?")
-#  choice(choices: ["-",'ab2d-east-impl', 'ab2d-dev', 'ab2d-sbx-sandbox', 'ab2d-east-prod', 'ab2d-east-prod-test'], name: 'PARENT_ENV', description: "Ab2d environment?")
-#  string(defaultValue: 'main', name: 'BRANCH_NAME', description: "Github branch?")
-#  string(defaultValue: 'main', name: 'AB2D_REPO_REF', description: "ab2d-lambda branch?")
+# gh workflow run deploy-lambda.yml --ref lambda-tf-workflow -f apply=false -f environment=dev -f ab2dOpsBranch=main -f ab2dLambdasBranch=main -f runBuildJob=false -f buildVersion=1.1.0
 
 on:
-#  push:
-#    branches:
-#      - lambda-tf-workflow
   workflow_call:
     inputs:
       apply:
@@ -72,12 +66,13 @@ jobs:
     uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
     with:
       environment: dev
+      ref: ${{ inputs.ab2dLambdasBranch }}
     if: ${{ inputs.runBuildJob == true }}
 
   deploy:
     runs-on: self-hosted
     needs: publish_lambdas
-    # always run this job but - if runBuildJob=true, then wait for 'publish_lambdas' job to finish
+    # always run this job but if runBuildJob=true, then wait for 'publish_lambdas' job to finish
     # without this conditional, this job will not run unless runBuildJob=true
     if: ${{ always() && !cancelled() }}
 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -22,18 +22,10 @@ on:
 
 jobs:
   publish_lambdas:
-    runs-on: self-hosted
-    steps:
-      - name: Checkout ab2d-lambdas repository
-        uses: actions/checkout@v4
-        with:
-          repository: 'cmsgov/ab2d-lambdas'
-
-      - name: Run publish-lambdas workflow
-        uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
-        with:
-          environment: dev
-        if: true
+    uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
+    with:
+      environment: dev
+    if: true
 
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Determine lambdas build version
         run: |
+          echo "build version from inputs = ${{ inputs.buildVersion }}
           buildVersion=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
           echo "buildVersion=$buildVersion"
           echo "BUILD_VERSION=$buildVersion" >> $GITHUB_ENV

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -110,7 +110,7 @@ jobs:
             echo "Unable to determine build version"
             exit 1
           fi  
-          echo "BUILD_VERSION=$buildVersion" >> $GITHUB_ENV
+          echo "BUILD_VERSION=${BUILD_VERSION}" >> $GITHUB_ENV
 
 
       - name: Assume role in AB2D account for this environment

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -104,11 +104,14 @@ jobs:
 
       - name: Determine lambdas build version
         run: |
-          echo "build version from inputs = '${{ inputs.buildVersion }}'"
-          echo "build version from job output = '${{ needs.publish_lambdas.outputs.build_version }}'"
-          buildVersion=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
-          echo "buildVersion=$buildVersion"
+          BUILD_VERSION=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
+          echo "BUILD_VERSION=${BUILD_VERSION}"
+          if [ -z "${BUILD_VERSION}" ]; then
+            echo "Unable to determine build version"
+            exit 1
+          fi  
           echo "BUILD_VERSION=$buildVersion" >> $GITHUB_ENV
+
 
       - name: Assume role in AB2D account for this environment
         uses: aws-actions/configure-aws-credentials@v3
@@ -124,7 +127,7 @@ jobs:
 
         run: |
           curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${BUILD_VERSION}/metrics-lambda-${BUILD_VERSION}.zip" --output metrics-lambda.zip
-          echo "$(ls)"
+          echo "$(ls -lah)"
 #          mkdir -p terraform/modules/lambda/event-service || true
 #          cd terraform/modules/lambda/event-service
 #          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/metrics-lambda/${buildVersion//[$'\t\r\n ']}/metrics-lambda-${buildVersion//[$'\t\r\n ']}.zip" --output metrics-lambda.zip

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -145,3 +145,15 @@ jobs:
           
           echo "$(ls -lah)"
           cd -
+          
+          set -x
+          
+          if [[ ${{ inputs.environment }} = "dev" ]];         then AB2D_ENV='ab2d-dev'
+          elif [[ ${{ inputs.environment }} = "test" ]];      then AB2D_ENV='ab2d-east-impl'
+          elif [[ ${{ inputs.environment }} = "sbx" ]];       then AB2D_ENV='ab2d-sbx-sandbox'
+          elif [[ ${{ inputs.environment }} = "prod_test" ]]; then AB2D_ENV='ab2d-east-prod-test'
+          elif [[ ${{ inputs.environment }} = "prod" ]];      then AB2D_ENV='ab2d-east-prod'
+          fi
+          
+          terraform init -no-color -reconfigure -backend-config=backend/${AB2D_ENV}.conf
+          terraform plan -no-color -var env=${AB2D_ENV} -out=lambda.tfplan

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -136,7 +136,6 @@ jobs:
       - name: Download ZIP files
         env:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
-
         run: |
           mkdir -p terraform/modules/lambda/event-service || true
           cd terraform/modules/lambda/event-service
@@ -154,10 +153,16 @@ jobs:
           
           echo "$(ls -lah)"
           cd -
-          
+
+      - name: install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.0.0"
+
+      - name: Terraform init and plan
+        run: |
+          echo "$(ls -lah)"
           set -x
-          
-          
-          
+          cd terraform/environments/ab2d/lambda/
           terraform init -no-color -reconfigure -backend-config=backend/${AB2D_ENV}.conf
           terraform plan -no-color -var env=${AB2D_ENV} -out=lambda.tfplan

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -126,7 +126,8 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
-          for name in 'metrics-lambda' 'audit' 'database-management' 'coverage-counts' 'retrieve-hpms-counts'; 
+          declare -a lambdas=('metrics-lambda' 'audit' 'database-management' 'coverage-counts' 'retrieve-hpms-counts')
+          for name in "${lambdas[@]}"
             do curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/${name}/${{ env.BUILD_VERSION }}/${name}-${{ env.BUILD_VERSION }}.zip" --output ${name}.zip
           done
           

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -165,9 +165,9 @@ jobs:
           node-version: '20'
 
       - name: Setup terraform
-        uses: actions/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: '1.2.0'
+          terraform_version: '1.1.2'
 
       - name: Terraform init and plan
         run: |

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -154,11 +154,6 @@ jobs:
           echo "$(ls -lah)"
           cd -
 
-      - name: install terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.0.0"
-
       - name: Setup node for terraform
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -126,7 +126,7 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
-          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${ env.BUILD_VERSION }/metrics-lambda-${ env.BUILD_VERSION }.zip" --output metrics-lambda.zip
+          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${{ env.BUILD_VERSION }}/metrics-lambda-${{ env.BUILD_VERSION }}.zip" --output metrics-lambda.zip
           echo "$(ls -lah)"
 #          mkdir -p terraform/modules/lambda/event-service || true
 #          cd terraform/modules/lambda/event-service

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -118,7 +118,7 @@ jobs:
           echo "AB2D_ENV=${AB2D_ENV}" >> $GITHUB_ENV
 
       - name: Assume role in AB2D account for this environment
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         env:
           ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
         with:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -77,6 +77,7 @@ jobs:
   deploy:
     runs-on: self-hosted
     needs: publish_lambdas
+    if: always()
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -154,6 +154,7 @@ jobs:
           echo "$(ls -lah)"
           cd -
 
+      # without this step, terraform fails with `/usr/bin/env: ‘node’: No such file or directory`
       - name: Setup node for terraform
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -166,8 +166,14 @@ jobs:
 
       - name: Terraform init and plan
         run: |
-          echo "$(ls -lah)"
           set -x
           cd terraform/environments/ab2d/lambda/
           terraform init -no-color -reconfigure -backend-config=backend/${AB2D_ENV}.conf
           terraform plan -no-color -var env=${AB2D_ENV} -out=lambda.tfplan
+
+      - name: Terraform apply
+        if: ${{ inputs.apply == true }}
+        run: |
+          set -e
+          cd terraform/environments/ab2d/lambda/
+          terraform apply -input=false -no-color lambda.tfplan

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,0 +1,54 @@
+name: deploy-lambdas
+
+on:
+  push:
+    branches:
+      - lambda-tf-workflow
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - test
+          - prod
+
+jobs:
+  publish_lambdas:
+    uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
+    if: true
+
+  deploy:
+    runs-on: self-hosted
+    needs: publish_lambdas
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Test publish lambdas
+        run: |
+          echo "test"
+          echo "build_version=${{ needs.publish_lambdas.outputs.build_version }}"
+        
+
+#      - name: Assume role in AB2D account for this environment
+#        uses: aws-actions/configure-aws-credentials@v3
+#        env:
+#          ACCOUNT: ${{ inputs.environment }}
+#        with:
+#          aws-region: ${{ vars.AWS_REGION }}
+#          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
+#
+#

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -84,6 +84,17 @@ jobs:
       DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
 
     steps:
+      - name: Set environment variables
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            ARTIFACTORY_URL=/artifactory/url
+            ARTIFACTORY_USER=/artifactory/user
+            ARTIFACTORY_PASSWORD=/artifactory/password
+            OPS_GITHUB_TOKEN=/ci/github/token
+
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
@@ -104,16 +115,6 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
-
-      - name: Set Artifactory-related environment variables
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-        with:
-          params: |
-            ARTIFACTORY_URL=/artifactory/url
-            ARTIFACTORY_USER=/artifactory/user
-            ARTIFACTORY_PASSWORD=/artifactory/password
 
       - name: Download ZIP files
         env:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -159,6 +159,16 @@ jobs:
         with:
           terraform_version: "1.0.0"
 
+      - name: Setup node for terraform
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Setup terraform
+        uses: actions/setup-terraform@v3
+        with:
+          terraform_version: '1.2.0'
+
       - name: Terraform init and plan
         run: |
           echo "$(ls -lah)"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   publish_lambdas:
     uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
+    with:
+      environment: dev
     if: true
 
   deploy:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -22,10 +22,18 @@ on:
 
 jobs:
   publish_lambdas:
-    uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
-    with:
-      environment: dev
-    if: true
+    runs-on: self-hosted
+    steps:
+      - name: Checkout ab2d-lambdas repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'cmsgov/ab2d-lambdas'
+
+      - name: Run publish-lambdas workflow
+        uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
+        with:
+          environment: dev
+        if: true
 
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -126,7 +126,10 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
-          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${{ env.BUILD_VERSION }}/metrics-lambda-${{ env.BUILD_VERSION }}.zip" --output metrics-lambda.zip
+          for name in 'metrics-lambda' 'audit' 'database-management' 'coverage-counts' 'retrieve-hpms-counts'; 
+            do curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/${name}/${{ env.BUILD_VERSION }}/${name}-${{ env.BUILD_VERSION }}.zip" --output ${name}.zip
+          done
+          
           echo "$(ls -lah)"
 #          mkdir -p terraform/modules/lambda/event-service || true
 #          cd terraform/modules/lambda/event-service

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -104,7 +104,8 @@ jobs:
 
       - name: Determine lambdas build version
         run: |
-          echo "build version from inputs = ${{ inputs.buildVersion }}
+          echo "build version from inputs = '${{ inputs.buildVersion }}'"
+          echo "build version from job output = '${{ needs.publish_lambdas.outputs.build_version }}'"
           buildVersion=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
           echo "buildVersion=$buildVersion"
           echo "BUILD_VERSION=$buildVersion" >> $GITHUB_ENV

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -161,4 +161,10 @@ jobs:
         run: |
           set -e
           cd terraform/environments/ab2d/lambda/
-          terraform apply -input=false -no-color lambda.tfplan
+          terraform apply -input=false lambda.tfplan
+
+      - name: Cleanup Terraform Plan
+        if: ${{ always() && !cancelled() }}
+        working-directory: terraform/environments/ab2d/lambda/
+        run: |
+          rm -f lambda.tfplan 

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,31 +1,78 @@
 name: deploy-lambdas
 
+#  booleanParam(defaultValue: false, name: 'APPLY', description: "Apply output from plan?")
+#  choice(choices: ["-",'ab2d-east-impl', 'ab2d-dev', 'ab2d-sbx-sandbox', 'ab2d-east-prod', 'ab2d-east-prod-test'], name: 'PARENT_ENV', description: "Ab2d environment?")
+#  string(defaultValue: 'main', name: 'BRANCH_NAME', description: "Github branch?")
+#  string(defaultValue: 'main', name: 'AB2D_REPO_REF', description: "ab2d-lambda branch?")
+
 on:
   push:
     branches:
       - lambda-tf-workflow
   workflow_call:
     inputs:
+      apply:
+        type: boolean
+        required: true
+        default: false
       environment:
         required: true
         type: string
+      ab2dOpsBranch:
+        type: string
+        required: true
+      ab2dLambdasBranch:
+        type: string
+        required: true
+      runBuildJob:
+        type: boolean
+        required: true
+        default: false
+      buildVersion:
+        type: string
+        required: false
+
   workflow_dispatch:
     inputs:
+      apply:
+        type: boolean
+        required: true
+        default: false
+        description: 'Apply output from terraform plan?'
       environment:
-        description: 'Environment'
+        description: 'AB2D environment'
         required: true
         type: choice
         options:
           - dev
           - test
+          - sbx
+          - prod_test
           - prod
+      ab2dOpsBranch:
+        type: string
+        required: true
+        description: 'Branch for ab2d-ops'
+      ab2dLambdasBranch:
+        type: string
+        required: true
+        description: 'Branch for ab2d-lambdas'
+      runBuildJob:
+        type: boolean
+        required: true
+        default: false
+        description: 'Build lambdas before publishing'
+      buildVersion:
+        type: string
+        required: false
+        description: 'Version of lambda you want to deploy - This is ignored if you check runBuildJob'
 
 jobs:
   publish_lambdas:
     uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
     with:
       environment: dev
-    if: true
+    if: ${{ inputs.runBuildJob == true }}
 
   deploy:
     runs-on: self-hosted
@@ -38,19 +85,46 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          repository: 'cmsgov/ab2d-ops'
+          ref: ${{ inputs.ab2dOpsBranch }}
 
-      - name: Test publish lambdas
+      - name: Determine lambdas build version
         run: |
-          echo "test"
-          echo "build_version=${{ needs.publish_lambdas.outputs.build_version }}"
-        
+          buildVersion=$(echo ${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }} | tr -d ' ')
+          echo "buildVersion=$buildVersion"
+          echo "BUILD_VERSION=$buildVersion" >> $GITHUB_ENV
 
-#      - name: Assume role in AB2D account for this environment
-#        uses: aws-actions/configure-aws-credentials@v3
-#        env:
-#          ACCOUNT: ${{ inputs.environment }}
-#        with:
-#          aws-region: ${{ vars.AWS_REGION }}
-#          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
-#
-#
+      - name: Assume role in AB2D account for this environment
+        uses: aws-actions/configure-aws-credentials@v3
+        env:
+          ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment }}
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
+
+      - name: Set Artifactory-related environment variables
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            ARTIFACTORY_URL=/artifactory/url
+            ARTIFACTORY_USER=/artifactory/user
+            ARTIFACTORY_PASSWORD=/artifactory/password
+
+      - name: Download ZIP files
+        env:
+          ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
+
+        run: |
+          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${BUILD_VERSION}/metrics-lambda-${BUILD_VERSION}.zip" --output metrics-lambda.zip
+
+#          mkdir -p terraform/modules/lambda/event-service || true
+#          cd terraform/modules/lambda/event-service
+#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/metrics-lambda/${buildVersion//[$'\t\r\n ']}/metrics-lambda-${buildVersion//[$'\t\r\n ']}.zip" --output metrics-lambda.zip
+#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/audit/${buildVersion//[$'\t\r\n ']}/audit-${buildVersion//[$'\t\r\n ']}.zip" --output audit.zip
+#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/database-management/${buildVersion//[$'\t\r\n ']}/database-management-${buildVersion//[$'\t\r\n ']}.zip" --output database-management.zip
+#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/coverage-counts/${buildVersion//[$'\t\r\n ']}/coverage-counts-${buildVersion//[$'\t\r\n ']}.zip" --output coverage-counts.zip
+#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/retrieve-hpms-counts/${buildVersion//[$'\t\r\n ']}/retrieve-hpms-counts-${buildVersion//[$'\t\r\n ']}.zip" --output retrieve-hpms-counts.zip
+#          cd -

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   publish_lambdas:
-    uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@update-publish-lamda-workflow
+    uses: cmsgov/ab2d-lambdas/.github/workflows/publish-lambdas.yml@main
     with:
       ref: ${{ inputs.ab2dLambdasBranch }}
     if: ${{ inputs.runBuildJob == true }}

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -98,9 +98,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          token: ${{ env.OPS_GITHUB_TOKEN }}
           repository: 'cmsgov/ab2d-ops'
           ref: ${{ inputs.ab2dOpsBranch }}
+          token: ${{ env.OPS_GITHUB_TOKEN }}
 
       - name: Determine lambdas build version
         run: |
@@ -122,7 +122,7 @@ jobs:
 
         run: |
           curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/metrics-lambda/${BUILD_VERSION}/metrics-lambda-${BUILD_VERSION}.zip" --output metrics-lambda.zip
-
+          echo "$(ls)"
 #          mkdir -p terraform/modules/lambda/event-service || true
 #          cd terraform/modules/lambda/event-service
 #          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/metrics-lambda/${buildVersion//[$'\t\r\n ']}/metrics-lambda-${buildVersion//[$'\t\r\n ']}.zip" --output metrics-lambda.zip

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -6,9 +6,9 @@ name: deploy-lambdas
 #  string(defaultValue: 'main', name: 'AB2D_REPO_REF', description: "ab2d-lambda branch?")
 
 on:
-  push:
-    branches:
-      - lambda-tf-workflow
+#  push:
+#    branches:
+#      - lambda-tf-workflow
   workflow_call:
     inputs:
       apply:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -126,7 +126,13 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
-          declare -a lambdas=('metrics-lambda' 'audit' 'database-management' 'coverage-counts' 'retrieve-hpms-counts')
+          declare -a lambdas=(
+            'metrics-lambda' 
+            'audit' 
+            'database-management' 
+            'coverage-counts' 
+            'retrieve-hpms-counts'
+          )
           for name in "${lambdas[@]}"
             do curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "${ARTIFACTORY_PREFIX}/${name}/${{ env.BUILD_VERSION }}/${name}-${{ env.BUILD_VERSION }}.zip" --output ${name}.zip
           done

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,7 +1,5 @@
 name: deploy-lambdas
 
-# gh workflow run deploy-lambda.yml --ref lambda-tf-workflow -f apply=false -f environment=dev -f ab2dOpsBranch=main -f ab2dLambdasBranch=main -f runBuildJob=false -f buildVersion=1.1.0
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -105,7 +105,7 @@ jobs:
           ref: ${{ inputs.ab2dOpsBranch }}
           token: ${{ env.OPS_GITHUB_TOKEN }}
 
-      - name: Determine lambdas build version
+      - name: Set variables for build version and AB2D environment
         run: |
           BUILD_VERSION=$(echo "${{ needs.publish_lambdas.outputs.build_version || inputs.buildVersion }}" | tr -d ' ')
           echo "BUILD_VERSION=${BUILD_VERSION}"
@@ -113,8 +113,17 @@ jobs:
             echo "Unable to determine build version"
             exit 1
           fi  
+          
+          if [[ ${{ inputs.environment }} = "dev" ]];         then AB2D_ENV='ab2d-dev'
+          elif [[ ${{ inputs.environment }} = "test" ]];      then AB2D_ENV='ab2d-east-impl'
+          elif [[ ${{ inputs.environment }} = "sbx" ]];       then AB2D_ENV='ab2d-sbx-sandbox'
+          elif [[ ${{ inputs.environment }} = "prod_test" ]]; then AB2D_ENV='ab2d-east-prod-test'
+          elif [[ ${{ inputs.environment }} = "prod" ]];      then AB2D_ENV='ab2d-east-prod'
+          else echo "Unable to determine AB2D environment"; exit 1
+          fi
+          
           echo "BUILD_VERSION=${BUILD_VERSION}" >> $GITHUB_ENV
-
+          echo "AB2D_ENV=${AB2D_ENV}" >> $GITHUB_ENV
 
       - name: Assume role in AB2D account for this environment
         uses: aws-actions/configure-aws-credentials@v3
@@ -148,12 +157,7 @@ jobs:
           
           set -x
           
-          if [[ ${{ inputs.environment }} = "dev" ]];         then AB2D_ENV='ab2d-dev'
-          elif [[ ${{ inputs.environment }} = "test" ]];      then AB2D_ENV='ab2d-east-impl'
-          elif [[ ${{ inputs.environment }} = "sbx" ]];       then AB2D_ENV='ab2d-sbx-sandbox'
-          elif [[ ${{ inputs.environment }} = "prod_test" ]]; then AB2D_ENV='ab2d-east-prod-test'
-          elif [[ ${{ inputs.environment }} = "prod" ]];      then AB2D_ENV='ab2d-east-prod'
-          fi
+          
           
           terraform init -no-color -reconfigure -backend-config=backend/${AB2D_ENV}.conf
           terraform plan -no-color -var env=${AB2D_ENV} -out=lambda.tfplan

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -77,7 +77,10 @@ jobs:
   deploy:
     runs-on: self-hosted
     needs: publish_lambdas
-    if: always()
+    # always run this job but - if runBuildJob=true, then wait for 'publish_lambdas' job to finish
+    # without this conditional, this job will not run unless runBuildJob=true
+    if: ${{ always() && !cancelled() }}
+
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}
@@ -126,6 +129,9 @@ jobs:
           ARTIFACTORY_PREFIX: 'https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d'
 
         run: |
+          mkdir -p terraform/modules/lambda/event-service || true
+          cd terraform/modules/lambda/event-service
+          
           declare -a lambdas=(
             'metrics-lambda' 
             'audit' 
@@ -138,11 +144,4 @@ jobs:
           done
           
           echo "$(ls -lah)"
-#          mkdir -p terraform/modules/lambda/event-service || true
-#          cd terraform/modules/lambda/event-service
-#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/metrics-lambda/${buildVersion//[$'\t\r\n ']}/metrics-lambda-${buildVersion//[$'\t\r\n ']}.zip" --output metrics-lambda.zip
-#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/audit/${buildVersion//[$'\t\r\n ']}/audit-${buildVersion//[$'\t\r\n ']}.zip" --output audit.zip
-#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/database-management/${buildVersion//[$'\t\r\n ']}/database-management-${buildVersion//[$'\t\r\n ']}.zip" --output database-management.zip
-#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/coverage-counts/${buildVersion//[$'\t\r\n ']}/coverage-counts-${buildVersion//[$'\t\r\n ']}.zip" --output coverage-counts.zip
-#          curl -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" "https://artifactory.cloud.cms.gov/artifactory/ab2d-main/gov/cms/ab2d/retrieve-hpms-counts/${buildVersion//[$'\t\r\n ']}/retrieve-hpms-counts-${buildVersion//[$'\t\r\n ']}.zip" --output retrieve-hpms-counts.zip
-#          cd -
+          cd -


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6588

## Before merging this PR

- [x]  Merge [ab2d-lambdas PR #121](https://github.com/CMSgov/ab2d-lambdas/pull/121)
- [x]  Update [line 64](https://github.com/CMSgov/ab2d/blob/lambda-tf-workflow/.github/workflows/deploy-lambda.yml#L64) to set branch to `main` instead of `update-publish-lamda-workflow` 


## 🛠 Changes

- Add deploy-lamda.yml workflow to run terraform init, plan, apply
- Workflow can also reuse `ab2d-lambdas/publish-lambdas.yml` workflow to build lambdas

## Related PRs

- https://github.com/CMSgov/ab2d-lambdas/pull/121
- https://github.com/CMSgov/ab2d-ops/pull/310 

## ℹ️ Context

This workflow is migrated from 
- https://jenkins.ab2d.cms.gov/job/AB2D-Ops/job/Terraform/job/Deploy%20Lambda/build?delay=0sec
- https://github.com/CMSgov/ab2d-ops/blob/main/jenkins-files/Jenkinsfile.terraform-lambda

![image](https://github.com/user-attachments/assets/8488c403-2a91-4218-9128-d5f3062a3401)

## 🧪 Validation

Terraform apply works in dev: https://github.com/CMSgov/ab2d/actions/runs/13910578486/job/38923695969

![image](https://github.com/user-attachments/assets/05ec9f55-b372-4d8b-8470-5f3fe2416771)


```
gh workflow run deploy-lambda.yml --ref lambda-tf-workflow -f apply=true -f environment=dev -f ab2dOpsBranch=PLT-939 -f ab2dLambdasBranch=update-publish-lamda-workflow -f runBuildJob=false -f buildVersion=1.1.0
```