### PR TITLE
AB2D-6655 Update workflow to remove whitespace from prod bucket name

### DIFF
--- a/.github/workflows/opt-out-export-deploy-gf.yml
+++ b/.github/workflows/opt-out-export-deploy-gf.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload and reload
         env:
-          BUCKET: ${{ inputs.environment == 'prod' && 'ab2d-prod-opt-out-export-function-20250616154436478600000001 ' || 'ab2d-test-opt-out-export-function-20250529140617557400000001' }}
+          BUCKET: ${{ inputs.environment == 'prod' && 'ab2d-prod-opt-out-export-function-20250616154436478600000001' || 'ab2d-test-opt-out-export-function-20250529140617557400000001' }}
         run: |
           aws s3 cp --no-progress build/distributions/attributionDataShare.zip s3://${{ env.BUCKET }}/function.zip
           aws lambda update-function-code --function-name ab2d-${{ env.AB2D_ENV }}-opt-out-export \


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6655

## 🛠 Changes

- Remove whitespace from bucket name

## ℹ️ Context

Addressed Snyk vulnerabilities (updated postgres dependency) as part of [AB2D-6655](https://jira.cms.gov/browse/AB2D-6655) and redeployed to all environments. 

Only had issue with this workflow: https://github.com/CMSgov/ab2d/actions/runs/16945955956


## 🧪 Validation

Successful run: https://github.com/CMSgov/ab2d/actions/runs/16946170962
