### PR TITLE
[PLT-1077] Use CMS Cloud bucket for load balancer logs

### DIFF
--- a/ops/services/20-microservices/main.tf
+++ b/ops/services/20-microservices/main.tf
@@ -126,6 +126,8 @@ data "aws_iam_policy_document" "this" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_lb" "internal_lb" {
   name               = "${local.service_prefix}-${local.service}"
   internal           = true
@@ -138,8 +140,7 @@ resource "aws_lb" "internal_lb" {
   drop_invalid_header_fields       = true
 
   access_logs {
-    bucket  = local.network_access_logs_bucket
-    prefix  = "${local.service_prefix}-${local.service}"
+    bucket  = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
     enabled = true
   }
 }

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -339,6 +339,8 @@ resource "aws_cloudwatch_metric_alarm" "health" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "aws_lb" "ab2d_api" {
   #TODO Consider using name_prefix for ephemeral environments... thhey may only be up to 6-characters
   name               = "${local.service_prefix}-api"
@@ -360,8 +362,7 @@ resource "aws_lb" "ab2d_api" {
   drop_invalid_header_fields       = true
 
   access_logs {
-    bucket  = local.network_access_logs_bucket
-    prefix  = "${local.service_prefix}-${local.service}"
+    bucket  = "cms-cloud-${data.aws_caller_identity.current.account_id}-us-east-1"
     enabled = true
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1077

## 🛠 Changes

Pointed access logs for load balancers at the cms-cloud bucket.

## ℹ️ Context

Following docs at https://cloud.cms.gov/using-splunk-ingest-logs, this should enable ingestion of load balancer access logs into Splunk.