### PR TITLE
AB2D-6439 Add FHIR Test Workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -34,6 +34,12 @@ jobs:
     with:
       environment: test
     secrets: inherit
+  fhir-test:
+    needs: [ build-deploy-api, build-deploy-worker ]
+    uses: ./.github/workflows/fhir-test.yml
+    with:
+      environment: test
+    secrets: inherit
   sonarqube:
     uses: ./.github/workflows/sonarqube.yml
     secrets: inherit


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6439

## 🛠 Changes

Add the FHIR conformance tests to the git workflow on merge to main.



## ℹ️ Context

It's important to run these conformance check on an ongoing basis to make sure we don't fall out of conformance. This allows clients to be more confident their integration will continue to work according to the Implementation Guide. 

Since it takes a few minutes to run, and is unlikely to break often, we figured it was reasonable to add this check here (as opposed to on PR or something)

## 🧪 Validation

Make sure the tests point to the `test` env and pass when merged to main. These are the same tests that are run here: https://github.com/CMSgov/ab2d/actions/workflows/fhir-test.yml
