### PR TITLE
AB2D-6856 Fix false positive alerts for COVERAGE_VERIFICATION_FAILURE

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 
 import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getAttestationTime;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -57,7 +57,11 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
             int year = attestationTime.getYear();
             int month = attestationTime.getMonthValue();
 
-            if (!hasEnrollment(coverageCounts, year, month)) {
+            final boolean hasEnrollment = coverageCounts.stream().anyMatch(coverageCount -> {
+                return coverageCount.getYear() == year && coverageCount.getMonth() == month;
+            });
+
+            if (!hasEnrollment) {
                 logIssue(contract, year, month, noEnrollment);
             }
 
@@ -81,11 +85,5 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
      * */
     private boolean ignoreMissing(@NotNull String contractNumber, int year, int month) {
         return contractNumber.equals("S3147") && year == 2021 && month == 12;
-    }
-
-    protected boolean hasEnrollment(List<CoverageCount> coverageCounts, int year, int month) {
-        return coverageCounts.stream().anyMatch(coverageCount -> {
-            return coverageCount.getYear() == year && coverageCount.getMonth() == month;
-        });
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/CoveragePresentCheck.java
@@ -53,21 +53,12 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
         ZonedDateTime now = getEndDateTime().minusMonths(1);
         ZonedDateTime attestationTime = getAttestationTime(new ContractToContractCoverageMapping().map(contract));
 
-        ListIterator<CoverageCount> countIterator = coverageCounts.listIterator();
         while (attestationTime.isBefore(now)) {
             int year = attestationTime.getYear();
             int month = attestationTime.getMonthValue();
 
-            // If nothing in the iterator
-            if (!countIterator.hasNext()) {
+            if (!hasEnrollment(coverageCounts, year, month)) {
                 logIssue(contract, year, month, noEnrollment);
-            // If something in iterator make sure it matches expected
-            } else {
-                CoverageCount coverageCount = countIterator.next();
-                if (year != coverageCount.getYear() || month != coverageCount.getMonth()) {
-                    countIterator.previous();
-                    logIssue(contract, year, month, noEnrollment);
-                }
             }
 
             attestationTime = attestationTime.plusMonths(1);
@@ -90,5 +81,11 @@ public class CoveragePresentCheck extends CoverageCheckPredicate {
      * */
     private boolean ignoreMissing(@NotNull String contractNumber, int year, int month) {
         return contractNumber.equals("S3147") && year == 2021 && month == 12;
+    }
+
+    protected boolean hasEnrollment(List<CoverageCount> coverageCounts, int year, int month) {
+        return coverageCounts.stream().anyMatch(coverageCount -> {
+            return coverageCount.getYear() == year && coverageCount.getMonth() == month;
+        });
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
@@ -143,7 +143,7 @@ public class CoverageCheckPredicatesUnitTest {
         issues.forEach(issue -> assertTrue(issue.contains("no enrollment found")));
     }
 
-    @DisplayName("Coverage periods have no coverage present")
+    @DisplayName("Coverage periods are present")
     @Test
     void whenCoveragePeriodsPresent_passCoveragePresentCheck() {
 
@@ -167,6 +167,43 @@ public class CoverageCheckPredicatesUnitTest {
         assertTrue(presentCheck.test(contract));
         assertTrue(issues.isEmpty());
     }
+
+    @DisplayName("Coverage periods are earlier than attestation date")
+    @Test
+    void whenCoveragePeriodsAreEarlierThanAttestationDate_passCoveragePresentCheck() {
+
+        ATTESTATION_TIME = CURRENT_TIME.minusMonths(3);
+
+        Map<String, List<CoverageCount>> coverageCounts = new HashMap<>();
+        List<String> issues = new ArrayList<>();
+        CoveragePresentCheck presentCheck =
+                new CoveragePresentCheck(coverageService, coverageCounts, issues);
+
+        ContractDTO contract = getContractDTO();
+
+        List<CoverageCount> fakeCounts = List.of(
+                // add coverage dates that are earlier than attestation date
+                new CoverageCount("TEST", ATTESTATION_TIME.minusMonths(3).getYear(),
+                        ATTESTATION_TIME.minusMonths(3).getMonthValue(), 1, 1, 1),
+                new CoverageCount("TEST", ATTESTATION_TIME.minusMonths(2).getYear(),
+                        ATTESTATION_TIME.minusMonths(2).getMonthValue(), 1, 1, 1),
+                new CoverageCount("TEST", ATTESTATION_TIME.minusMonths(1).getYear(),
+                        ATTESTATION_TIME.minusMonths(1).getMonthValue(), 1, 1, 1),
+                // add coverage dates for attestation month and later
+                new CoverageCount("TEST", ATTESTATION_TIME.plusMonths(0).getYear(),
+                        ATTESTATION_TIME.plusMonths(0).getMonthValue(), 1, 1, 1),
+                new CoverageCount("TEST", ATTESTATION_TIME.plusMonths(1).getYear(),
+                        ATTESTATION_TIME.plusMonths(1).getMonthValue(), 1, 1, 1),
+                new CoverageCount("TEST", ATTESTATION_TIME.plusMonths(2).getYear(),
+                        ATTESTATION_TIME.plusMonths(2).getMonthValue(), 1, 1, 1)
+
+        );
+        coverageCounts.put("TEST", fakeCounts);
+
+        assertTrue(presentCheck.test(contract));
+        assertTrue(issues.isEmpty());
+    }
+
 
     @DisplayName("Coverage changes are limited to 10% between months fails when changes are large")
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesUnitTest.java
@@ -168,7 +168,7 @@ public class CoverageCheckPredicatesUnitTest {
         assertTrue(issues.isEmpty());
     }
 
-    @DisplayName("Coverage periods are earlier than attestation date")
+    @DisplayName("Some coverage periods are earlier than attestation date")
     @Test
     void whenCoveragePeriodsAreEarlierThanAttestationDate_passCoveragePresentCheck() {
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6856

## 🛠 Changes

- Fix logic for `CoveragePresentCheck` which checks for missing enrollments for a given year/month combo. 

## ℹ️ Context

This alert is a false positive:
<img width="474" height="92" alt="image" src="https://github.com/user-attachments/assets/4298d27a-1f74-4366-9d44-71fba990f4a5" />

**The current logic doesn't work if coverage periods exist before the attestation date.**

`CoveragePresentCheck` is provided a list of coverage periods (`List<CoverageCount>`) and attempts to verify a coverage period exists for each month starting with the month of the attestation date. 

The current logic wrongly compares the year/month of the first element in the coverage periods list with the attestation month/year 
- Instead, the logic should verify the month/year exists in any elements in `List<CoverageCount>`

---

For reference, query used by the code to gather `List<CoverageCount>`
```
SELECT coverage.contract, coverage.year, coverage.month, coverage.bene_coverage_period_id, coverage.bene_coverage_search_event_id, COUNT(*) as bene_count  
FROM coverage INNER JOIN bene_coverage_period bcp ON coverage.bene_coverage_period_id = bcp.id  
WHERE bcp.status = 'SUCCESSFUL' 
	AND coverage.contract IN ('?')  
	and coverage.current_mbi is not null 
	AND coverage.year IN (2020, 2021, 2022, 2023, 2024, 2025)  
GROUP BY coverage.contract, coverage.year, coverage.month,  coverage.bene_coverage_period_id, coverage.bene_coverage_search_event_id  
ORDER BY coverage.contract, coverage.year, coverage.month,  coverage.bene_coverage_period_id, coverage.bene_coverage_search_event_id;
```


## 🧪 Validation

Unit & integration tests pass: https://github.com/CMSgov/ab2d/actions/runs/16979176175
