### PR TITLE
PLT-891 Test build workflow on codebuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  push:
   workflow_call:
     inputs:
       environment:
@@ -26,12 +27,12 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
 
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       AWS_REGION: ${{ vars.AWS_REGION }}
-      DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', inputs.environment)] }}
+      DEPLOYMENT_ENV: ${{ vars[format('{0}_DEPLOYMENT_ENV', 'test')] }}
 
     steps:
       - name: Checkout Code
@@ -71,11 +72,11 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.MGMT_ACCOUNT_ID }}:role/delegatedadmin/developer/ab2d-mgmt-github-actions
 
       - name: Build image and push to ECR
-        working-directory: ./${{ inputs.module }}
+        working-directory: ./api
         run: |
           ECR_REPO_DOMAIN="${{ secrets.MGMT_ACCOUNT_ID }}.dkr.ecr.$AWS_REGION.amazonaws.com"
           aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_REPO_DOMAIN"
-          ECR_REPO_URI="$ECR_REPO_DOMAIN/ab2d_${{ inputs.module }}"
+          ECR_REPO_URI="$ECR_REPO_DOMAIN/ab2d_api"
           SHA_SHORT=$(git rev-parse --short HEAD)
           echo "Building image for commit sha $SHA_SHORT"
           docker build \


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-891

## 🛠 Changes

Updated build workflow to test on a codebuild runner.

## ℹ️ Context

This is a temporary change to the build workflow to test whether workflows can be run on the new codebuild runners in the greenfield account.

## 🧪 Validation

See checks.