### PR TITLE
AB2D-6371: Add Bulk IG Support to CapabilityStatement

### DIFF
--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityStatementR4.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityStatementR4.java
@@ -52,6 +52,8 @@ public class CapabilityStatementR4 {
         implementation.setUrl(server);
         cs.setImplementation(implementation);
 
+        cs.addInstantiates("http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data");
+
         CapabilityStatement.CapabilityStatementRestComponent rest = new CapabilityStatement.CapabilityStatementRestComponent();
         rest.setMode(CapabilityStatement.RestfulCapabilityMode.SERVER);
         CapabilityStatement.CapabilityStatementRestSecurityComponent security = new CapabilityStatement.CapabilityStatementRestSecurityComponent();


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6371

## 🛠 Changes

Added the bulk data IG to the "instantiates" field of the v2 CapabilityStatement

## ℹ️ Context

This will let FHIR clients know the capabilities of the our FHIR server, and where they can go to reference more info

## 🧪 Validation

Hit the `/v2/fhir/metadata` endpoint and confirm that the "instantiates" field is there, with a value: `["http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"]`
