### PR TITLE
Update SQL for 'start job' workflow

### DIFF
--- a/.github/workflows/resources/insert-record.sql
+++ b/.github/workflows/resources/insert-record.sql
@@ -1,5 +1,4 @@
 INSERT INTO ${DATABASE_SCHEMA_NAME}.job (
-    id,
     job_uuid,
     organization,
     created_at,
@@ -16,7 +15,6 @@ INSERT INTO ${DATABASE_SCHEMA_NAME}.job (
     started_by
 )
 VALUES (
-    (select nextval('hibernate_sequence')),
     '${JOB_ID}',
     '${ORGANIZATION}',
     (select now()),


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Update SQL to let the database generate the `id` for the job table using the `job_seq` sequence. Currently the script can generate a duplicate key due to using the wrong sequence. 

## ℹ️ Context

Sravanti ran [this job](https://github.com/CMSgov/ab2d/actions/runs/14391862587) in sandbox which failed due to duplicate key exception and noticed the sequence is wrong (`hibernate_sequence` instead of `job_seq`)

![image](https://github.com/user-attachments/assets/c2da1339-418e-4d5f-a66e-510fbe8fdb36)

![image](https://github.com/user-attachments/assets/5754e0c8-045e-43ea-a947-169aecee47c7)


## 🧪 Validation

Tested in sandbox - job is successful:

https://github.com/CMSgov/ab2d/actions/runs/14407081338
