### PR TITLE
Temporary path to okta pdp credentials

### DIFF
--- a/.github/workflows/e2e-test-gf.yml
+++ b/.github/workflows/e2e-test-gf.yml
@@ -60,10 +60,11 @@ jobs:
             ARTIFACTORY_USER=/artifactory/user
             ARTIFACTORY_PASSWORD=/artifactory/password
             AB2D_BFD_KEYSTORE_PASSWORD=/ab2d/${{ env.AB2D_ENV }}/worker/sensitive/bfd_keystore_password
-            OKTA_CLIENT_ID=/ab2d/${{ env.AB2D_ENV }}/okta/sensitive/test-pdp-100-id
-            OKTA_CLIENT_PASSWORD=/ab2d/${{ env.AB2D_ENV }}/okta/sensitive/test-pdp-100-secret
-            SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/${{ env.AB2D_ENV }}/okta/sensitive/test-pdp-1000-id
-            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/${{ env.AB2D_ENV }}/okta/sensitive/test-pdp-1000-secret
+         # ToDo: replace 'dev' on 'mgmt' (or 'global') when available
+            OKTA_CLIENT_ID=/ab2d/dev/okta/sensitive/test-pdp-100-id
+            OKTA_CLIENT_PASSWORD=/ab2d/dev/okta/sensitive/test-pdp-100-secret
+            SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/dev/okta/sensitive/test-pdp-1000-id
+            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/dev/okta/sensitive/test-pdp-1000-secret
 
       - name: Run e2e-test
         env:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

Okta test pdp credentials are similar across any test environment


## ℹ️ Context

Okta test PDP credentials are consistent across all test environments. For now, I've hardcoded the 'dev' environment in the paths, since global parameters like `/ab2d/mgmt/okta/sensitive/test-pdd-100-id` or `/ab2d/global/okta/sensitive/test-pdd-100-id` are not yet available in the Parameter Store.
(https://cmsgov.slack.com/archives/CNHDC8HCZ/p1750784019465209?thread_ts=1750778670.552399&cid=CNHDC8HCZ) 
## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
