### PR TITLE
AB2D-6746: Encode account level test credentials

### DIFF
--- a/.github/workflows/e2e-test-gf.yml
+++ b/.github/workflows/e2e-test-gf.yml
@@ -60,10 +60,10 @@ jobs:
             ARTIFACTORY_USER=/artifactory/user
             ARTIFACTORY_PASSWORD=/artifactory/password
             AB2D_BFD_KEYSTORE_PASSWORD=/ab2d/${{ env.AB2D_ENV }}/worker/sensitive/bfd_keystore_password
-            OKTA_CLIENT_ID=/ab2d/dev/okta/sensitive/test-pdp-100-id
-            OKTA_CLIENT_PASSWORD=/ab2d/dev/okta/sensitive/test-pdp-100-secret
-            SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/dev/okta/sensitive/test-pdp-1000-id
-            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/dev/okta/sensitive/test-pdp-1000-secret
+            OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-100-id
+            OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
+            SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-1000-id
+            SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret
 
       - name: Run e2e-test
         env:

--- a/ops/services/00-bootstrap/README.md
+++ b/ops/services/00-bootstrap/README.md
@@ -1,3 +1,9 @@
+# AB2D Bootstrap Root Module
+
+This root module is responsible for creating the account-level resources that all environments share and depend on.
+
+**NOTE** Only `test` and `prod` environment workspaces are honored by this module. Because these resources are not specific to any one environment, named resources either do not identify a specific environment, or identify as `mgmt`.
+
 <!-- BEGIN_TF_DOCS -->
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'

--- a/ops/services/00-bootstrap/README.md
+++ b/ops/services/00-bootstrap/README.md
@@ -1,0 +1,68 @@
+<!-- BEGIN_TF_DOCS -->
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.99.1 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_parent_env"></a> [parent\_env](#input\_parent\_env) | The parent environment of the current solution. Will correspond with `terraform.workspace`".<br/>Necessary on `tofu init` and `tofu workspace select` \_only\_. In all other situations, parent env<br/>will be divined from `terraform.workspace`. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `"us-east-1"` | no |
+| <a name="input_secondary_region"></a> [secondary\_region](#input\_secondary\_region) | n/a | `string` | `"us-west-2"` | no |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_platform"></a> [platform](#module\_platform) | git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform | PLT-1099 |
+| <a name="module_sops"></a> [sops](#module\_sops) | git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/sops | PLT-1099 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/ops/services/00-bootstrap/main.tf
+++ b/ops/services/00-bootstrap/main.tf
@@ -1,0 +1,52 @@
+module "platform" {
+  source    = "git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform?ref=PLT-1099"
+  providers = { aws = aws, aws.secondary = aws.secondary }
+
+  app         = "ab2d"
+  env         = local.env
+  root_module = "https://github.com/CMSgov/ab2d/tree/main/ops/services/00-bootstrap"
+  service     = local.service
+}
+
+locals {
+  service      = "bootstrap"
+  default_tags = module.platform.default_tags
+  env          = terraform.workspace
+
+  ecr_container_repositories = toset([
+    "ab2d-api",
+    "ab2d-worker",
+    "ab2d-properties",
+    "ab2d-contracts",
+    "ab2d-events"
+  ])
+}
+
+module "sops" {
+  source = "git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/sops?ref=PLT-1099"
+
+  platform = module.platform
+}
+
+resource "aws_ecr_repository" "this" {
+  for_each = local.ecr_container_repositories
+
+  name                 = each.value
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
+  tags = {
+    # strip ab2d- from container repository name to yield service
+    service = replace(each.value, "ab2d-", "")
+  }
+
+  # ECR Repository-Level Scanning is Deprecated
+  # Leave this `false` until it is fully removed from the API, provider
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+

--- a/ops/services/00-bootstrap/tofu.tf
+++ b/ops/services/00-bootstrap/tofu.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+locals {
+  app              = "ab2d"
+  established_envs = ["test", "prod"]
+  parent_env = coalesce(
+    var.parent_env,
+    contains(local.established_envs, terraform.workspace) ? terraform.workspace : null,
+    "invalid-parent-environment;do-better"
+  )
+
+  state_buckets = {
+    test    = "ab2d-test-tfstate-20250410134820763500000001"
+    prod    = "ab2d-prod-tfstate-20250411202936776600000001"
+  }
+}
+
+variable "region" {
+  default  = "us-east-1"
+  nullable = false
+}
+
+variable "secondary_region" {
+  default  = "us-west-2"
+  nullable = false
+}
+
+variable "parent_env" {
+  description = <<-EOF
+  The parent environment of the current solution. Will correspond with `terraform.workspace`".
+  Necessary on `tofu init` and `tofu workspace select` _only_. In all other situations, parent env
+  will be divined from `terraform.workspace`.
+  EOF
+  type        = string
+  nullable    = true
+  default     = null
+  validation {
+    condition     = var.parent_env == null || one([for x in local.established_envs : x if var.parent_env == x && x == terraform.workspace]) != null
+    error_message = "Invalid parent environment name."
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+provider "aws" {
+  alias = "secondary"
+
+  region = var.secondary_region
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket       = local.state_buckets[local.parent_env]
+    key          = "ops/services/${local.service}/tofu.tfstate"
+    region       = var.region
+    encrypt      = true
+    kms_key_id   = "alias/${local.app}-${local.parent_env}-tfstate-bucket"
+    use_lockfile = true
+  }
+}

--- a/ops/services/00-bootstrap/values/prod.sops.yaml
+++ b/ops/services/00-bootstrap/values/prod.sops.yaml
@@ -1,0 +1,45 @@
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/avalon-insurance: S8067
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/banner-health: S3147
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/cambia-health: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/centene-wellcare: S5810,S5768,S4802
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/cigna-health: S5617
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/clear-spring: S6946
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/humana: S5884,S5552
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/mutual-of-omaha: S7126
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/navitus-health: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/regence-oregon: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/silverscript: S5601
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/united-health: S5805,S5921,S5820
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/avalon-insurance: ENC[AES256_GCM,data:gwg+QYmSsLghrDK9tEhy+0g=,iv:RKebenkajLlRBQjOtAoeHt66MrR385q+fji1H8KfTHU=,tag:MAUd9sLup9PTe7jjurHhJg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/banner-health: ENC[AES256_GCM,data:NvZoTH6QqFfXI3/oMO7selKqvMRfQJshuyLfjEGCu+PfDwtWNvVDFLXAwYl+PHd3Frxr9KCEew==,iv:cGN88c4sAyDlTViLKoccMROsIua5ujqp/onhkrt2atI=,tag:3Kik5s4J5qHZetXt4TMgBA==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/cambia-health: ENC[AES256_GCM,data:GuhvhQ+Nifr7oD5WGvSOcBY=,iv:Yyji3CIzQgVEmSXUFJkTefhqBUEZr4/1wrYVQvfDA3I=,tag:wX9fejAN94AoWmeCI0cgvQ==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/centene-wellcare: ENC[AES256_GCM,data:SEoblPqEA107h2F9IdS81i3rjzwJ3yKuUDKqx1cJTPVi072vFRtfZH4zP0wc4OVdKPrcyR3si42wU8dXcMJq1N7fcFacv+XMPycey8SexCSQ+ZtWPSgJip9SU9NmsOU6domBAyNresT6aXoUrzEz3YTkr+632t91NUfr62FQlzSeaxi7oOSjqOnbUmO+3rXOsrZyobjj1MamJmZh7TOuSs2kYqp+2C9emQaBe+YGQipD9unKk7tbXNlYsPm+Sx9wpVGFmTOgY65eUEz3DMBJ+Cd6Vj+WufS18fZexl9d+Co4ySGEuSKWXMrtKc9pjp5iPApinTDGT4w=,iv:OtJtVFFOKw49F8hjyvvROeZwzhvNBSjHYzzQbdt/gTE=,tag:iRyaNPKoNKvwnG7bI3MZqw==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/cigna-health: ENC[AES256_GCM,data:O92pamKzWYc5xnKv/mw=,iv:fNXRONBE8SfWlhaIfTTlUtJWbfg1nPJ50YzlbXlaZSA=,tag:3yaTh0LJiOlIRR7BoUKxdQ==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/clear-spring: ENC[AES256_GCM,data:/2mFubwlkBM8Tl4soNz2AzRkG5gCnrwNB/XAbqKxCJWepA==,iv:vcsCgIQ+MGBLWSzIBQTL7zgK7Mvi7k0SVZQPe397BI4=,tag:1P0xanISD3Xo6/gDFp4hhw==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/humana: ENC[AES256_GCM,data:Q0s5dJ3CluWHbF153dfCU2U=,iv:EaV8CYtUqqOvef4xKDAqLOZxIk1JheZfHNb1LjxnfBk=,tag:eL5ch8b05IRmyAbSRFp/Tg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/mutual-of-omaha: ENC[AES256_GCM,data:LQqJsqct44A4fxRb2fsbIenmP/vZiyiwhE1ZQ9SSaSb25k1IYndiq5OugRLp+QNkdBAEout4aS5lYL00+VDiRglu+w5pG1X2XCB0kmR4oZytJQJ9iEhd1mPJ1Ya/+LvZhfke2zYDjxWZ2376sWi1TttsRwkDcN6n,iv:kkwuAmVCWz1xYQjD6sk5hb14eGhRwBgh2z2EwD014JI=,tag:e7Pvws9HkPdPB62rLQA/Mg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/navitus-health: ENC[AES256_GCM,data:Kl7EeiWMMlOglq6ze+Z/,iv:a+pZ2jc7mQckX6QML0qDWnkU84ZbWQBJtyN6rKRqLio=,tag:KbZ1TRKvPf3XrfReubjc1Q==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/regence-oregon: ENC[AES256_GCM,data:kT0yl0uk0kI/H2WdMaWdTQ==,iv:hUYmx6ZkDUnUpvzLkHsulGtxuemVIYnlWTMImeAxfK0=,tag:Ufy687xbNTe3yzBIILA5zw==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/silverscript: ENC[AES256_GCM,data:8EpalRwzzOF9O7eNAH+AShV+yZl+iAAtrNLcJ4TsPkRYyNPSfI8xz7thw/SM5j62AdKOQQ/3s00A1w+g0ieM2S9EHD8iFz26Q+G66R8a6p4SEwi95qSGfUXRGdHPwMNvrHGjZwcmiL5pjejHSlK/YNDD,iv:27m73uhcLRmsJXXSXIFjzPgvqxStkEbgSoqDBqJAxzw=,tag:CtbyDfStb32Vl1B1ALvkqg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/united-health: ENC[AES256_GCM,data:cEFl9jbxoL0lQ3gSqJehA158,iv:jP+4ymDT7z4aDKvKgcX/JolR2XwrYzIzc0if3ho1YWs=,tag:cV4F2Ss5eSoe5J0J1W32TQ==,type:str]
+/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:Zs4JrgK+AZ1wz52GuB3OZpMjublg4w2/+KVIAuqhjTxNeakt9tbpvsTf4iami46fNscNYaU9EKHLI0ilzeDR9e+H8CSVk6dGHBhSYnnJzUK490ADNSt7BVTl7LNnqDqriuHBAGz/Akce4BeSkEfFlpxOdXZTNHzCxmD+PR3r15U19Ewq6yZmcfZx2RviCQCehsyIuzVDrKVVBeFc8jn5RHXOlNnfEtGN0nFKQ19F0YnQDM99rGI1LgouETjI4zIY2x/nLEIkDNHBH1jxIyz+34QkQaa4hTKTvA3N8rWXkoRaV+l3KWdo3cmxTWg/0qro8b3rcvYkQ0rYIU+BVMsEYx7kVpgCMW1VzcyNRmeTW46+WYG0tHryENDeWvkCpxM0/DaSVxL596rCq7C7wFuLTbUvlMz+lmc5wn9PeHgkqCICxXNxxCud4368GnMUJj2ZAMcNzH/ah1ZjHC2DRUNFVx5D8R44llcmgc7i+NXgR+yE9Je93CRj+YKjKFRgyv61b7DlfAszl/Nuvzi80Ibq3Thl/7AGNJtkG19yf7ctnWs83pSp6Fzzi/eetpWt/wB0/7IluFiyjnUnlyxyLz2tUFEfGLxgnF9HTGfsjeRCcosr2qefa/QL09+BoqgwvXTHJndR9KZ2UH1zgK9gF+qoEfoPetfHHFW951P2/VEFrVB1+iaGgx8mlyPKNdSl6mHDrYyK4FGxvzKyba9zrys75ntS7P24hBVAUBKWhdtRz864uRYJ2/aoDW35Dcudez9C9a2F33A6tF2qWIgAwgPNjglcmnQHsTy9GRE90yZNNGng2P+L8NVm3ATSHgEKVdXroDN4BzBxs13ux1fBRyiLMkFSyMPneqUJhkdB7hzussE204hKSzKPJ1A2lqB7y8OVox1IxjhBtjC/5bWSWibh9NDpm3+co5PuIeIAmCeG1OEqcHCJOZ1Z6EKL06uUnVhWX4bW9zgoiA21v3yiClWklYyQMB4xPma6VL9uBGRJ6OuyxDGbtLTNja2GMXCLyspSXyY77DIrtZ9l+8ve2Cy6,iv:PPMx7c21hjfs48+ts0qSpBr3F0/wFw9szugRt9B9k2I=,tag:oLSeNFfdM6rNIkwgHpE/4Q==,type:str]
+/ab2d/mgmt/artifactory/nonsensitive/url: https://artifactory.cloud.cms.gov/artifactory
+/ab2d/mgmt/slack-webhooks/sensitive/ab2d-slack-alerts: ENC[AES256_GCM,data:waCpQX/XxXYYTKMMlSjI+JANTXaOhrpbOOKDjfvAGbEfYo/YyVDEfIal/nrmAtsSlCX4un5wzsahhNy1tZm37Z97pKP23m7v1dWRiq3hLA==,iv:l0EWqKWapuxOSB+qjesk+oaLH9bn22clno+KgPVa6cc=,tag:TaSEyt6EJQisGAp6JIFsWw==,type:str]
+/ab2d/mgmt/slack-webhooks/sensitive/ab2d-security: ENC[AES256_GCM,data:vcCWMy+1z78xRSfms72opb246OlHvdt/ytPfwaWjgx8XuSeAdl3Dbctm99vi/siHxT2X5t7Y+Z7MqcsJ8F6kArv1zmdPkbF5TjIaWexEmw==,iv:tR8iIvIol5BkRYY4VQBStM8gDY3XXjtgUof6vM4uQ5g=,tag:e6NgmJcZJVEzDe84tib2Rg==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-1000-id: ENC[AES256_GCM,data:GHjlAuKnUb39EJ0upP72KzDAca8=,iv:xrT1Tnvxa1ZMy5GW1zm5deoKmBFsNdkBFfTVFpRs57s=,tag:lwF6PCvNUE+mRDG9h2KSVw==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret: ENC[AES256_GCM,data:i0VlfH2mr11I+6Dxu9OmC+ejbPLAhLCh6SLdP6wSDI2RFrlv75YSxA==,iv:p7qAIl0BoVb3PSiUjF204Jzpaf6xC1iUUyA9+yf+NsI=,tag:vczXBSIEdIUVZs9BaMCjgA==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-100-id: ENC[AES256_GCM,data:EtdmWLJ4bsRQ3Ng04GCeRnMdB/o=,iv:OkKEv20WhW9oQiB/jG6WK/Kppyl2b2srLuJ42Gd0794=,tag:KMejN0ew/S4i7ghlTPqZiw==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-100-secret: ENC[AES256_GCM,data:tUS1YB7YoTagFTvsZd4193FCLAr9eyCa0b+BIvUAFu4bJidacxROKw==,iv:n1PqC7bEB59Ogxzhn2Mmp9ia1EPY2yXTh5K5Mv8et9g=,tag:xfv/x7sxrOOaFoYiflze7Q==,type:str]
+sops:
+  kms:
+    - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/ab2d-prod
+      created_at: "2025-06-30T19:15:02Z"
+      enc: AQICAHiiBcH1zXWffn77hoG6y6pEPZ+4jjugLfsVfebBM+L/LgHlCl+ZPjCo8JOcN+bft1xHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMgPYKsm4D+zfL36ByAgEQgDtAhv+GhjCNaxDzir/C4y7RDWMunWNoBhCrfkEUYO/LGI7e/Y3NtNwzLgSR87sI+GXER0s9NJ6vtW9+Cg==
+      aws_profile: ""
+    - arn: arn:aws:kms:us-west-2:${ACCOUNT_ID}:alias/ab2d-prod
+      created_at: "2025-06-30T19:15:02Z"
+      enc: AQICAHhQOCwYYioO/Y8DTCCF3UDslbqq7E89gMxakADNsQ0frwHZhUFhT3cxecuIluMEm26wAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMn3o8iTDE/yxepTTnAgEQgDsZ1rfL+6FMEpIK10eiNjmMM8E2jNVeGGQbAZSvpnWYdxBUet6iCZtDaHs7Od70oegQvAJjpTbA12+ecQ==
+      aws_profile: ""
+  unencrypted_regex: /nonsensitive/
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/ops/services/00-bootstrap/values/test.sops.yaml
+++ b/ops/services/00-bootstrap/values/test.sops.yaml
@@ -1,0 +1,46 @@
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/avalon-insurance: S8067
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/banner-health: S3147
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/cambia-health: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/centene-wellcare: S5810,S5768,S4802
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/cigna-health: S5617
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/clear-spring: S6946
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/humana: S5884,S5552
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/mutual-of-omaha: S7126
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/navitus-health: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/regence-oregon: No contract listed
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/silverscript: S5601
+/ab2d/mgmt/pdps/nonsensitive/contracts-csv/united-health: S5805,S5921,S5820
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/avalon-insurance: ENC[AES256_GCM,data:qN5lQQt4+p7B0tPzK7pXoGw=,iv:quvi/mXBYKBiOwutn6/6gLSRaDgpa74jMYxCROhExHY=,tag:DAym6sBpg70khxELNxvbtA==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/banner-health: ENC[AES256_GCM,data:HnngsjPBNBGBMNDnWgiqOQv127OxdvbWSO2KKNi13OLGV0a4rHCzc7r3t84DhrWlQTcfMPBQbA==,iv:y7SmG0CmNkQIn4qDA0f3bpGm/Un5VnVzZVwTJGlHf0Y=,tag:rP1/QEsR3sexCEJsWV2hCg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/cambia-health: ENC[AES256_GCM,data:guyv9xMQV1tIFNZSJs3jr4o=,iv:a1yZoh3jVi+a+bfridh/Bdf3/bFNQy5i/rbINYBWXMw=,tag:44OMEETkuVJddQr0epeL4A==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/centene-wellcare: ENC[AES256_GCM,data:rdGZjsk89weqiZIGapiclSuj7yadjv+7EQztff9flSdpM8huobIyIE/z7MNJMKlSMHGB6+M3AvaGQi2OMpbqLnmmHrqeCj/02nstGBxM/DC3O4Uk3vewdBOc6jJ/BJXimP8dhwJWYANg3QbfFB15hrrfdeLT0xOQsY0Q96/j4W++HcHSryEVTQtnPPnA35tErOr1Ptb9i9RWYbh8nvW8KydEUZ2y7j76KxpCZpAZwo14t+/ZQ/Ph8y0kcYP/q4g3dgnNo+LRVSfQtdf2AlkiakYyeSC3DXz7JQCYFGCQpp2XS8AzcMhMqxL/tHl45GZEHZl/Ld38jQA=,iv:TDPN3ptITW9nZkcXmSD6aDoZ4wE12dZUdkK/V2/zj9k=,tag:EEsiT1f6Gnk25SYcVWuqrg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/cigna-health: ENC[AES256_GCM,data:wBHJ+g+DVdLzdSBBNU4=,iv:+ez7WTxoKxP6yaQ89SMg9yaIoFqdfLl+IhKW8RMFZ/g=,tag:Y66R437e7EWJgI8lwRYIZQ==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/clear-spring: ENC[AES256_GCM,data:KBt+Vp14pr2AfTZCucR4NetOWwaMKYRR1NlqZv+yZr2gRg==,iv:upIVI0lQ8y4QtTVzt/Q7YBrVQUBMH0G5MLuNvnQQ/kI=,tag:Z5QgGX5ZSs21zztfynuubQ==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/humana: ENC[AES256_GCM,data:lG7nc3ymuCys4G/Ap/rklQg=,iv:EEn+o8C4rn718C/JWkq0BcasM92wY+fXaYQxVOu2keY=,tag:YsxsGiO+Lq/KPFGcEz1Pug==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/mutual-of-omaha: ENC[AES256_GCM,data:J12Ioawg5z987yd6rVZp4gykMeX3hUb/x6WuojWDedt1yqtorVWIDp0C6qx+sFI/LACEH62Hw7E9O9r52G52rBUz0aFez9FkTqzyCDI4rICP2rIbaEF7EMqV7M5s82JYS/V/j0wpwg627/fCqIqYyytqd+R2LMDo,iv:Sl7heXxKBPwOOdGJ5v3CbP+Rha8wPn/K1u11kySHhO4=,tag:0sEebjmjJeQ+ZgAkfUW4yw==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/navitus-health: ENC[AES256_GCM,data:22RH74SOtPDmM882mvke,iv:ddKoyo6jwLbHzVVJWvKRa/SYOBQkEESlhJ4rdDOozyY=,tag:QEQ3ei3Pdo1kSGUhAC/smQ==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/regence-oregon: ENC[AES256_GCM,data:NzJnHjmimIYhWas9rgUynA==,iv:ctKPhkp+Yl1wf3BqJ4kTtHWe53HLgV+bBLAxipbpH3w=,tag:lL/RZJxjeSVLkAESLkWrRg==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/silverscript: ENC[AES256_GCM,data:ytwhodJyFZv1/s6RhLRNgIjptpq6ZfkcHml/Izttm24/cCwOBSIso24HNhO1e4TgLz0lxutLWHVDsdbQy6prIlQWRY4p6Wa/T2JCdmzxl3L2kyFFTI9pvGjnI+LmesQ7Y1Fan+0lfoeoNAIyEW5YoMRG,iv:qd1NcSf0lRjNhM8gQglt8Iyddztd3ITgeVwzZzeddNU=,tag:tSIlvV/FbDit9Dmwn6X+Mw==,type:str]
+/ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/united-health: ENC[AES256_GCM,data:N9VvCFeiyWxIfY7ggjO5VjEE,iv:NoIJHFJy6PA1OHDIIafLmH+ZpvGDTmAA48qmiF3r+7U=,tag:ZyguVJ6o1paHOebTku+tHw==,type:str]
+/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:Fza3n5j1g2B57Ckn3hG+TgEKyq8MOIX1jF7LOqX20rXVd9ZTC3CB1SejabJ/+l/0dxa+P3EX8A2gtLd7YaKB01wAd0eDwqp4Em9da296GAEr4PqJGllxUjDoPGkW2OssyUbVdhdxB76kzWgQ/IHXLduCCzNDeLTt6koF32GFQ3pnxI2N41QrSoZikRiY8QkBafIPIuVKSk031PozOHNu/gS0kPO5dt9R1HP6oBluqRDGKBl4GOCmmrVupsYtUgu1ZdRr7jz+SoAXzOOXcDF+H3ipr2xQV7VH53Ebrmobt1zOrDgMWC2O1VMDnHV4pp3Tya0yZYeGMOSTU0+/LSdjoxm7wO6nEvKx6fUG/NleI0KAQgtbY+UeqbDtz4DJO/b2niJfvhZCmgdZu8NlUbWi/L2xD/QmNdmssnvJDe95DIUArfND8pJ14OcVGBVjnsrp5m6SenumEPYXLt0JzOkItlEqk3fbeLPQCLbAQcBOxyEMO+3pmCBZ96PrndANKVQBCWPEvW/NwFiL7YxZg63lOwLs54AIzZcxlXB5O0W/sN0HL7St5bhLOGjQW8E3Ruut35IeP5o/bQCFNrRZ6ZEsuYj+KKcQKSrZlByecbaFJppXR7uN9y0fpCjJqFm2qf4q58lETb1b83YkMMHG1tH5nSkEGqZRxuMNV6cr4JiRM8NogNVp3gSUzbfF11G5DpBaUFRuTDNf1hjNns1aOhIM6oZEUR44Sv421gvWslpbj06XsiQZPvxz6wOeVys59BLkhsTy9cQFQaQhDC9ninWE9917iMzfrjXJlizRI9TtBufGV3x+pznXtTaA0J3+8ebeYCwMysV+ALas+3pTRSXBs23RlXq/uaiq2UwLC4VjGcvz9AxvawzNQqdAKJRlnz9dP7nlxdpQYtUrRMnKzzM5Qlq+WY7f2CwZEAGJPZtcI6Et6JciFuKMhhDhI5TnNy/ThxN5h2bkajygggjUD5dTiTm1fi/i3BapUCYduWZPqhtwu2YfPCNOHGgDNu5zvdQ3CZSctffZtGPUf2k8f06Y,iv:mUIzvFO06PK///G+6LIoj+B67075NiiQ9MKGwSbbas0=,tag:ZdNvMdiYC6RrxQYQTf/ndg==,type:str]
+/ab2d/mgmt/artifactory/nonsensitive/url: https://artifactory.cloud.cms.gov/artifactory
+/ab2d/mgmt/slack-webhooks/sensitive/ab2d-slack-alerts: ENC[AES256_GCM,data:58Y7rl8CyfaS3jZSXpPy8CKgtAovX/9A+9u2cbDZUmoYcYbtsEPV2rQIMeg4FKNYLwubQr5RY2lAPDxpWVF3aTLvRLPN6YjeH1flrVCRmA==,iv:6riIsnw2dBUOb4U4yDqYd29o5y27hQKHJVkRG8Sq3nc=,tag:x/4p0Q37Bh7bhsZQRjY23w==,type:str]
+/ab2d/mgmt/slack-webhooks/sensitive/ab2d-security: ENC[AES256_GCM,data:V0zGPxtcaW5nR/aekV+ZYJ+vsEmz7JCE8cK73Ru1+c8J2Aab8sRmjAU4a5NbgRXEtUPSwrAVSpBXsauQQ82c5N5e5qxtY80rvPAcmnZ+jw==,iv:3ad/GlKVHfLQwXGeno0B72C/qtelOVd6oN7xpn0jgxM=,tag:yzWGyRF7RLMoBkrjix5K5A==,type:str]
+/ab2d/mgmt/aws-account-numbers/sensitive/cms-gold-images: ENC[AES256_GCM,data:q378dyJ+xwEwGTpJ,iv:DXpKTwKnhGF9JU8TtNd/TnaCatBuNgL5kfE74q/mHoI=,tag:r3qjJn0Mnxqqm3XS8Q+Auw==,type:int]
+/ab2d/mgmt/okta/sensitive/test-pdp-1000-id: ENC[AES256_GCM,data:kF2TjKLoPc5m8749FFY7FlkPI/U=,iv:Z3ytMHKNhfcaeQ1hMHpBD+a4Feq7W1rLTHVjVUrPKlc=,tag:kG7axfJxwtHekYqFLXn47g==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret: ENC[AES256_GCM,data:Q8MsB1OUvMph5E0VpIc/BKrZ7NMrP9XpWAyDcVJMRfFs5AI1mx7aqQ==,iv:vdHqH3efCduf1cNUkzQ+Xa0eIRclv8QRrNQG5gvTbqg=,tag:hRRiHFpvIg3/G3ByEEO1nw==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-100-id: ENC[AES256_GCM,data:HgbdzulT7rINHJXuzi+CZy/xYoU=,iv:4bB6Kgq544NxaB7dzWWJQ9+ngwmH63U76Z71rbcf6jo=,tag:LPuZGQ9wuGgTp8d00pFBLw==,type:str]
+/ab2d/mgmt/okta/sensitive/test-pdp-100-secret: ENC[AES256_GCM,data:7yTny1G/owPKO1ENKfrq7x+KCv9M2AKDLcfxkxF6jswj9CxaYJKvCw==,iv:oWrz/USSCr7C/dsbanP8tdlZZdrAHJHOPn5vx5P2qhE=,tag:7QZbrdYEDoqmgERImjXMnQ==,type:str]
+sops:
+  kms:
+    - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/ab2d-test
+      created_at: "2025-05-30T19:53:41Z"
+      enc: AQICAHieQbEmk17B5WDxP9ZbssNWaBXaOMPBrnVqrvEMaeLytwG0uJB6cG/yKXVUO3Sfrgl2AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMFaG6tAOHorfTGDUUAgEQgDu6Uueh4M5tJnw0FXK8138nJWvYYFJOcGrRyiT7a9c04CBCsW7FwVOxGJjfIqpXsyZp243y5TNzZ5RhJQ==
+      aws_profile: ""
+    - arn: arn:aws:kms:us-west-2:${ACCOUNT_ID}:alias/ab2d-test
+      created_at: "2025-05-30T19:53:41Z"
+      enc: AQICAHgJRNGY1npk30Hair/yhcKNRMjEO1Ac57p4o8l/f+IR2AG6Qq0G9cR18A+UMQqxvAQSAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQIr1X2uyp2sflqFWAgEQgDvwAcj/DIH3hP8Spw2XVqOOeCr+FJm4KFaWvyFK+QILbjm6VPvBknXmiwCppSboQtHPC7VXsVhOMXXUTw==
+      aws_profile: ""
+  unencrypted_regex: /nonsensitive/
+  mac_only_encrypted: true
+  version: 3.10.2


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6746

## 🛠 Changes
Here, we're introducing a work-in-progress `00-bootstrap` terraservice module that serves AB2D at the AWS Account Level, encoding AB2D's account-level resources in ECR and SSM.

We're also migrating from usage of the unmanaged ssm values for the PDP test credentials to those defined in `00-bootstrap`.

## ℹ️ Context
Post greenfield migration.

## 🧪 Validation
* manual dispatch of e2e-test-gf.yml ran successfully against `test`
* manual dispatch of e2e-test-gf.yml ran successfully against `sandbox`
