### PR TITLE
Make sure prod and prodtest use the same account

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Assume role in AB2D account for this environment
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         env:
-          ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment == '' && 'test' || inputs.environment }}
+          ACCOUNT: ${{ inputs.environment == 'prod-test' && 'prod' || inputs.environment == '' && 'test' || inputs.environment }}
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -96,11 +96,11 @@ jobs:
       - name: Assume role in AB2D account for this environment
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         env:
-          ACCOUNT: ${{ inputs.environment == '' && 'test' || inputs.environment }}
+          ACCOUNT: ${{ inputs.environment == 'prod_test' && 'prod' || inputs.environment == '' && 'test' || inputs.environment }}
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_ACCOUNT_ID', env.ACCOUNT)] }}:role/delegatedadmin/developer/ab2d-${{ env.ACCOUNT }}-github-actions
-
+          
       - name: Terraform Init & Plan
         working-directory: terraform/environments/ab2d/${{ inputs.service }}/
         run: |


### PR DESCRIPTION
## 🎫 Ticket

Adhoc change

## 🛠 Changes

This is to address failures on run where prodtest is selected but the account number remains blank.

## ℹ️ Context

In our step we use the environment chosen for the account number. However prod and prod-test use the same account number. We have to explicitly say they are using the same account number.
## 🧪 Validation
https://github.com/CMSgov/ab2d/actions/runs/13970690678/job/39111416664

the assume steps works fine in the run above. It failed on the backend because we do not deploy api in prod-test

