### PR TITLE
PLT-1236 Adopt latest aurora updates

### DIFF
--- a/ops/services/10-core/README.md
+++ b/ops/services/10-core/README.md
@@ -48,7 +48,7 @@ This root module is responsible for creating essential resources that the majori
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db"></a> [db](#module\_db) | github.com/CMSgov/cdap//terraform/modules/aurora | f91210d2640845f1b6f0edb7087b6cbf02acbdec |
+| <a name="module_db"></a> [db](#module\_db) | github.com/CMSgov/cdap//terraform/modules/aurora | 58952d6b964a5215e38c38d49518148584e73d01 |
 | <a name="module_platform"></a> [platform](#module\_platform) | github.com/CMSgov/cdap//terraform/modules/platform | ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66 |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.

--- a/ops/services/10-core/database.tf
+++ b/ops/services/10-core/database.tf
@@ -1,5 +1,5 @@
 module "db" {
-  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=f91210d2640845f1b6f0edb7087b6cbf02acbdec"
+  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=58952d6b964a5215e38c38d49518148584e73d01"
 
   snapshot_identifier     = var.aurora_snapshot
   backup_retention_period = module.platform.is_ephemeral_env ? 1 : 7


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1236

## 🛠 Changes

This PR adopts the latest changes based on the PLT-1236 updates, including:
* enables aws_iam_auth for all clusters
* skips redundant final cluster snapshots
* enables copying cluster tags to snapshots

## ℹ️ Context
Post-greenfield migration.

## 🧪 Validation
This has been applied to all environments without incident and has addressed a handful of findings reported by various controls in security hub, including AWS Foundational Best Practices 1.0.0 `RDS.16`.
