### PR TITLE
[PLT-907] adding api to deploy workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,6 +41,7 @@ on:
         required: true
         type: choice
         options:
+          - api
           - api_gateway
           - core
           - controller


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-907

## 🛠 Changes

Added "api" to the list of services

## ℹ️ Context

So that deploy will uniformly create images on correct gold ami for all services.

## 🧪 Validation

Upon workflow run all services will be based on an AL2023 ami.
