### PR TITLE
AB2D-6891 Use aurora standard storage in dev, test

### DIFF
--- a/ops/services/10-core/database.tf
+++ b/ops/services/10-core/database.tf
@@ -19,8 +19,6 @@ module "db" {
 
   storage_type = lookup({
     prod = "aurora-iopt1"
-    dev  = "aurora-iopt1" #TODO: Remove NLT 2025-08-15
-    test = "aurora-iopt1" #TODO: Remove NLT 2025-08-15
   }, local.env, "")
 
   backup_window = lookup({


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6891

## 🛠 Changes
Use aurora standard instead of io-optimized storage for non-production clusters to realize some *very* modest cost improvements.

## ℹ️ Context
Post-greenfield migration cleanup.

## 🧪 Validation
Successfully applied to the impacted environments of `dev` and `test` with no diffs in the IaC output.
