### PR TITLE
Fix error response

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.MDC;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -223,7 +223,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         response.getWriter().flush();
     }
 
-    public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {
+    private ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {
         String msg = getRootCause(e);
         HttpStatus httpStatus = getErrorResponse(e.getClass());
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -205,11 +205,11 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         httpHeaders.add(CONTENT_LOCATION, contentLocationHeader);
     }
 
-    private ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpServletRequest request) throws IOException {
+    public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpServletRequest request) throws IOException {
         return generateFHIRError(e, null, request);
     }
 
-    private ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {
+    public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {
         String msg = getRootCause(e);
         HttpStatus httpStatus = getErrorResponse(e.getClass());
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -24,7 +24,9 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.MDC;
@@ -207,6 +209,12 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
 
     public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpServletRequest request) throws IOException {
         return generateFHIRError(e, null, request);
+    }
+
+    public void generateFHIRError(Exception e, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        ResponseEntity<JsonNode> r = generateFHIRError(e, null, request);
+        response.getWriter().write(new ObjectMapper().writeValueAsString(r.getBody()));
+        response.setStatus(r.getStatusCode().value());
     }
 
     public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.MDC;
@@ -210,10 +211,17 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
         return generateFHIRError(e, null, request);
     }
 
+    /**
+     * Call {@link #generateFHIRError(Exception, HttpHeaders, HttpServletRequest)} to build a response entity
+     * and then write directly to response stream.
+     */
     public void generateFHIRError(Exception e, HttpServletRequest request, HttpServletResponse response) throws IOException {
-        ResponseEntity<JsonNode> r = generateFHIRError(e, null, request);
-        response.getWriter().write(new ObjectMapper().writeValueAsString(r.getBody()));
-        response.setStatus(r.getStatusCode().value());
+        val headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        val responseEntity = generateFHIRError(e, headers, request);
+        response.setStatus(responseEntity.getStatusCode().value());
+        response.getWriter().write(new ObjectMapper().writeValueAsString(responseEntity.getBody()));
+        response.getWriter().flush();
     }
 
     public ResponseEntity<JsonNode> generateFHIRError(Exception e, HttpHeaders httpHeaders, HttpServletRequest request) throws IOException {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -41,14 +41,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 
+import static gov.cms.ab2d.api.controller.common.ApiText.APPLICATION_JSON;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V1;
 import static gov.cms.ab2d.common.util.Constants.API_PREFIX_V2;
 import static gov.cms.ab2d.common.util.Constants.FHIR_PREFIX;
 import static gov.cms.ab2d.common.util.Constants.ORGANIZATION;
 import static gov.cms.ab2d.common.util.Constants.REQUEST_ID;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.API_INVALID_CONTRACT;
-import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
-import static org.springframework.http.HttpHeaders.RETRY_AFTER;
+import static org.springframework.http.HttpHeaders.*;
 
 /**
  * Don't change exception classes without updating alerts in Splunk. Splunk alerts rely on the classname to filter
@@ -216,10 +216,9 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
      * and then write directly to response stream.
      */
     public void generateFHIRError(Exception e, HttpServletRequest request, HttpServletResponse response) throws IOException {
-        val headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
-        val responseEntity = generateFHIRError(e, headers, request);
+        val responseEntity = generateFHIRError(e, null, request);
         response.setStatus(responseEntity.getStatusCode().value());
+        response.setHeader(CONTENT_TYPE, APPLICATION_JSON);
         response.getWriter().write(new ObjectMapper().writeValueAsString(responseEntity.getBody()));
         response.getWriter().flush();
     }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.common;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;
@@ -40,7 +41,8 @@ public class FileDownloadCommon {
         try {
             return downloadFileInternal(jobUuid, filename, request, response);
         } catch (Exception e) {
-            return errorHandler.generateFHIRError(e, request);
+            errorHandler.generateFHIRError(e, request, response);
+            return null;
         }
     }
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -36,7 +36,7 @@ public class FileDownloadCommon {
     private final PdpClientService pdpClientService;
     private final ErrorHandler errorHandler;
 
-    private ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
             return _downloadFile(jobUuid, filename, request, response);
         } catch (Exception e) {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.api.controller.common;
 
-import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
@@ -34,18 +33,8 @@ public class FileDownloadCommon {
     private final JobClient jobClient;
     private final SQSEventClient eventLogger;
     private final PdpClientService pdpClientService;
-    private final ErrorHandler errorHandler;
 
-    public ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
-        try {
-            return downloadFileInternal(jobUuid, filename, request, response);
-        } catch (Exception e) {
-            errorHandler.generateFHIRError(e, request, response);
-            return null;
-        }
-    }
-
-    private ResponseEntity downloadFileInternal(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public ResponseEntity<String> downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         MDC.put(JOB_LOG, jobUuid);
         MDC.put(FILE_LOG, filename);
         log.info("Request submitted to download file");

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -38,13 +38,13 @@ public class FileDownloadCommon {
 
     public ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            return _downloadFile(jobUuid, filename, request, response);
+            return downloadFileInternal(jobUuid, filename, request, response);
         } catch (Exception e) {
             return errorHandler.generateFHIRError(e, request);
         }
     }
 
-    private ResponseEntity _downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private ResponseEntity downloadFileInternal(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         MDC.put(JOB_LOG, jobUuid);
         MDC.put(FILE_LOG, filename);
         log.info("Request submitted to download file");

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.api.controller.common;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.common;
 
+import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
@@ -33,8 +34,17 @@ public class FileDownloadCommon {
     private final JobClient jobClient;
     private final SQSEventClient eventLogger;
     private final PdpClientService pdpClientService;
+    private final ErrorHandler errorHandler;
 
-    public ResponseEntity<String> downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private ResponseEntity downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try {
+            return _downloadFile(jobUuid, filename, request, response);
+        } catch (Exception e) {
+            return errorHandler.generateFHIRError(e, request);
+        }
+    }
+
+    private ResponseEntity _downloadFile(String jobUuid, String filename, HttpServletRequest request, HttpServletResponse response) throws IOException {
         MDC.put(JOB_LOG, jobUuid);
         MDC.put(FILE_LOG, filename);
         log.info("Request submitted to download file");

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.api.controller.common;
 
-import feign.Response;
 import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.common;
 
+import feign.Response;
 import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.remote.JobClient;
 import gov.cms.ab2d.common.service.PdpClientService;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
 import java.io.IOException;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -49,6 +51,7 @@ import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX)
 public class FileDownloadAPIV1 {
     private FileDownloadCommon fileDownloadCommon;
+    private HandlerExceptionResolver handlerExceptionResolver;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
@@ -72,6 +75,15 @@ public class FileDownloadAPIV1 {
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
 
-        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        try {
+            log.info("Calling downloadFile()");
+            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        }
+        catch (Exception e) {
+            log.error("Exception calling downloadFile()", e);
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return null;
+        }
+
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.v1;
 
+import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.controller.common.FileDownloadCommon;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,6 +50,7 @@ import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX)
 public class FileDownloadAPIV1 {
     private FileDownloadCommon fileDownloadCommon;
+    private ErrorHandler errorHandler;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
@@ -71,7 +73,11 @@ public class FileDownloadAPIV1 {
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
-
-        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        try {
+            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        } catch (Exception e) {
+            errorHandler.generateFHIRError(e, request, response);
+            return null;
+        }
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -78,8 +78,7 @@ public class FileDownloadAPIV1 {
         try {
             log.info("Calling downloadFile()");
             return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Exception calling downloadFile()", e);
             handlerExceptionResolver.resolveException(request, response, null, e);
             return null;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/FileDownloadAPIV1.java
@@ -23,8 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.web.servlet.HandlerExceptionResolver;
-
 import java.io.IOException;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -51,7 +49,6 @@ import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V1 + FHIR_PREFIX)
 public class FileDownloadAPIV1 {
     private FileDownloadCommon fileDownloadCommon;
-    private HandlerExceptionResolver handlerExceptionResolver;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
@@ -75,14 +72,6 @@ public class FileDownloadAPIV1 {
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
 
-        try {
-            log.info("Calling downloadFile()");
-            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
-        } catch (Exception e) {
-            log.error("Exception calling downloadFile()", e);
-            handlerExceptionResolver.resolveException(request, response, null, e);
-            return null;
-        }
-
+        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -24,8 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.web.servlet.HandlerExceptionResolver;
-
 import java.io.IOException;
 
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_DNLD_DSC;
@@ -50,7 +48,6 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_NDJSON_CONTENT_TYPE, FHIR_JSON_CONTENT_TYPE})
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
-    private HandlerExceptionResolver handlerExceptionResolver;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
@@ -74,13 +71,6 @@ public class FileDownloadAPIV2 {
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
 
-        try {
-            log.info("Calling downloadFile()");
-            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
-        } catch (Exception e) {
-            log.error("Exception calling downloadFile()", e);
-            handlerExceptionResolver.resolveException(request, response, null, e);
-            return null;
-        }
+        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.v2;
 
+import gov.cms.ab2d.api.controller.ErrorHandler;
 import gov.cms.ab2d.api.controller.common.FileDownloadCommon;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -48,6 +49,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_NDJSON_CONTENT_TYPE, FHIR_JSON_CONTENT_TYPE})
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
+    private ErrorHandler errorHandler;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
@@ -70,7 +72,11 @@ public class FileDownloadAPIV2 {
             HttpServletResponse response,
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
-
-        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        try {
+            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        } catch (Exception e) {
+            errorHandler.generateFHIRError(e, request, response);
+            return null;
+        }
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -25,7 +25,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.io.IOException;
 
@@ -51,8 +50,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @RequestMapping(path = API_PREFIX_V2 + FHIR_PREFIX, produces = {FHIR_NDJSON_CONTENT_TYPE, FHIR_JSON_CONTENT_TYPE})
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
-
-    private final HandlerExceptionResolver handlerExceptionResolver;
+    private HandlerExceptionResolver handlerExceptionResolver;
 
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -24,6 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
 import java.io.IOException;
 
 import static gov.cms.ab2d.api.controller.common.ApiText.BULK_DNLD_DSC;
@@ -49,6 +52,8 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 public class FileDownloadAPIV2 {
     private FileDownloadCommon fileDownloadCommon;
 
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
     @Operation(summary = DOWNLOAD_DESC)
     @Parameters(value = {
         @Parameter(name = "jobUuid", description = JOB_ID, required = true),
@@ -71,6 +76,14 @@ public class FileDownloadAPIV2 {
             @PathVariable @NotBlank String jobUuid,
             @PathVariable @NotBlank String filename) throws IOException {
 
-        return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        try {
+            log.info("Calling downloadFile()");
+            return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
+        }
+        catch (Exception e) {
+            log.error("Exception calling downloadFile()", e);
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return null;
+        }
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/FileDownloadAPIV2.java
@@ -77,8 +77,7 @@ public class FileDownloadAPIV2 {
         try {
             log.info("Calling downloadFile()");
             return fileDownloadCommon.downloadFile(jobUuid, filename, request, response);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Exception calling downloadFile()", e);
             handlerExceptionResolver.resolveException(request, response, null, e);
             return null;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/ErrorHandlerTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/ErrorHandlerTest.java
@@ -1,0 +1,116 @@
+package gov.cms.ab2d.api.controller;
+
+import gov.cms.ab2d.api.controller.common.ApiCommon;
+import gov.cms.ab2d.common.service.ResourceNotFoundException;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
+import gov.cms.ab2d.job.service.JobOutputMissingException;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class ErrorHandlerTest {
+
+    ErrorHandler handler;
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
+
+    @BeforeEach
+    void setup() {
+        handler = new ErrorHandler(
+            mock(SQSEventClient.class),
+            -1,
+            mock(ApiCommon.class)
+        );
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void test_download_job_not_found() throws Exception {
+        request.setRequestURI("https://ab2d.cms.gov/api/v2/fhir/Job/1234/file/Z0001.json");
+        handler.generateFHIRError(new ResourceNotFoundException("No job with jobUuid 1234 was found"), request, response);
+
+        assertEquals(404, response.getStatus());
+        assertJsonEquals(
+        """
+        {
+          "resourceType": "OperationOutcome",
+          "issue": [
+            {
+              "severity": "error",
+              "code": "invalid",
+              "details": {
+                "text": "No job with jobUuid 1234 was found"
+              }
+            }
+          ]
+        }
+        """,
+        response.getContentAsString());
+    }
+
+    @Test
+    void test_download_file_expired() throws Exception {
+        request.setRequestURI("https://ab2d.cms.gov/api/v2/fhir/Job/1234/file/Z0001.json");
+        handler.generateFHIRError(new JobOutputMissingException("The file is not present as it has expired. Please resubmit the job"), request, response);
+
+        assertEquals(500, response.getStatus());
+        assertJsonEquals(
+        """
+        {
+          "resourceType": "OperationOutcome",
+          "issue": [
+            {
+              "severity": "error",
+              "code": "invalid",
+              "details": {
+                "text": "The file is not present as it has expired. Please resubmit the job"
+              }
+            }
+          ]
+        }
+        """,
+        response.getContentAsString());
+    }
+
+    /**
+     * Exception messages that don't originate from AB2D code should not be sent to user
+     * See {@link ErrorHandler#getRootCause)} for details
+     */
+    @Test
+    void test_download_exception_thrown_outside_ab2d() throws Exception {
+        request.setRequestURI("https://ab2d.cms.gov/api/v2/fhir/Job/1234/file/Z0001.json");
+        handler.generateFHIRError(new PSQLException("oops", PSQLState.UNKNOWN_STATE), request, response);
+
+        assertEquals(500, response.getStatus());
+        assertJsonEquals(
+        """
+        {
+          "resourceType": "OperationOutcome",
+          "issue": [
+            {
+              "severity": "error",
+              "code": "invalid",
+              "details": {
+                "text": "An internal error occurred"
+              }
+            }
+          ]
+        }
+        """,
+        response.getContentAsString());
+    }
+
+    private void assertJsonEquals(String expected, String actual) throws Exception {
+        val mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(expected), mapper.readTree(actual));
+    }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6579

## 🛠 Changes

Fix error handling related to the download API so that error messages are displayed to the user. Currently, a blank response is returned to the user. 

## ℹ️ Context

Currently, the download API fails to return error message to the user. The server sends a blank response and HTTP 500. 

For reference, the status API returns a helpful error message if e.g. a job is not found:
![image](https://github.com/user-attachments/assets/f44e657c-1a66-4f63-8e5b-dc16c434fd87)

If an exception is thrown from the status API, the `ErrorHandler` catches the exception and returns an error response as expected. 

If an exception is thrown from the download API, the `ErrorHandler` does **not** catch the exception. The exception bubbles up until a `ServletException` is thrown. 
- The reason for this is not clear. The download and status APIs have similar configuration. The only difference is the download API method accepts a `HttpServletResponse response` which is written to directly. Spring might exclude methods like this from error handling?   

## 🧪 Validation

Deployed to IMPL and verified the following download scenarios return helpful error messages:
- Valid job ID but non-existent file
- Non-existent job ID
- File downloaded the max number of times

![Screenshot 2025-03-25 at 11 39 29 AM](https://github.com/user-attachments/assets/633036a4-30d4-4471-969e-05f780e59368)

![Screenshot 2025-03-25 at 11 39 54 AM](https://github.com/user-attachments/assets/e2f9e3fa-4f43-4da7-88e8-81920e0fa930)

![Screenshot 2025-03-25 at 11 42 53 AM](https://github.com/user-attachments/assets/a2483392-ce6c-4c6d-be14-e128bda158bd)

