### PR TITLE
AB2D-6821 Rename workflows / remove '-gf' prefix from files and workflow names

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,5 @@
-name: build-deploy-gf
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('build-deploy-gf {0} {1} {2}', inputs.module, inputs.environment || 'build-only', inputs.skip_build && 'deploy-only' || 'build-and-deploy') || format('build-deploy-gf {0} auto', inputs.module) }}
+name: API/Worker build deploy
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('build-deploy {0} {1} {2}', inputs.module, inputs.environment || 'build-only', inputs.skip_build && 'deploy-only' || 'build-and-deploy') || format('build-deploy {0} auto', inputs.module) }}
 
 on:
   workflow_call:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: API/Worker build
-run-name: build non-prod ${{ inputs.module }}
+run-name: build ${{ inputs.module }}
 
 on:
   workflow_call:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
-name: build-gf
-run-name: build-gf non-prod ${{ inputs.module }}
+name: API/Worker build
+run-name: build non-prod ${{ inputs.module }}
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,5 +1,5 @@
-name: deploy-lambdas-gf
-run-name: deploy-lambdas-gf ${{ inputs.environment }}
+name: Lambdas deploy
+run-name: deploy-lambdas ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
-name: deploy-gf
-run-name: deploy-gf ${{ inputs.module }} ${{ inputs.environment }} ${{ inputs.image_tag }}
+name: API/Worker deploy
+run-name: deploy ${{ inputs.module }} ${{ inputs.environment }} ${{ inputs.image_tag }}
 
 on:
   workflow_call:

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -1,6 +1,5 @@
-name: end-to-end-bfd-gf tests
-run-name: end-to-end-bfd-gf tests ${{ inputs.environment }}
-
+name: end-to-end-bfd tests
+run-name: end-to-end-bfd tests ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,5 +1,5 @@
-name: end-to-end-gf tests
-run-name: end-to-end-gf tests ${{ inputs.environment }}
+name: end-to-end tests
+run-name: end-to-end tests ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/opt-out-export-deploy.yml
+++ b/.github/workflows/opt-out-export-deploy.yml
@@ -1,5 +1,5 @@
-name: opt-out-export deploy-gf
-run-name: opt-out-export deploy-gf ${{ inputs.environment }}
+name: opt-out-export deploy
+run-name: opt-out-export deploy ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/opt-out-export-unit.yml
+++ b/.github/workflows/opt-out-export-unit.yml
@@ -1,10 +1,10 @@
-name: opt-out-import-gf unit tests
+name: opt-out-export unit tests
 
 on:
   pull_request:
     paths:
-      - .github/workflows/opt-out-import-unit-gf.yml
-      - lambdas/optout/**
+      - .github/workflows/opt-out-export-unit.yml
+      - lambdas/attribution-data-file-share/**
   workflow_dispatch:
 
 jobs:
@@ -17,8 +17,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run:
-        working-directory: ./lambdas/optout
-
+        working-directory: ./lambdas/attribution-data-file-share
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -40,5 +39,6 @@ jobs:
             ARTIFACTORY_PASSWORD=/artifactory/password
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
-      - name: Run unit tests for opt-out-import lambda
+
+      - name: Run unit tests for opt-out-export lambda
         run: ../gradlew test

--- a/.github/workflows/opt-out-import-deploy.yml
+++ b/.github/workflows/opt-out-import-deploy.yml
@@ -1,5 +1,5 @@
-name: opt-out-import deploy-gf
-run-name: opt-out-import deploy-gf ${{ inputs.environment }}
+name: opt-out-import deploy
+run-name: opt-out-import deploy ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     if: ${{ github.event_name == 'push' }}
-    uses: ./.github/workflows/opt-out-import-deploy-gf.yml
+    uses: ./.github/workflows/opt-out-import-deploy.yml
     secrets: inherit
     with:
       environment: test

--- a/.github/workflows/opt-out-import-unit.yml
+++ b/.github/workflows/opt-out-import-unit.yml
@@ -1,10 +1,10 @@
-name: opt-out-export-gf unit tests
+name: opt-out-import unit tests
 
 on:
   pull_request:
     paths:
-      - .github/workflows/opt-out-export-unit-gf.yml
-      - lambdas/attribution-data-file-share/**
+      - .github/workflows/opt-out-import-unit.yml
+      - lambdas/optout/**
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,8 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run:
-        working-directory: ./lambdas/attribution-data-file-share
+        working-directory: ./lambdas/optout
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -39,6 +40,5 @@ jobs:
             ARTIFACTORY_PASSWORD=/artifactory/password
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
-
-      - name: Run unit tests for opt-out-export lambda
+      - name: Run unit tests for opt-out-import lambda
         run: ../gradlew test

--- a/.github/workflows/opt-out-import-upload-test.yml
+++ b/.github/workflows/opt-out-import-upload-test.yml
@@ -1,5 +1,5 @@
-name: opt-out-import test-gf
-run-name: opt-out-import test-gf ${{ inputs.environment }}
+name: opt-out-import test
+run-name: opt-out-import test ${{ inputs.environment }}
 
 on:
   workflow_call:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,5 +1,5 @@
-name: promote-gf
-#run-name: promote-gf ${{ inputs.tag_name }}
+name: API/Worker promote
+run-name: promote ${{ inputs.tag_name }}
 
 on:
   workflow_call:

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -1,4 +1,5 @@
-name: publish-lambdas-gf
+name: Lambdas publish
+run-name: publish-lambdas
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
   e2e-test:
     needs: [build-deploy-api, build-deploy-worker]
-    uses: ./.github/workflows/e2e-test-gf.yml
+    uses: ./.github/workflows/e2e-test.yml
     with:
       environment: test
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,13 +14,13 @@ jobs:
     uses: ./.github/workflows/unit-integration-test.yml
     secrets: inherit
   build-deploy-api:
-    uses: ./.github/workflows/build-deploy-gf.yml
+    uses: ./.github/workflows/build-deploy.yml
     with:
       environment: test
       module: api
     secrets: inherit
   build-deploy-worker:
-    uses: ./.github/workflows/build-deploy-gf.yml
+    uses: ./.github/workflows/build-deploy.yml
     with:
       environment: test
       module: worker

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -30,7 +30,7 @@ jobs:
 #    secrets: inherit
   e2e-test:
     needs: [ build-deploy-api, build-deploy-worker ]
-    uses: ./.github/workflows/e2e-test-gf.yml
+    uses: ./.github/workflows/e2e-test.yml
     with:
       environment: test
     secrets: inherit

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   build-deploy-api:
-    uses: ./.github/workflows/build-deploy-gf.yml
+    uses: ./.github/workflows/build-deploy.yml
     with:
       environment: test
       module: api
     secrets: inherit
   build-deploy-worker:
-    uses: ./.github/workflows/build-deploy-gf.yml
+    uses: ./.github/workflows/build-deploy.yml
     with:
       environment: test
       module: worker
@@ -24,7 +24,7 @@ jobs:
 # Should be fixed in AB2D-6853 Fix e2e-bfd tests
 #  e2e-bfd-test:
 #    needs: [ build-deploy-api, build-deploy-worker ]
-#    uses: ./.github/workflows/e2e-bfd-test-gf.yml
+#    uses: ./.github/workflows/e2e-bfd-test.yml
 #    with:
 #      environment: test
 #    secrets: inherit

--- a/.github/workflows/start-job.yml
+++ b/.github/workflows/start-job.yml
@@ -1,6 +1,5 @@
-
-name: start-job-gf
-run-name: start-job-gf ${{ inputs.environment }} ${{ inputs.contractNumber }}
+name: Start job
+run-name: start-job ${{ inputs.environment }} ${{ inputs.contractNumber }}
 
 on:
   workflow_dispatch: # Allow manual trigger


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6821

## 🛠 Changes

- Remove '-gf' from workflow filenames and workflow names
- Minor updates to workflow to include `API/Worker` to differentiate from other workflows (contracts, events)

## ℹ️ Context

Now that legacy workflows have been removed, we can rename our greenfield workflows

## 🧪 Validation

N/A