### PR TITLE
AB2D-6890 Propagate service tags to task workloads

### DIFF
--- a/ops/services/20-microservices/contracts.tf
+++ b/ops/services/20-microservices/contracts.tf
@@ -95,6 +95,11 @@ resource "aws_ecs_service" "contracts" {
   launch_type          = "FARGATE"
   platform_version     = "1.4.0"
   force_new_deployment = anytrue([var.force_contracts_deployment, var.contracts_service_image_tag != null])
+  propagate_tags       = "SERVICE"
+
+  tags = {
+    service = "contracts"
+  }
 
   network_configuration {
     subnets          = keys(module.platform.private_subnets)

--- a/ops/services/20-microservices/events.tf
+++ b/ops/services/20-microservices/events.tf
@@ -104,6 +104,11 @@ resource "aws_ecs_service" "events" {
   launch_type          = "FARGATE"
   platform_version     = "1.4.0"
   force_new_deployment = anytrue([var.force_events_deployment, var.events_service_image_tag != null])
+  propagate_tags       = "SERVICE"
+
+  tags = {
+    service = "events"
+  }
 
   network_configuration {
     subnets          = keys(module.platform.private_subnets)

--- a/ops/services/20-microservices/properties.tf
+++ b/ops/services/20-microservices/properties.tf
@@ -85,6 +85,11 @@ resource "aws_ecs_service" "properties" {
   launch_type          = "FARGATE"
   platform_version     = "1.4.0"
   force_new_deployment = anytrue([var.force_properties_deployment, var.properties_service_image_tag != null])
+  propagate_tags       = "SERVICE"
+
+  tags = {
+    service = "properties"
+  }
 
   network_configuration {
     subnets          = keys(module.platform.private_subnets)

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -340,6 +340,7 @@ resource "aws_ecs_service" "api" {
   force_new_deployment               = anytrue([var.force_api_deployment, var.api_service_image_tag != null])
   deployment_minimum_healthy_percent = 100
   health_check_grace_period_seconds  = 180
+  propagate_tags                     = "SERVICE"
 
   network_configuration {
     subnets          = local.private_subnet_ids

--- a/ops/services/30-worker/main.tf
+++ b/ops/services/30-worker/main.tf
@@ -228,6 +228,7 @@ resource "aws_ecs_service" "worker" {
   desired_count                      = local.worker_desired_instances
   force_new_deployment               = anytrue([var.force_worker_deployment, var.worker_service_image_tag != null])
   deployment_minimum_healthy_percent = 100
+  propagate_tags                     = "SERVICE"
 
   network_configuration {
     subnets          = local.writer_adjacent_subnets


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6890

## 🛠 Changes
* tags microservices with specific service names
* propagates service tags to ECS task workloads


## ℹ️ Context
ECS task workloads don't automatically inherit tags from either of their task definitions nor parent service, and without these tags, costs incurred by these workloads aren't accurately reflected in cost explorer.

## 🧪 Validation
I evaluated this solution on a subset of resources in `dev`, including `contracts`, `events`, and `worker`. This should be sufficient for a low-risk change like this.