### PR TITLE
Update container image to amazoncorretto:21-al2023-jdk

### DIFF
--- a/.github/workflows/build-gf-non-prod.yml
+++ b/.github/workflows/build-gf-non-prod.yml
@@ -1,5 +1,5 @@
-name: build-gf
-run-name: build-gf ${{ inputs.module }}
+name: build-gf-non-prod
+run-name: build-gf-non-prod ${{ inputs.module }}
 
 on:
   workflow_call:

--- a/.github/workflows/build-gf-prod.yml
+++ b/.github/workflows/build-gf-prod.yml
@@ -1,5 +1,5 @@
 name: build-gf-prod # Note: This workflow is temporary until the promote workflow is created
-run-name: build-gf-prod ${{ inputs.module }}
+run-name: build-gf prod ${{ inputs.module }}
 
 on:
   workflow_call:

--- a/.github/workflows/build-gf-prod.yml
+++ b/.github/workflows/build-gf-prod.yml
@@ -1,5 +1,5 @@
-name: build-gf
-run-name: build-gf ${{ inputs.module }}
+name: build-gf-prod # Note: This workflow is temporary until the promote workflow is created
+run-name: build-gf-prod ${{ inputs.module }}
 
 on:
   workflow_call:
@@ -27,14 +27,14 @@ jobs:
       id-token: write
     runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
     env:
-      AWS_ACCOUNT: ${{ secrets.NON_PROD_ACCOUNT }}
+      AWS_ACCOUNT: ${{ secrets.PROD_ACCOUNT }}
       MODULE: ${{ inputs.module }}
     steps:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/delegatedadmin/developer/ab2d-test-github-actions
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/delegatedadmin/developer/ab2d-prod-github-actions
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -59,11 +59,12 @@ jobs:
       - name: Build image and push to ECR
         working-directory: ./${{ env.MODULE }}
         run: |
-          ECR_REPO_DOMAIN="${AWS_ACCOUNT}.dkr.ecr.$AWS_REGION.amazonaws.com"
-          aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_REPO_DOMAIN"
-          ECR_REPO_URI="$ECR_REPO_DOMAIN/ab2d-${MODULE}"
+          ECR_DOMAIN="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
           SHA_SHORT=$(git rev-parse --short HEAD)
-          echo "Building image for commit sha $SHA_SHORT"
-          docker build -t "${ECR_REPO_URI}:ab2d-${MODULE}-$SHA_SHORT" 
-          echo "Pushing image"
-          docker push "${ECR_REPO_URI}" --all-tags
+          TAG_PREFIX="ab2d-${MODULE}"
+          aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN
+          ECR_URI="$ECR_DOMAIN/$ECR_REPO"
+          TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME-$SHA_SHORT"
+          docker build -t "$ECR_URI:$TAG_SHORT" .
+          docker push "$ECR_URI" --all-tags
+          echo "Published **$ECR_URI:$TAG_SHORT**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -75,9 +75,7 @@ jobs:
           ECR_REPO_URI="$ECR_REPO_DOMAIN/ab2d-${MODULE}"
           SHA_SHORT=$(git rev-parse --short HEAD)
           echo "Building image for commit sha $SHA_SHORT"
-          docker build \
-            -t "${ECR_REPO_URI}:ab2d-aurora-${AB2D_ENV}-$SHA_SHORT" \
-            -t "${ECR_REPO_URI}:ab2d-aurora-${AB2D_ENV}-latest" .
+          docker build -t "${ECR_REPO_URI}:ab2d-${AB2D_ENV}-$SHA_SHORT" 
 
           # Push to special tag for promotion if this is run on a push to main
           if [ "$GITHUB_REF" == "refs/heads/main" ]; then

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -4,9 +4,6 @@ run-name: build-gf non-prod ${{ inputs.module }}
 on:
   workflow_call:
     inputs:
-      environment:
-        required: true
-        type: string
       module:
         required: true
         type: string

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -29,6 +29,8 @@ jobs:
     env:
       AWS_ACCOUNT: ${{ secrets.NON_PROD_ACCOUNT }}
       MODULE: ${{ inputs.module }}
+      ECR_REPO: ab2d-${{ inputs.module }}
+      TAG_PREFIX: ab2d-${{ inputs.module }}
     steps:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
@@ -61,7 +63,6 @@ jobs:
         run: |
           ECR_DOMAIN="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
           SHA_SHORT=$(git rev-parse --short HEAD)
-          TAG_PREFIX="ab2d-${MODULE}"
           aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_DOMAIN
           ECR_URI="$ECR_DOMAIN/$ECR_REPO"
           TAG_SHORT="$TAG_PREFIX-$GITHUB_REF_NAME-$SHA_SHORT"

--- a/.github/workflows/build-gf.yml
+++ b/.github/workflows/build-gf.yml
@@ -1,5 +1,5 @@
-name: build-gf-non-prod
-run-name: build-gf-non-prod ${{ inputs.module }}
+name: build-gf
+run-name: build-gf non-prod ${{ inputs.module }}
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-gf.yml
+++ b/.github/workflows/deploy-gf.yml
@@ -31,7 +31,7 @@ on:
           - worker
           - core
       image_tag:
-        description: ECR image tag for selected module (e.g. ab2d-dev-<SHA>)
+        description: ECR image tag for selected module (ab2d-<module>-<branch>-<SHA>)
         required: true
         type: string
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2-jdk
+FROM amazoncorretto:21-al2023-jdk
 WORKDIR /usr/src/ab2d-api
 ADD target/api-*-SNAPSHOT.jar /usr/src/ab2d-api/api.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-api/newrelic/newrelic.jar

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 #AWS Corretto and AL2
-FROM amazoncorretto:17-al2-jdk
+FROM amazoncorretto:21-al2023-jdk
 WORKDIR /usr/src/ab2d-worker
 ADD target/worker-*-SNAPSHOT-exe.jar /usr/src/ab2d-worker/worker.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-worker/newrelic/newrelic.jar


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-6812
- https://jira.cms.gov/browse/AB2D-6766

## 🛠 Changes

- Update `Dockerfile` to use **amazoncorretto:21-al2023-jdk** container image
- Minor cleanup in workflow

## ℹ️ Context

From Brian Hodges:
```
Please move to a supported tagged release that is not AL2-based. 17-al2023-jdk should be a straightforward. This needs to occur for all containerized AB2D services.
```

Folks have reported better memory usage using correta 21.  

## 🧪 Validation

Validated in `dev`.

https://github.com/CMSgov/ab2d/actions/runs/16483035999
