### PR TITLE
PLT-970: add ASG instance refresh step for api and worker deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,36 +58,11 @@ jobs:
           set -e
           echo "✅ ECS service stabilized."
 
-      - name: Set Auto Scaling Group Name
-        run: |
-          if [[ "${{ inputs.environment }}" == "dev" && "${{ inputs.module }}" == "worker" ]]; then
-            echo "ASG_NAME=ab2d-dev-worker" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "dev" && "${{ inputs.module }}" == "api" ]]; then
-            echo "ASG_NAME=ab2d-dev-api" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "test" && "${{ inputs.module }}" == "worker" ]]; then
-            echo "ASG_NAME=ab2d-east-impl-worker" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "test" && "${{ inputs.module }}" == "api" ]]; then
-            echo "ASG_NAME=ab2d-east-impl-api" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "sbx" && "${{ inputs.module }}" == "worker" ]]; then
-            echo "ASG_NAME=ab2d-sbx-sandbox-worker" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "sbx" && "${{ inputs.module }}" == "api" ]]; then
-            echo "ASG_NAME=ab2d-sbx-sandbox-api" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "prod" && "${{ inputs.module }}" == "worker" ]]; then
-            echo "ASG_NAME=ab2d-east-prod-worker" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "prod" && "${{ inputs.module }}" == "api" ]]; then
-            echo "ASG_NAME=ab2d-east-prod-api" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "prod_test" && "${{ inputs.module }}" == "worker" ]]; then
-            echo "ASG_NAME=ab2d-east-prod-test-worker" >> $GITHUB_ENV
-          elif [[ "${{ inputs.environment }}" == "prod_test" && "${{ inputs.module }}" == "api" ]]; then
-            echo "ASG_NAME=ab2d-east-prod-api" >> $GITHUB_ENV
-          else
-            echo "Invalid environment or module provided" && exit 1
-          fi
-          echo "Auto Scaling Group name set to: $ASG_NAME"
-
-
       - name: Start EC2 Instance Refresh
+        env:
+          ASG_NAME: "ab2d-${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}-${{ inputs.module }}"
         run: |
+          echo "ASG_NAME=$ASG_NAME" >> $GITHUB_ENV
           echo "Starting instance refresh for Auto Scaling Group: $ASG_NAME"
           aws autoscaling start-instance-refresh \
             --auto-scaling-group-name "$ASG_NAME" \
@@ -123,4 +98,3 @@ jobs:
             echo "❌ Instance refresh failed or timed out. Final status: $refresh_status"
             exit 1
           fi
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,3 +58,45 @@ jobs:
           set -e
           echo "✅ ECS service stabilized."
 
+      - name: Set Auto Scaling Group Name
+        run: |
+          echo "ASG_NAME=${{ inputs.environment }}-${{ inputs.module }}" >> $GITHUB_ENV
+
+      - name: Start EC2 Instance Refresh
+        run: |
+          echo "Starting instance refresh for Auto Scaling Group: $ASG_NAME"
+          aws autoscaling start-instance-refresh \
+            --auto-scaling-group-name "$ASG_NAME" \
+            --strategy Rolling \
+            --preferences '{"MinHealthyPercentage":90,"InstanceWarmup":300}' > /dev/null
+          echo "Instance refresh started for $ASG_NAME."
+  
+      - name: Wait for Instance Refresh to Complete
+        run: |
+          echo "Checking the status of the instance refresh for ASG: $ASG_NAME"
+  
+          timeout=600  # 10 minutes
+          elapsed=0
+  
+          refresh_status=$(aws autoscaling describe-instance-refreshes \
+            --auto-scaling-group-name "$ASG_NAME" \
+            --query "InstanceRefreshes[0].Status" \
+            --output text)
+  
+          while [ "$refresh_status" != "Successful" ] && [ "$refresh_status" != "Cancelled" ] && [ "$refresh_status" != "Failed" ] && [ $elapsed -lt $timeout ]; do
+            echo "Current status: $refresh_status (elapsed: ${elapsed}s)"
+            sleep 30
+            elapsed=$((elapsed + 30))
+            refresh_status=$(aws autoscaling describe-instance-refreshes \
+              --auto-scaling-group-name "$ASG_NAME" \
+              --query "InstanceRefreshes[0].Status" \
+              --output text)
+          done
+  
+          if [ "$refresh_status" == "Successful" ]; then
+            echo "✅ Instance refresh completed successfully for $ASG_NAME."
+          else
+            echo "❌ Instance refresh failed or timed out. Final status: $refresh_status"
+            exit 1
+          fi
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,31 @@ jobs:
 
       - name: Set Auto Scaling Group Name
         run: |
-          echo "ASG_NAME=${{ inputs.environment }}-${{ inputs.module }}" >> $GITHUB_ENV
+          if [[ "${{ inputs.environment }}" == "dev" && "${{ inputs.module }}" == "worker" ]]; then
+            echo "ASG_NAME=ab2d-dev-worker" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "dev" && "${{ inputs.module }}" == "api" ]]; then
+            echo "ASG_NAME=ab2d-dev-api" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "test" && "${{ inputs.module }}" == "worker" ]]; then
+            echo "ASG_NAME=ab2d-east-impl-worker" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "test" && "${{ inputs.module }}" == "api" ]]; then
+            echo "ASG_NAME=ab2d-east-impl-api" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "sbx" && "${{ inputs.module }}" == "worker" ]]; then
+            echo "ASG_NAME=ab2d-sbx-sandbox-worker" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "sbx" && "${{ inputs.module }}" == "api" ]]; then
+            echo "ASG_NAME=ab2d-sbx-sandbox-api" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "prod" && "${{ inputs.module }}" == "worker" ]]; then
+            echo "ASG_NAME=ab2d-east-prod-worker" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "prod" && "${{ inputs.module }}" == "api" ]]; then
+            echo "ASG_NAME=ab2d-east-prod-api" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "prod_test" && "${{ inputs.module }}" == "worker" ]]; then
+            echo "ASG_NAME=ab2d-east-prod-test-worker" >> $GITHUB_ENV
+          elif [[ "${{ inputs.environment }}" == "prod_test" && "${{ inputs.module }}" == "api" ]]; then
+            echo "ASG_NAME=ab2d-east-prod-api" >> $GITHUB_ENV
+          else
+            echo "Invalid environment or module provided" && exit 1
+          fi
+          echo "Auto Scaling Group name set to: $ASG_NAME"
+
 
       - name: Start EC2 Instance Refresh
         run: |


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

ASG instance refresh step for api and worker deployments added

## ℹ️ Context

With the migration from EC2 launch configurations to launch templates, the api and worker autoscaling groups must now have their EC2 instances refreshed after a new version of a launch template is deployed in order for those instances to pick up the new AMI version specified in the new launch template version.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

GitHub action workflow
