### PR TITLE
AB2D-6829 adding SSL secure transport for main bucket

### DIFF
--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -43,10 +43,10 @@ locals {
 
 resource "aws_s3_bucket" "main_bucket" {
   bucket_prefix = "${local.service_prefix}-main"
-  policy = data.aws_iam_policy_document.main_bucket_policy.json
 }
 
-data "aws_iam_policy_document" "main_bucket_policy" {
+data "aws_iam_policy_document" "main_bucket" {
+  depends_on = [aws_s3_bucket.main_bucket]
   statement {
     sid    = "AllowSSLRequestsOnly"
     effect = "Deny"
@@ -56,8 +56,8 @@ data "aws_iam_policy_document" "main_bucket_policy" {
     }
     actions = ["s3:*"]
     resources = [
-      aws_s3_bucket.main_bucket.arn,
-      "${aws_s3_bucket.main_bucket.arn}/*"
+      "arn:aws:s3:::${aws_s3_bucket.main_bucket.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.main_bucket.bucket}/*"
     ]
     condition {
       test     = "Bool"
@@ -65,6 +65,11 @@ data "aws_iam_policy_document" "main_bucket_policy" {
       values   = ["false"]
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "main_bucket" {
+  bucket = aws_s3_bucket.main_bucket.id
+  policy = data.aws_iam_policy_document.main_bucket.json
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "main_bucket" {

--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -43,6 +43,28 @@ locals {
 
 resource "aws_s3_bucket" "main_bucket" {
   bucket_prefix = "${local.service_prefix}-main"
+  policy = data.aws_iam_policy_document.main_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "main_bucket_policy" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.main_bucket.arn,
+      "${aws_s3_bucket.main_bucket.arn}/*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "main_bucket" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6829

## 🛠 Changes

Adding secure ssl transport on to out main buckets in s3

## ℹ️ Context

SECHUB mandats that we turn this on to be in compliance with security best practices.

## 🧪 Validation

Tofu plan

```  # aws_s3_bucket_policy.main_bucket will be created
  + resource "aws_s3_bucket_policy" "main_bucket" {
      + bucket = "ab2d-dev-main20250514133221464300000001"
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + Bool = {
                              + "aws:SecureTransport" = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = "*"
                      + Resource  = [
                          + "arn:aws:s3:::ab2d-dev-main20250514133221464300000001/*",
                          + "arn:aws:s3:::ab2d-dev-main20250514133221464300000001",
                        ]
                      + Sid       = "AllowSSLRequestsOnly"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }```