### PR TITLE
PLT-1228: SecHub warning: This control fails if kms:Decrypt or kms:ReEncryptFrom actions are allowed on all KMS keys in an inline policy.

### DIFF
--- a/ops/services/30-lambda/optout-export.tf
+++ b/ops/services/30-lambda/optout-export.tf
@@ -90,6 +90,7 @@ resource "aws_iam_role" "export" {
     name = "default-function"
     policy = jsonencode(
       {
+        Version = "2012-10-17"
         Statement = [
           {
             Action = [
@@ -101,18 +102,23 @@ resource "aws_iam_role" "export" {
               "logs:PutLogEvents",
               "logs:CreateLogStream",
               "logs:CreateLogGroup",
-              "kms:Encrypt",
-              "kms:Decrypt",
               "ec2:DescribeNetworkInterfaces",
               "ec2:DescribeAccountAttributes",
               "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface",
+              "ec2:CreateNetworkInterface"
             ]
             Effect   = "Allow"
             Resource = "*"
           },
+          {
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ]
+            Effect   = "Allow"
+            Resource = [local.env_key_alias.target_key_arn]
+          }
         ]
-        Version = "2012-10-17"
       }
     )
   }

--- a/ops/services/30-lambda/optout-export.tf
+++ b/ops/services/30-lambda/optout-export.tf
@@ -69,59 +69,56 @@ resource "aws_iam_role" "export" {
   name                  = "${local.service_prefix}-opt-out-export-function"
   path                  = "/delegatedadmin/developer/"
   permissions_boundary  = "arn:aws:iam::${module.platform.aws_caller_identity.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+}
 
-  inline_policy {
-    name = "assume-bucket-role"
-    policy = jsonencode(
+resource "aws_iam_role_policy" "export_assume_bucket_role" {
+  count = contains(["prod", "test"], local.env) ? 1 : 0
+  name  = "assume-bucket-role"
+  role  = aws_iam_role.export[0].id
+  policy = jsonencode({
+    Statement = [
       {
-        Statement = [
-          {
-            Action   = "sts:AssumeRole"
-            Effect   = "Allow"
-            Resource = module.platform.ssm.eft.bfd-bucket-role-arn.value
-          },
-        ]
-        Version = "2012-10-17"
+        Action   = "sts:AssumeRole"
+        Effect   = "Allow"
+        Resource = module.platform.ssm.eft.bfd-bucket-role-arn.value
       }
-    )
-  }
+    ]
+    Version = "2012-10-17"
+  })
+}
 
-  inline_policy {
-    name = "default-function"
-    policy = jsonencode(
+resource "aws_iam_role_policy" "export_default_function" {
+  count = contains(["prod", "test"], local.env) ? 1 : 0
+  name  = "default-function"
+  role  = aws_iam_role.export[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        Version = "2012-10-17"
-        Statement = [
-          {
-            Action = [
-              "ssm:GetParameters",
-              "ssm:GetParameter",
-              "sqs:ReceiveMessage",
-              "sqs:GetQueueAttributes",
-              "sqs:DeleteMessage",
-              "logs:PutLogEvents",
-              "logs:CreateLogStream",
-              "logs:CreateLogGroup",
-              "ec2:DescribeNetworkInterfaces",
-              "ec2:DescribeAccountAttributes",
-              "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface"
-            ]
-            Effect   = "Allow"
-            Resource = "*"
-          },
-          {
-            Action = [
-              "kms:Encrypt",
-              "kms:Decrypt"
-            ]
-            Effect   = "Allow"
-            Resource = [local.env_key_alias.target_key_arn]
-          }
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter",
+          "sqs:ReceiveMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:DeleteMessage",
+          "logs:PutLogEvents",
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DeleteNetworkInterface",
+          "ec2:CreateNetworkInterface"
         ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action   = ["kms:Encrypt", "kms:Decrypt"]
+        Effect   = "Allow"
+        Resource = [local.env_key_alias.target_key_arn]
       }
-    )
-  }
+    ]
+  })
 }
 
 resource "aws_lambda_function" "export" {

--- a/ops/services/30-lambda/optout-import.tf
+++ b/ops/services/30-lambda/optout-import.tf
@@ -61,59 +61,56 @@ resource "aws_iam_role" "import" {
   name                  = "${local.service_prefix}-opt-out-import-function"
   path                  = "/delegatedadmin/developer/"
   permissions_boundary  = "arn:aws:iam::${module.platform.aws_caller_identity.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+}
 
-  inline_policy {
-    name = "assume-bucket-role"
-    policy = jsonencode(
+resource "aws_iam_role_policy" "import_assume_bucket_role" {
+  count = contains(["prod", "test"], local.env) ? 1 : 0
+  name  = "assume-bucket-role"
+  role  = aws_iam_role.import[0].id
+  policy = jsonencode({
+    Statement = [
       {
-        Statement = [
-          {
-            Action   = "sts:AssumeRole"
-            Effect   = "Allow"
-            Resource = module.platform.ssm.eft.bfd-bucket-role-arn.value
-          },
-        ]
-        Version = "2012-10-17"
+        Action   = "sts:AssumeRole"
+        Effect   = "Allow"
+        Resource = module.platform.ssm.eft.bfd-bucket-role-arn.value
       }
-    )
-  }
+    ]
+    Version = "2012-10-17"
+  })
+}
 
-  inline_policy {
-    name = "default-function"
-    policy = jsonencode(
+resource "aws_iam_role_policy" "import_default_function" {
+  count = contains(["prod", "test"], local.env) ? 1 : 0
+  name  = "default-function"
+  role  = aws_iam_role.import[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        Version = "2012-10-17"
-        Statement = [
-          {
-            Action = [
-              "ssm:GetParameters",
-              "ssm:GetParameter",
-              "sqs:ReceiveMessage",
-              "sqs:GetQueueAttributes",
-              "sqs:DeleteMessage",
-              "logs:PutLogEvents",
-              "logs:CreateLogStream",
-              "logs:CreateLogGroup",
-              "ec2:DescribeNetworkInterfaces",
-              "ec2:DescribeAccountAttributes",
-              "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface"
-            ]
-            Effect   = "Allow"
-            Resource = "*"
-          },
-          {
-            Action = [
-              "kms:Encrypt",
-              "kms:Decrypt"
-            ]
-            Effect   = "Allow"
-            Resource = [local.env_key_alias.target_key_arn]
-          }
+        Action = [
+          "ssm:GetParameters",
+          "ssm:GetParameter",
+          "sqs:ReceiveMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:DeleteMessage",
+          "logs:PutLogEvents",
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DeleteNetworkInterface",
+          "ec2:CreateNetworkInterface"
         ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+      {
+        Action   = ["kms:Encrypt", "kms:Decrypt"]
+        Effect   = "Allow"
+        Resource = [local.env_key_alias.target_key_arn]
       }
-    )
-  }
+    ]
+  })
 }
 
 resource "aws_lambda_function" "import" {

--- a/ops/services/30-lambda/optout-import.tf
+++ b/ops/services/30-lambda/optout-import.tf
@@ -77,10 +77,12 @@ resource "aws_iam_role" "import" {
       }
     )
   }
+
   inline_policy {
     name = "default-function"
     policy = jsonencode(
       {
+        Version = "2012-10-17"
         Statement = [
           {
             Action = [
@@ -92,18 +94,23 @@ resource "aws_iam_role" "import" {
               "logs:PutLogEvents",
               "logs:CreateLogStream",
               "logs:CreateLogGroup",
-              "kms:Encrypt",
-              "kms:Decrypt",
               "ec2:DescribeNetworkInterfaces",
               "ec2:DescribeAccountAttributes",
               "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterface",
+              "ec2:CreateNetworkInterface"
             ]
             Effect   = "Allow"
             Resource = "*"
           },
+          {
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ]
+            Effect   = "Allow"
+            Resource = [local.env_key_alias.target_key_arn]
+          }
         ]
-        Version = "2012-10-17"
       }
     )
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1228

## 🛠 Changes

 inline_policy switched to aws_iam_role_policy.

## ℹ️ Context

Due to terraform deprecation warning in plan checks, the is the need to switch from inline_policy to aws_iam_role_policy.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
see checks
