### PR TITLE
AB2D-6846/Replace references from ab2d-bcda-dpc-platform to cdap

### DIFF
--- a/.github/workflows/opt-out-export-unit-gf.yml
+++ b/.github/workflows/opt-out-export-unit-gf.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set env vars from AWS params in BCDA management account
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        uses: cmsgov/cdap/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:

--- a/.github/workflows/opt-out-import-unit-gf.yml
+++ b/.github/workflows/opt-out-import-unit-gf.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set env vars from AWS params in BCDA management account
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        uses: cmsgov/cdap/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:

--- a/e2e-test/src/test/resources/impl-config.yml
+++ b/e2e-test/src/test/resources/impl-config.yml
@@ -1,2 +1,2 @@
 okta-url: 'https://test.idp.idm.cms.gov/oauth2/aus2r7y3gdaFMKBol297/v1/token'
-base-url: 'https://impl.ab2d.cms.gov'
+base-url: 'https://test.ab2d.cms.gov'

--- a/ops/services/40-insights/README.md
+++ b/ops/services/40-insights/README.md
@@ -45,7 +45,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_platform"></a> [platform](#module\_platform) | git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform | PLT-1099 |
+| <a name="module_platform"></a> [platform](#module\_platform) | git::https://github.com/CMSgov/cdap.git//terraform/modules/platform | PLT-1099 |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'

--- a/ops/services/40-insights/main.tf
+++ b/ops/services/40-insights/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 module "platform" {
-  source    = "git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform?ref=PLT-1099"
+  source    = "git::https://github.com/CMSgov/cdap.git//terraform/modules/platform?ref=PLT-1099"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app         = local.app


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6846

## 🛠 Changes

Replaced references from ab2d-bcda-dpc-platform to cdap 
Replaced references from http://impl.ab2d.cms.gov to http://test.ab2d.cms.gov in e2e tests

## ℹ️ Context

We have a lot of references to https://github.com/CMSgov/ab2d-bcda-dpc-platform which was renamed to: https://github.com/CMSgov/cdap


## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
