### PR TITLE
AB2D-6903 Use sensible backup strategy for Aurora

### DIFF
--- a/ops/services/10-core/README.md
+++ b/ops/services/10-core/README.md
@@ -48,7 +48,7 @@ This root module is responsible for creating essential resources that the majori
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db"></a> [db](#module\_db) | github.com/CMSgov/cdap//terraform/modules/aurora | 58952d6b964a5215e38c38d49518148584e73d01 |
+| <a name="module_db"></a> [db](#module\_db) | github.com/CMSgov/cdap//terraform/modules/aurora | f333c0a8367889a46aa00eeb95fd67cbd838b909 |
 | <a name="module_platform"></a> [platform](#module\_platform) | github.com/CMSgov/cdap//terraform/modules/platform | ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66 |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.

--- a/ops/services/10-core/database.tf
+++ b/ops/services/10-core/database.tf
@@ -1,5 +1,5 @@
 module "db" {
-  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=58952d6b964a5215e38c38d49518148584e73d01"
+  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=f333c0a8367889a46aa00eeb95fd67cbd838b909"
 
   snapshot_identifier     = var.aurora_snapshot
   backup_retention_period = module.platform.is_ephemeral_env ? 1 : 7


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6903

## 🛠 Changes
Adopts the updated CDAP-managed Aurora module to take advantage of newly introduce AWS Backup Service backup plans. Specifically, this adopts the AWS Backup Plan `4Hours1DR_Daily7_Weekly35_Monthly90` and `cdap_managed_backup_selection` criteria of tag="AWS_Backup",value="4hr1dr_d7_w35_m90".

## ℹ️ Context
This is among some outstanding post-greenfield, post-aurora migration tasks in support of PLT-1217.

## 🧪 Validation
This has been applied to all path-to-production environments without issue.