### PR TITLE
AB2D-6852 Manage WAFV2 IP Sets in 30-api

### DIFF
--- a/ops/services/30-api/README.md
+++ b/ops/services/30-api/README.md
@@ -93,6 +93,7 @@ This module is responsible for deploying the EC2-backed ECS cluster that hosts t
 | [aws_sns_topic.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.splunk_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_sns_topic_subscription.splunk_elb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_wafv2_ip_set.pdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set) | resource |
 | [aws_acm_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [aws_ecr_image.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_image) | data source |
 | [aws_efs_access_point.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/efs_access_point) | data source |


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6852

## 🛠 Changes
This adds the SSM-managed cidr material for AB2D PDP customers to a specific IP Set used by the web acl and waf infrastructure.

**Note**: We've imported the existing IP sets that were defined ahead of time. The change realized here adds 3 new cidr addresses to the existing ip set, including the latest change from earlier today, 2025-08-07.

## ℹ️ Context
Post-greenfield migration.

## 🧪 Validation
Applied to production without incident and IP Sets are now up-to-date and managed by AB2D.