### PR TITLE
PLT-1228: SecHub warning: This control fails if kms:Decrypt or kms:ReEncryptFrom actions are allowed on all KMS keys in an inline policy.

### DIFF
--- a/ops/services/30-lambda/optout-export.tf
+++ b/ops/services/30-lambda/optout-export.tf
@@ -90,6 +90,7 @@ resource "aws_iam_role" "export" {
     name = "default-function"
     policy = jsonencode(
       {
+        Version = "2012-10-17"
         Statement = [
           {
             Action = [
@@ -101,18 +102,23 @@ resource "aws_iam_role" "export" {
               "logs:PutLogEvents",
               "logs:CreateLogStream",
               "logs:CreateLogGroup",
-              "kms:Encrypt",
-              "kms:Decrypt",
               "ec2:DescribeNetworkInterfaces",
               "ec2:DescribeAccountAttributes",
               "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface",
+              "ec2:CreateNetworkInterface"
             ]
             Effect   = "Allow"
             Resource = "*"
           },
+          {
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ]
+            Effect   = "Allow"
+            Resource = [local.env_key_alias.target_key_arn]
+          }
         ]
-        Version = "2012-10-17"
       }
     )
   }

--- a/ops/services/30-lambda/optout-import.tf
+++ b/ops/services/30-lambda/optout-import.tf
@@ -77,10 +77,12 @@ resource "aws_iam_role" "import" {
       }
     )
   }
+
   inline_policy {
     name = "default-function"
     policy = jsonencode(
       {
+        Version = "2012-10-17"
         Statement = [
           {
             Action = [
@@ -92,18 +94,23 @@ resource "aws_iam_role" "import" {
               "logs:PutLogEvents",
               "logs:CreateLogStream",
               "logs:CreateLogGroup",
-              "kms:Encrypt",
-              "kms:Decrypt",
               "ec2:DescribeNetworkInterfaces",
               "ec2:DescribeAccountAttributes",
               "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface",
+              "ec2:CreateNetworkInterface"
             ]
             Effect   = "Allow"
             Resource = "*"
           },
+          {
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ]
+            Effect   = "Allow"
+            Resource = [local.env_key_alias.target_key_arn]
+          }
         ]
-        Version = "2012-10-17"
       }
     )
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1228

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

inline policy for import and export role was changed. Restricting the kms key action to the specific kms key being used.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
we received a SecHub warning on allowing the AWS Key Management Service (KMS) decryption actions on all KMS keys. This control fails if kms:Decrypt or kms:ReEncryptFrom actions are allowed on all KMS keys in an inline policy.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

see checks
