### PR TITLE
PLT-1038 update idm url

### DIFF
--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -49,7 +49,7 @@ echo "AB2D API is online."
 
 # Refresh token
 echo "Refreshing token..."
-TOKEN=$(curl -s --location --request POST 'https://test.idp.idm.cms.gov/oauth2/aus2r7y3gdaFMKBol297/v1/token?grant_type=client_credentials&scope=clientCreds' \
+TOKEN=$(curl -s --location --request POST 'https://cms-test.okta.com/oauth2/aus2r7y3gdaFMKBol297/v1/token?grant_type=client_credentials&scope=clientCreds' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --header "Authorization: Basic $BASIC_AUTH" \
 --header 'Cookie: JSESSIONID=3E7BD665DE5673C73A82647BBD9E548A' \


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1038

## 🛠 Changes

Update the okta url for idm

## ℹ️ Context

https://cmsgov.slack.com/archives/CNVRZ73NF/p1744121296051429?thread_ts=1744054808.021109&cid=CNVRZ73NF

We are having issues with fips mode being enforced and idm not allowing access from our runners because of this.

We want to change the vanity url we're accessing so that we don't run into this issue.

## Security

IDM by default doesn't require fips with TLS 1.2. Amazon Linux 2023 uses openssl 3.x.x by default and with this comes with TLS 1.3 and fips enabled.  By switching the vanity URL we access we won't hit the same issue

## 🧪 Validation
This has been run and works now
https://github.com/CMSgov/ab2d/actions/runs/14738998143/job/41372081943
