### PR TITLE
AB2D-6825: Fix 30-lambda object lookup failures

### DIFF
--- a/ops/services/30-lambda/optout-export.tf
+++ b/ops/services/30-lambda/optout-export.tf
@@ -12,9 +12,9 @@ locals {
 }
 
 data "aws_s3_object" "export" {
-  count = contains(["prod", "test"], local.env) ? 1 : 0
+  for_each = toset([for env in ["prod", "test"] : env if env == local.env])
 
-  bucket = local.export_bucket[local.env]
+  bucket = local.export_bucket[each.key]
   key    = "function.zip"
 }
 
@@ -121,9 +121,9 @@ resource "aws_iam_role" "export" {
 resource "aws_lambda_function" "export" {
   count = contains(["prod", "test"], local.env) ? 1 : 0
 
-  s3_bucket                      = data.aws_s3_object.export[0].bucket
-  s3_key                         = data.aws_s3_object.export[0].key
-  s3_object_version              = data.aws_s3_object.export[0].version_id
+  s3_bucket                      = data.aws_s3_object.export[local.env].bucket
+  s3_key                         = data.aws_s3_object.export[local.env].key
+  s3_object_version              = data.aws_s3_object.export[local.env].version_id
   description                    = "Exports data files to a BFD bucket for opt-out"
   function_name                  = "${local.service_prefix}-opt-out-export"
   handler                        = "gov.cms.ab2d.attributiondatashare.AttributionDataShareHandler"

--- a/ops/services/30-lambda/optout-import.tf
+++ b/ops/services/30-lambda/optout-import.tf
@@ -6,9 +6,9 @@ locals {
 }
 
 data "aws_s3_object" "import" {
-  count = contains(["prod", "test"], local.env) ? 1 : 0
+  for_each = toset([for env in ["prod", "test"] : env if env == local.env])
 
-  bucket = local.import_bucket[local.env]
+  bucket = local.import_bucket[each.key]
   key    = "function.zip"
 }
 
@@ -113,9 +113,9 @@ resource "aws_lambda_function" "import" {
   count = contains(["prod", "test"], local.env) ? 1 : 0
 
 
-  s3_bucket         = data.aws_s3_object.import[0].bucket
-  s3_key            = data.aws_s3_object.import[0].key
-  s3_object_version = data.aws_s3_object.import[0].version_id
+  s3_bucket         = data.aws_s3_object.import[local.env].bucket
+  s3_key            = data.aws_s3_object.import[local.env].key
+  s3_object_version = data.aws_s3_object.import[local.env].version_id
   architectures = [
     "x86_64",
   ]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6825

## 🛠 Changes
Fix S3 Object Lookup failures in environments that aren't `test` or `prod` for `30-lambda` by yielding to a `for_each` instead of a `count` meta parameter.

## ℹ️ Context
Addressing post greenfield migration issues.

## 🧪 Validation
This applies successfully in `dev`, `test`, `sandbox`, and `prod`
