### PR TITLE
PLT-1301: Enable EFS Automated Backups

### DIFF
--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -124,6 +124,14 @@ resource "aws_efs_file_system" "efs" {
   tags           = { Name = "${local.service_prefix}-efs" }
 }
 
+resource "aws_efs_backup_policy" "policy" {
+  file_system_id = aws_efs_file_system.efs.id
+
+  backup_policy {
+    status = "ENABLED"
+  }
+}
+
 resource "aws_efs_access_point" "efs" {
   count          = module.platform.is_ephemeral_env ? 0 : 1
   file_system_id = aws_efs_file_system.efs[0].id


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1301

## 🛠 Changes

Adds automated backup policy for EFS

## ℹ️ Context

Security findings originally posted with PLT-1210 and PLT-1211 call out EFS automated backups as necessary.

## 🧪 Validation

Plan output:
```
Terraform will perform the following actions:

  # module.persistent.module.export_efs.aws_efs_backup_policy.policy will be created
  + resource "aws_efs_backup_policy" "policy" {
      + file_system_id = "fs-06898a9a35a2a8959"
      + id             = (known after apply)

      + backup_policy {
          + status = "ENABLED"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
