### PR TITLE
Enable read-only root filesystem

### DIFF
--- a/ops/services/20-microservices/contracts.tf
+++ b/ops/services/20-microservices/contracts.tf
@@ -21,6 +21,8 @@ resource "aws_ecs_task_definition" "contracts" {
   container_definitions = nonsensitive(jsonencode([{
     name : "contracts-service-container", #TODO: Consider simplifying this name, just use "contracts"
     image : local.contracts_image_uri,
+    # Enable read-only root filesystem AB2D-6797
+    readonlyRootFilesystem = true
     essential : true,
     secrets : [
       { name : "AB2D_DB_DATABASE", valueFrom : local.db_database_arn },

--- a/ops/services/20-microservices/events.tf
+++ b/ops/services/20-microservices/events.tf
@@ -30,6 +30,8 @@ resource "aws_ecs_task_definition" "events" {
   container_definitions = nonsensitive(jsonencode([{
     name : "events-service-container", #TODO: Consider simplifying this name, just use "events"
     image : local.events_image_uri,
+    # Enable read-only root filesystem AB2D-6797
+    readonlyRootFilesystem = true
     essential : true,
     secrets : [
       { name : "AB2D_DB_DATABASE", valueFrom : local.db_database_arn },

--- a/ops/services/20-microservices/properties.tf
+++ b/ops/services/20-microservices/properties.tf
@@ -16,6 +16,8 @@ resource "aws_ecs_task_definition" "properties" {
   container_definitions = nonsensitive(jsonencode([{
     name : "properties-service-container", #TODO: Consider simplifying this name, just use "properties"
     image : local.properties_image_uri
+    # Enable read-only root filesystem AB2D-6797
+    readonlyRootFilesystem = true
     essential : true,
     secrets : [
       { name : "AB2D_DB_DATABASE", valueFrom : local.db_database_arn },

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -239,6 +239,8 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions = nonsensitive(jsonencode([{
     name : local.service,
     image : local.api_image_uri,
+    # Enable read-only root filesystem AB2D-6797
+    readonlyRootFilesystem = true
     essential : true,
     portMappings : [
       {

--- a/ops/services/30-worker/main.tf
+++ b/ops/services/30-worker/main.tf
@@ -140,6 +140,8 @@ resource "aws_ecs_task_definition" "worker" {
   container_definitions = nonsensitive(jsonencode([{
     name : local.service,
     image : local.worker_image_uri,
+    # Enable read-only root filesystem AB2D-6797
+    readonlyRootFilesystem = true
     essential : true,
     mountPoints : [
       {


### PR DESCRIPTION
Enable repository scanning

## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6797

## 🛠 Changes

 Enable read-only root filesystem

## ℹ️ Context

Set the container read-only root filesystem  to true- address security alerts related to "This control checks if ECS containers are limited to read-only access to mounted root filesystems. This control fails if the ReadonlyRootFilesystem parameter in the container definition of ECS task definitions is set to ‘false’."

## 🧪 Validation


