### PR TITLE
AB2D-6704: Deploy API in greenfield

### DIFF
--- a/ops/services/30-api/README.md
+++ b/ops/services/30-api/README.md
@@ -1,0 +1,117 @@
+# AB2D API Root Module
+This module is responsible for deploying the EC2-backed ECS cluster that hosts the API service, task definition, and related IAM, Security Group, and CloudWatch resources.
+
+## Dependencies
+- core
+- microservices (properties)
+- cdap/cms hybrid cloud security groups
+- ec2 amis prepared within the AWS account
+- api container image in local ecr repository
+
+<!-- BEGIN_TF_DOCS -->
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.99.1 |<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_service_image_tag"></a> [api\_service\_image\_tag](#input\_api\_service\_image\_tag) | Desired image tag for the api service stored in ECR | `string` | `null` | no |
+| <a name="input_launch_template_block_device_mappings"></a> [launch\_template\_block\_device\_mappings](#input\_launch\_template\_block\_device\_mappings) | ECS Container Host block device map | `map(any)` | <pre>{<br>  "delete_on_termination": true,<br>  "device_name": "/dev/xvda",<br>  "encrypted": true,<br>  "iops": 3000,<br>  "throughput": 128,<br>  "volume_size": 100,<br>  "volume_type": "gp3"<br>}</pre> | no |
+| <a name="input_override_task_definition_arn"></a> [override\_task\_definition\_arn](#input\_override\_task\_definition\_arn) | Use to override the task definition managed by this solution | `string` | `null` | no |
+| <a name="input_parent_env"></a> [parent\_env](#input\_parent\_env) | The parent environment of the current solution. Will correspond with `terraform.workspace`".<br>Necessary on `tofu init` and `tofu workspace select` \_only\_. In all other situations, parent env<br>will be divined from `terraform.workspace`. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `"us-east-1"` | no |
+| <a name="input_secondary_region"></a> [secondary\_region](#input\_secondary\_region) | n/a | `string` | `"us-west-2"` | no |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_platform"></a> [platform](#module\_platform) | git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform | PLT-1099 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_autoscaling_policy.api_target_tracking_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_policy) | resource |
+| [aws_cloudwatch_metric_alarm.app_cpu_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.app_elb_http_code_elb_4xx_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.app_status_check_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.health](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.healthy_host_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.http_code_elb_5xx_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.target_response_time](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_ecs_cluster.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_instance_profile.api_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_launch_template.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_lb.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_security_group.load_balancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.pdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.cdap_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.efs_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.host_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.load_balancer_access_nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.node_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.open_access_sandbox](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.pdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_sns_topic.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_acm_certificate.issued](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_ami.ab2d](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.cms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_db_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/db_instance) | data source |
+| [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
+| [aws_ecr_image.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_image) | data source |
+| [aws_efs_file_system.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_file_system) | data source |
+| [aws_iam_role.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_security_group.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_security_group.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_sns_topic.cloudwatch_alarms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+| [aws_sqs_queue.events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sqs_queue) | data source |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/ops/services/30-api/cloudwatch.tf
+++ b/ops/services/30-api/cloudwatch.tf
@@ -1,0 +1,92 @@
+resource "aws_cloudwatch_metric_alarm" "app_cpu_alarm" {
+  alarm_name          = "${local.service_prefix}-app-cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "90.0"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.asg.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "target_response_time" {
+  alarm_name          = "${local.service_prefix}-target-response-time"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = "900"
+  statistic           = "Average"
+  threshold           = "1.4"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+  dimensions = {
+    LoadBalancer = aws_lb.ab2d_api.arn_suffix
+    TargetGroup  = aws_lb_target_group.ab2d_api.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "healthy_host_count" {
+  alarm_name          = "${local.service_prefix}-healthy-host-count"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Minimum"
+  threshold           = "1.0"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+  dimensions = {
+    LoadBalancer = aws_lb.ab2d_api.arn_suffix
+    TargetGroup  = aws_lb_target_group.ab2d_api.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_status_check_alarm" {
+  alarm_name          = "${local.service_prefix}-app-status-check-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = "300"
+  statistic           = "Maximum"
+  threshold           = "1.0"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+  dimensions = {
+    AutoScalingGroupName = aws_autoscaling_group.asg.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_elb_http_code_elb_4xx_count" {
+  alarm_name          = "${local.service_prefix}-app-elb-http-code-elb_4xx_count"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_ELB_4XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "10.0"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+  dimensions = {
+    LoadBalancer = aws_lb.ab2d_api.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "http_code_elb_5xx_count" {
+  alarm_name          = "${local.service_prefix}-app-elb-http-code_elb-5xx_count"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "10.0"
+  alarm_actions       = [local.cloudwatch_sns_topic]
+  dimensions = {
+    LoadBalancer = aws_lb.ab2d_api.arn_suffix
+  }
+}

--- a/ops/services/30-api/data.tf
+++ b/ops/services/30-api/data.tf
@@ -1,0 +1,59 @@
+data "aws_ami" "ab2d" {
+  most_recent = true
+  owners      = ["self"]
+  filter {
+    name   = "tag:Name"
+    values = ["ab2d-*-ami"]
+  }
+}
+
+data "aws_ami" "cms" {
+  most_recent = true
+  owners      = [local.aws_account_cms_gold_images]
+  filter {
+    name   = "name"
+    values = ["al2023-*"]
+  }
+}
+
+data "aws_acm_certificate" "issued" {
+  #TODO think harder about this withe ephemeral environments
+  count     = module.platform.is_ephemeral_env ? 0 : 1
+  domain    = "${local.env}.ab2d.cms.gov"
+  statuses  = ["ISSUED", "EXPIRED"]
+  key_types = ["RSA_2048", "RSA_4096"]
+}
+
+data "aws_sqs_queue" "events" {
+  name = "${local.service_prefix}-events-sqs" #FIXME just use -events
+}
+
+data "aws_security_group" "efs" {
+  #TODO Expand the filtering criteria to support ephemeral environments in the future
+  name   = "${local.service_prefix}-efs-sg" #FIXME just use -efs
+  vpc_id = local.vpc_id
+}
+
+data "aws_security_group" "api" {
+  name = "${local.service_prefix}-api-sg" #FIXME jsut use -api
+}
+
+data "aws_efs_file_system" "this" {
+  tags = {
+    Name = "${local.service_prefix}-efs"
+  }
+}
+
+data "aws_db_instance" "this" {
+  db_instance_identifier = local.service_prefix
+}
+
+data "aws_ecr_image" "api" {
+  repository_name = "ab2d-api"
+  image_tag       = var.api_service_image_tag
+  most_recent     = var.api_service_image_tag == null ? true : null
+}
+
+data "aws_sns_topic" "cloudwatch_alarms" {
+  name = "${local.service_prefix}-cloudwatch-alarms"
+}

--- a/ops/services/30-api/iam.tf
+++ b/ops/services/30-api/iam.tf
@@ -1,0 +1,9 @@
+data "aws_iam_role" "api" {
+  name = "${local.service_prefix}-api"
+}
+
+resource "aws_iam_instance_profile" "api_profile" {
+  name = "${local.service_prefix}-api"
+  path = "/delegatedadmin/developer/"
+  role = data.aws_iam_role.api.name
+}

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -1,0 +1,461 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+module "platform" {
+  source    = "git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform?ref=PLT-1099"
+  providers = { aws = aws, aws.secondary = aws.secondary }
+
+  app          = local.app
+  env          = local.env
+  root_module  = "https://github.com/CMSgov/ab2d/tree/main/ops/services/30-api"
+  service      = local.service
+  ssm_root_map = local.ssm_root_map
+}
+
+locals {
+  default_tags = module.platform.default_tags
+  env          = terraform.workspace
+  service      = "api"
+
+  ssm_root_map = {
+    common        = "/ab2d/${local.parent_env}/common"
+    core          = "/ab2d/${local.parent_env}/core"
+    microservices = "/ab2d/${local.parent_env}/microservices"
+    contracts     = "/ab2d/mgmt/pdps/nonsensitive/contracts-csv"
+    cidrs         = "/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv"
+    accounts      = "/ab2d/mgmt/aws-account-numbers"
+  }
+
+  #TODO in honor of Ben "Been Jammin'" Hesford
+  benv = lookup({
+    dev     = "ab2d-dev"
+    test    = "ab2d-east-impl"
+    prod    = "ab2d-east-prod"
+    sandbox = "ab2d-sbx-sandbox"
+  }, local.parent_env, local.env)
+
+  ab2d_keystore_location                = "classpath:ab2d.p12"
+  ab2d_keystore_password                = module.platform.ssm.core.keystore_password.value
+  ab2d_okta_jwt_issuer                  = module.platform.ssm.core.okta_jwt_issuer.value
+  ab2d_v2_enabled                       = true
+  alb_internal                          = false
+  alb_listener_certificate_arn          = module.platform.is_ephemeral_env ? null : data.aws_acm_certificate.issued[0].arn
+  alb_listener_port                     = module.platform.is_ephemeral_env ? 80 : 443
+  alb_listener_protocol                 = module.platform.is_ephemeral_env ? "HTTP" : "HTTPS"
+  ami_id                                = data.aws_ami.ab2d.id
+  api_desired_instances                 = module.platform.parent_env == "prod" ? 2 : 1
+  api_max_instances                     = module.platform.parent_env == "prod" ? 4 : 2
+  api_min_instances                     = module.platform.parent_env == "prod" ? 2 : 1
+  bfd_insights                          = "none" #FIXME?
+  container_port                        = 8443
+  cpm_backup                            = "Daily Weekly Monthly" #FIXME
+  db_name                               = module.platform.ssm.core.database_name.value
+  db_password                           = module.platform.ssm.core.database_password.value
+  db_port                               = 5432
+  db_username                           = module.platform.ssm.core.database_user.value
+  ec2_instance_type_api                 = "m6a.xlarge"
+  ecs_task_def_cpu_api                  = 4096
+  ecs_task_def_memory_api               = 14745
+  gold_disk_name                        = data.aws_ami.cms.name
+  hpms_api_params                       = module.platform.ssm.core.hpms_api_params.value
+  hpms_auth_key_id                      = module.platform.ssm.core.hpms_auth_key_id.value
+  hpms_auth_key_secret                  = module.platform.ssm.core.hpms_auth_key_secret.value
+  hpms_url                              = module.platform.ssm.core.hpms_url.value
+  image_version                         = "" #FIXME aws_ami cms or ab2d?
+  kms_master_key_id                     = nonsensitive(module.platform.kms_alias_primary.target_key_arn)
+  launch_template_block_device_mappings = var.launch_template_block_device_mappings
+  main_bucket                           = module.platform.ssm.core.main-bucket-name.value
+  microservices_url                     = module.platform.ssm.microservices.url.value
+  network_access_logs_bucket            = module.platform.ssm.core.network-access-logs-bucket-name.value
+  new_relic_app_name                    = module.platform.ssm.common.new_relic_app_name.value
+  new_relic_license_key                 = module.platform.ssm.common.new_relic_license_key.value
+  private_subnet_ids                    = keys(module.platform.private_subnets)
+  public_subnet_ids                     = keys(module.platform.public_subnets)
+  slack_alert_webhooks                  = module.platform.ssm.common.slack_alert_webhooks.value
+  slack_trace_webhooks                  = module.platform.ssm.common.slack_trace_webhooks.value
+  ssh_key_name                          = "burldawg" #FIXME
+  vpc_id                                = module.platform.vpc_id
+  cloudwatch_sns_topic                  = data.aws_sns_topic.cloudwatch_alarms.arn
+  aws_account_cms_gold_images           = module.platform.ssm.accounts.cms-gold-images.value
+
+  pdp_map = { for k in keys(module.platform.ssm.cidrs) : k => { "cidrs" = nonsensitive(module.platform.ssm.cidrs[k].value), "contracts" = nonsensitive(module.platform.ssm.contracts[k].value) } }
+
+  additional_asg_tags = {
+    Name           = "${local.service_prefix}-api"
+    stack          = local.env
+    purpose        = "ECS container instance"
+    sensitivity    = "Public"
+    "cpm backup"   = local.cpm_backup #FIXME
+    purchase_type  = "On-Demand"      #FIXME
+    os_license     = "Amazon Linux 2023"
+    gold_disk_name = local.gold_disk_name
+    image_version  = local.image_version
+  }
+}
+
+data "aws_default_tags" "this" {}
+
+resource "aws_security_group" "pdp" {
+  name        = "${local.service_prefix}-pdp"
+  description = "PDP security group"
+  vpc_id      = local.vpc_id
+  tags = {
+    Name = "${local.service_prefix}-pdp"
+  }
+}
+
+resource "aws_security_group_rule" "node_access" {
+  type                     = "ingress"
+  description              = "Node Access"
+  from_port                = "-1"
+  to_port                  = "-1"
+  protocol                 = "-1"
+  source_security_group_id = data.aws_security_group.api.id
+  security_group_id        = module.platform.security_groups["remote-management"].id
+}
+
+resource "aws_security_group_rule" "host_port" {
+  type                     = "ingress"
+  description              = "Host Port"
+  from_port                = local.alb_listener_port
+  to_port                  = local.alb_listener_port
+  protocol                 = "tcp"
+  source_security_group_id = data.aws_security_group.api.id
+  security_group_id        = data.aws_security_group.api.id
+}
+
+resource "aws_security_group_rule" "egress_api" {
+  type              = "egress"
+  description       = "Allow all egress"
+  from_port         = "0"
+  to_port           = "0"
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = data.aws_security_group.api.id
+}
+
+resource "aws_security_group" "load_balancer" {
+  name        = "${local.service_prefix}-load-balancer-sg"
+  description = "API load balancer security group"
+  vpc_id      = local.vpc_id
+  tags = {
+    Name = "${local.service_prefix}-load-balancer-sg"
+  }
+}
+
+resource "aws_security_group_rule" "load_balancer_access_nat" {
+  for_each = nonsensitive(module.platform.nat_gateways)
+
+  type              = "ingress"
+  description       = "${local.env} ${lookup(each.value.tags, "Name", "nat")} website access"
+  from_port         = local.alb_listener_port
+  to_port           = local.alb_listener_port
+  protocol          = "tcp"
+  cidr_blocks       = ["${each.value.public_ip}/32"]
+  security_group_id = aws_security_group.load_balancer.id
+}
+
+resource "aws_security_group_rule" "pdp" {
+  for_each = nonsensitive(local.pdp_map)
+
+  type              = "ingress"
+  description       = "${replace(each.key, "-", " ")}: ${each.value["contracts"]}"
+  from_port         = local.alb_listener_port
+  to_port           = local.alb_listener_port
+  protocol          = "tcp"
+  cidr_blocks       = split(", ", each.value["cidrs"])
+  security_group_id = aws_security_group.pdp.id
+}
+
+resource "aws_security_group_rule" "open_access_sandbox" {
+  count             = local.env == "ab2d-sbx-sandbox" ? 1 : 0
+  type              = "ingress"
+  description       = "Rule to open SBX to public"
+  from_port         = local.alb_listener_port
+  to_port           = local.alb_listener_port
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.pdp.id
+}
+
+resource "aws_security_group_rule" "cdap_ingress" {
+  type              = "ingress"
+  description       = "CDAP Platform Ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = [module.platform.platform_cidr]
+  security_group_id = aws_security_group.load_balancer.id
+}
+
+resource "aws_security_group_rule" "efs_ingress" {
+  type                     = "ingress"
+  description              = "NFS"
+  from_port                = "2049"
+  to_port                  = "2049"
+  protocol                 = "tcp"
+  source_security_group_id = data.aws_security_group.api.id
+  security_group_id        = data.aws_security_group.efs.id
+}
+
+
+resource "aws_ecs_cluster" "ab2d_api" {
+  name = "${local.service_prefix}-api"
+}
+
+resource "aws_ecs_task_definition" "api" {
+  #ts:skip=AWS.EcsCluster.NetworkSecurity.High.0104 vpc is assigned via a security group on the aws_lb
+  family = "${local.service_prefix}-api"
+
+  volume {
+    configure_at_launch = false
+    name                = "efs"
+    host_path           = "/mnt/efs"
+  }
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  execution_role_arn       = data.aws_iam_role.api.arn
+
+  container_definitions = templatefile("${path.module}/templates/api_definition.tpl",
+    {
+      ab2d_keystore_location          = local.ab2d_keystore_location
+      ab2d_keystore_password          = local.ab2d_keystore_password
+      ab2d_okta_jwt_issuer            = local.ab2d_okta_jwt_issuer
+      ab2d_v2_enabled                 = local.ab2d_v2_enabled
+      alb_listener_port               = local.alb_listener_port
+      bfd_insights                    = lower(local.bfd_insights) #FIXME?
+      container_port                  = local.container_port
+      db_host                         = data.aws_db_instance.this.address
+      db_name                         = local.db_name
+      db_password                     = local.db_password
+      db_port                         = local.db_port
+      db_username                     = local.db_username
+      api_image                       = data.aws_ecr_image.api.image_uri
+      ecs_task_def_cpu_api            = local.ecs_task_def_cpu_api
+      ecs_task_def_memory_api         = local.ecs_task_def_memory_api
+      env                             = lower(local.env)
+      execution_env                   = local.benv
+      hpms_api_params                 = local.hpms_api_params
+      hpms_auth_key_id                = local.hpms_auth_key_id
+      hpms_auth_key_secret            = local.hpms_auth_key_secret
+      hpms_url                        = local.hpms_url
+      new_relic_app_name              = local.new_relic_app_name
+      new_relic_license_key           = local.new_relic_license_key
+      slack_alert_webhooks            = local.slack_alert_webhooks
+      slack_trace_webhooks            = local.slack_trace_webhooks
+      sqs_url                         = data.aws_sqs_queue.events.url
+      sqs_feature_flag                = true
+      properties_service_url          = local.microservices_url
+      properties_service_feature_flag = true
+      contracts_service_feature_flag  = true
+  })
+}
+
+resource "aws_ecs_service" "api" {
+  name                               = "${local.service_prefix}-api"
+  cluster                            = aws_ecs_cluster.ab2d_api.id
+  task_definition                    = coalesce(var.override_task_definition_arn, aws_ecs_task_definition.api.arn)
+  launch_type                        = "EC2"
+  scheduling_strategy                = "DAEMON"
+  force_new_deployment               = true
+  deployment_minimum_healthy_percent = 100
+  health_check_grace_period_seconds  = 600
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ab2d_api.arn
+    container_name   = "ab2d-api"
+    container_port   = local.container_port
+  }
+}
+
+resource "aws_launch_template" "ab2d_api" {
+  name          = "${local.service_prefix}-api"
+  image_id      = local.ami_id
+  instance_type = local.ec2_instance_type_api
+  key_name      = local.ssh_key_name
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.api_profile.name
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  user_data = base64encode(
+    templatefile(
+      "${path.module}/templates/userdata.tpl",
+      {
+        env          = lower(local.env),
+        cluster_name = "${local.service_prefix}-api",
+        efs_id       = data.aws_efs_file_system.this.file_system_id
+        aws_region   = module.platform.primary_region.name
+        bucket_name  = local.main_bucket
+      }
+    )
+  )
+
+  vpc_security_group_ids = [
+    data.aws_security_group.api.id
+  ]
+
+  block_device_mappings {
+    device_name = local.launch_template_block_device_mappings["device_name"]
+
+    ebs {
+      volume_type           = local.launch_template_block_device_mappings["volume_type"]
+      volume_size           = local.launch_template_block_device_mappings["volume_size"]
+      iops                  = local.launch_template_block_device_mappings["iops"]
+      throughput            = local.launch_template_block_device_mappings["throughput"]
+      delete_on_termination = local.launch_template_block_device_mappings["delete_on_termination"]
+      encrypted             = local.launch_template_block_device_mappings["encrypted"]
+    }
+  }
+}
+
+locals {
+}
+
+resource "aws_autoscaling_group" "asg" {
+  name_prefix               = "${local.service_prefix}-api"
+  max_size                  = local.api_max_instances
+  min_size                  = local.api_min_instances
+  desired_capacity          = local.api_desired_instances
+  health_check_type         = "ELB"
+  health_check_grace_period = 600
+  default_cooldown          = 300
+  target_group_arns         = [aws_lb_target_group.ab2d_api.arn]
+  enabled_metrics           = ["GroupTerminatingInstances", "GroupInServiceInstances", "GroupMaxSize", "GroupTotalInstances", "GroupMinSize", "GroupPendingInstances", "GroupDesiredCapacity", "GroupStandbyInstances"]
+  wait_for_elb_capacity     = local.api_desired_instances
+  vpc_zone_identifier       = toset(local.private_subnet_ids)
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 100
+    }
+  }
+
+  launch_template {
+    id      = aws_launch_template.ab2d_api.id
+    version = "$Latest"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [instance_refresh]
+  }
+
+  dynamic "tag" {
+    for_each = merge(local.additional_asg_tags, data.aws_default_tags.this.tags)
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}
+resource "aws_autoscaling_policy" "api_target_tracking_policy" {
+  name                      = "${local.service_prefix}-api-target-tracking-policy"
+  policy_type               = "TargetTrackingScaling"
+  autoscaling_group_name    = aws_autoscaling_group.asg.name
+  estimated_instance_warmup = 120
+
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+
+    target_value = "80"
+
+  }
+}
+
+resource "aws_sns_topic" "api" {
+  name              = "${local.service_prefix}-api-healthy-host"
+  kms_master_key_id = local.kms_master_key_id
+}
+
+resource "aws_cloudwatch_metric_alarm" "health" {
+  alarm_name          = "${local.service_prefix}-api-healthy-host"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "20"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Healthy host count for API target group"
+  alarm_actions       = [aws_sns_topic.api.arn]
+  ok_actions          = [aws_sns_topic.api.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.ab2d_api.arn_suffix
+    TargetGroup  = aws_lb_target_group.ab2d_api.arn_suffix
+  }
+}
+
+resource "aws_lb" "ab2d_api" {
+  #TODO Consider using name_prefix for ephemeral environments... thhey may only be up to 6-characters
+  name               = "${local.service_prefix}-api"
+  depends_on         = [aws_lb_target_group.ab2d_api]
+  internal           = local.alb_internal
+  load_balancer_type = "application"
+
+  security_groups = [
+    data.aws_security_group.api.id,
+    aws_security_group.load_balancer.id,
+    aws_security_group.pdp.id,
+    module.platform.security_groups["zscaler-public"].id,
+  ]
+
+  subnets = local.public_subnet_ids
+
+  enable_deletion_protection       = contains(["prod", "sandbox", "test", "dev"], local.env)
+  enable_cross_zone_load_balancing = true
+  drop_invalid_header_fields       = true
+
+  access_logs {
+    bucket  = local.network_access_logs_bucket
+    prefix  = "${local.service_prefix}-${local.service}"
+    enabled = true
+  }
+}
+
+resource "aws_lb_target_group" "ab2d_api" {
+  name     = "${local.service_prefix}-api"
+  port     = local.alb_listener_port
+  protocol = "HTTPS"
+  vpc_id   = local.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    timeout             = 10
+    protocol            = "HTTPS"
+    path                = "/health"
+    interval            = 30
+  }
+}
+
+resource "aws_lb_listener" "ab2d_api" {
+  load_balancer_arn = aws_lb.ab2d_api.arn
+  port              = local.alb_listener_port
+  protocol          = local.alb_listener_protocol
+  certificate_arn   = local.alb_listener_certificate_arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.ab2d_api.arn
+    type             = "forward"
+  }
+}

--- a/ops/services/30-api/templates/api_definition.tpl
+++ b/ops/services/30-api/templates/api_definition.tpl
@@ -1,0 +1,129 @@
+[{
+  "name": "ab2d-api",
+    "image": "${api_image}",
+  "essential": true,
+  "cpu": ${ecs_task_def_cpu_api},
+  "memory": ${ecs_task_def_memory_api},
+  "portMappings": [
+    {
+      "containerPort": ${container_port},
+      "hostPort": ${alb_listener_port}
+    }
+  ],
+  "mountPoints": [
+    {
+      "containerPath": "/mnt/efs",
+      "sourceVolume": "efs"
+    }
+  ],
+  "environment" : [
+        {
+      "name" : "AB2D_DB_HOST",
+      "value" : "${db_host}"
+    },
+        {
+      "name" : "AB2D_DB_PORT",
+      "value" : "${db_port}"
+    },
+    {
+      "name" : "AB2D_DB_USER",
+      "value" : "${db_username}"
+    },
+    {
+      "name" : "AB2D_DB_PASSWORD",
+      "value" : "${db_password}"
+    },
+    {
+      "name" : "AB2D_DB_DATABASE",
+      "value" : "${db_name}"
+    },
+        {
+      "name" : "AB2D_EFS_MOUNT",
+      "value" : "/mnt/efs"
+    },
+    {
+      "name" : "AB2D_EXECUTION_ENV",
+      "value" : "${execution_env}"
+    },
+    {
+       "name" : "AB2D_BFD_INSIGHTS",
+       "value" : "${bfd_insights}"
+    },
+    {
+      "name" : "AB2D_DB_SSL_MODE",
+      "value" : "require"
+    },
+    {
+      "name" : "AB2D_KEYSTORE_LOCATION",
+      "value" : "${ab2d_keystore_location}"
+    },
+    {
+      "name" : "AB2D_KEYSTORE_PASSWORD",
+      "value" : "${ab2d_keystore_password}"
+    },
+    {
+      "name" : "AB2D_OKTA_JWT_ISSUER",
+      "value" : "${ab2d_okta_jwt_issuer}"
+    },
+    {
+      "name": "AB2D_V2_ENABLED",
+      "value": "${ab2d_v2_enabled}"
+    },
+    {
+      "name" : "NEW_RELIC_APP_NAME",
+      "value" : "${new_relic_app_name}"
+    },
+    {
+      "name" : "NEW_RELIC_LICENSE_KEY",
+      "value" : "${new_relic_license_key}"
+    },
+    {
+      "name" : "AB2D_HPMS_URL",
+      "value" : "${hpms_url}"
+    },
+    {
+      "name" : "AB2D_HPMS_API_PARAMS",
+      "value" : "${hpms_api_params}"
+    },
+    {
+      "name" : "HPMS_AUTH_KEY_ID",
+      "value" : "${hpms_auth_key_id}"
+    },
+    {
+      "name" : "HPMS_AUTH_KEY_SECRET",
+      "value" : "${hpms_auth_key_secret}"
+    },
+    {
+      "name": "AB2D_SLACK_ALERT_WEBHOOKS",
+      "value": "${slack_alert_webhooks}"
+    },
+    {
+      "name": "AB2D_SLACK_TRACE_WEBHOOKS",
+      "value": "${slack_trace_webhooks}"
+    },
+    {
+      "name": "AWS_SQS_URL",
+      "value": "${sqs_url}"
+    },
+    {
+      "name": "AWS_SQS_FEATURE_FLAG",
+      "value": "${sqs_feature_flag}"
+    },
+    {
+      "name": "PROPERTIES_SERVICE_URL",
+      "value": "${properties_service_url}"
+    },
+    {
+      "name": "PROPERTIES_SERVICE_FEATURE_FLAG",
+      "value": "${properties_service_feature_flag}"
+    },
+    {
+      "name": "CONTRACTS_SERVICE_FEATURE_FLAG",
+      "value": "${contracts_service_feature_flag}"
+    }
+  ],
+  "logConfiguration": {
+    "logDriver": "syslog"
+  },
+  "healthCheck": null
+}]

--- a/ops/services/30-api/templates/userdata.tpl
+++ b/ops/services/30-api/templates/userdata.tpl
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+#
+# Set more useful hostname
+#
+
+echo "$(hostname -s).${env}" > /tmp/hostname
+sudo mv /tmp/hostname /etc/hostname
+sudo hostname "$(hostname -s).${env}"
+
+AWS_REGION="${aws_region}"
+export AWS_REGION
+
+## Add an extra hop for docker networking with IMDSv2
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+echo $TOKEN
+INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+echo $INSTANCE_ID
+aws ec2 modify-instance-metadata-options --instance-id $INSTANCE_ID --http-put-response-hop-limit 2
+
+#####
+# -----------
+# Without TLS
+# -----------
+# echo '${efs_id}:/ /mnt/efs efs _netdev 0 0' | sudo tee -a /etc/fstab
+# sudo mount -a
+#
+# --------
+# With TLS
+# --------
+# Mount with IAM authorization to an Amazon EC2 instance that has an instance profile
+echo '${efs_id}:/ /mnt/efs efs _netdev,tls,iam 0 0' | sudo tee -a /etc/fstab
+sudo mount -a
+#####
+
+#
+# Setup ECS realted items
+#
+
+# ECS config file
+# https://github.com/aws/amazon-ecs-agent
+
+sudo mkdir -p /etc/ecs
+sudo sh -c 'echo "
+ECS_DATADIR=/data
+ECS_ENABLE_TASK_IAM_ROLE=true
+ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
+ECS_LOGFILE=/log/ecs-agent.log
+ECS_AVAILABLE_LOGGING_DRIVERS=[\"json-file\",\"awslogs\",\"syslog\",\"none\"]
+ECS_ENABLE_TASK_IAM_ROLE=true
+ECS_UPDATE_DOWNLOAD_DIR=/var/cache/ecs
+SSL_CERT_DIR=/etc/pki/tls/certs
+ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true
+ECS_UPDATES_ENABLED=true
+ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
+ECS_LOGFILE=/log/ecs-agent.log
+ECS_CLUSTER="${cluster_name}"
+ECS_LOGLEVEL=info" > /etc/ecs/ecs.config'
+
+# Autostart the ecs client
+
+sudo docker run --name ecs-agent \
+--detach=true \
+--restart=on-failure:10 \
+--volume=/var/run:/var/run \
+--volume=/var/log/ecs/:/log \
+--volume=/var/lib/ecs/data:/data \
+--volume=/etc/ecs:/etc/ecs \
+--net=host \
+--env-file=/etc/ecs/ecs.config \
+--privileged \
+--env-file=/etc/ecs/ecs.config \
+amazon/amazon-ecs-agent:latest

--- a/ops/services/30-api/tofu.tf
+++ b/ops/services/30-api/tofu.tf
@@ -1,0 +1,1 @@
+../root.tofu.tf

--- a/ops/services/30-api/variables.tf
+++ b/ops/services/30-api/variables.tf
@@ -1,0 +1,25 @@
+variable "launch_template_block_device_mappings" {
+  default = {
+    device_name           = "/dev/xvda"
+    iops                  = 3000
+    throughput            = 128
+    volume_size           = 100
+    volume_type           = "gp3"
+    delete_on_termination = true
+    encrypted             = true
+  }
+  description = "ECS Container Host block device map"
+  type        = map(any)
+}
+
+variable "override_task_definition_arn" {
+  default     = null
+  description = "Use to override the task definition managed by this solution"
+  type        = string
+}
+
+variable "api_service_image_tag" {
+  default     = null
+  description = "Desired image tag for the api service stored in ECR"
+  type        = string
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6704

## 🛠 Changes
- migrate terraform/(modules|services)/api from the legacy ab2d-ops repository into this repo
- migrate cloudwatch aspects from terraform/modules/web related to API into this api root module
- introduce modest documentation for the greenfield effort
- initial deployment of api in greenfield supporting `dev`

## ℹ️ Context
Greenfield migration.

## 🧪 Validation
This was successfully deployed in the dev greenfield environment.