### PR TITLE
AB2D-6904 Encrypt ECS cluster storage with CMK

### DIFF
--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -74,6 +74,8 @@ jobs:
           mvn -ntp -U clean
 
       - name: Run unit and integration tests
+        env:
+          MAVEN_OPTS: "-Xmx1G -Xms1G"
         run: |
             mvn -ntp -s settings.xml ${RUNNER_DEBUG:+"--debug"} -Dusername=${ARTIFACTORY_USER} -Dpassword=${ARTIFACTORY_PASSWORD} -Drepository_url=${ARTIFACTORY_URL} test -pl common,job,coverage,api,worker
 

--- a/ops/services/20-microservices/README.md
+++ b/ops/services/20-microservices/README.md
@@ -66,6 +66,7 @@ Notably:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | github.com/CMSgov/cdap//terraform/modules/cluster | e06f4acfea302df22c210549effa2e91bc3eff0d |
 | <a name="module_platform"></a> [platform](#module\_platform) | github.com/CMSgov/cdap//terraform/modules/platform | ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66 |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
@@ -79,7 +80,6 @@ Notably:
 |------|------|
 | [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_service.contracts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.properties](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |

--- a/ops/services/20-microservices/contracts.tf
+++ b/ops/services/20-microservices/contracts.tf
@@ -86,7 +86,7 @@ resource "aws_ecs_task_definition" "contracts" {
 
 resource "aws_ecs_service" "contracts" {
   name                 = "${local.service_prefix}-contracts"
-  cluster              = aws_ecs_cluster.this.id
+  cluster              = module.cluster.this.id
   task_definition      = aws_ecs_task_definition.contracts.arn
   desired_count        = 1
   launch_type          = "FARGATE"

--- a/ops/services/20-microservices/events.tf
+++ b/ops/services/20-microservices/events.tf
@@ -98,7 +98,7 @@ resource "aws_ecs_task_definition" "events" {
 
 resource "aws_ecs_service" "events" {
   name                 = "${local.service_prefix}-events"
-  cluster              = aws_ecs_cluster.this.id
+  cluster              = module.cluster.this.id
   task_definition      = aws_ecs_task_definition.events.arn
   desired_count        = 1
   launch_type          = "FARGATE"

--- a/ops/services/20-microservices/main.tf
+++ b/ops/services/20-microservices/main.tf
@@ -48,23 +48,9 @@ locals {
   vpc_id                     = module.platform.vpc_id
 }
 
-# ECS Cluster
-####################################
-resource "aws_ecs_cluster" "this" {
-  name = "${local.service_prefix}-${local.service}"
-
-  setting {
-    name  = "containerInsights"
-    value = module.platform.is_ephemeral_env ? "disabled" : "enabled"
-  }
-
-  # FIXME Enable the below, along with enabling the cluster acess to the CMK
-  # configuration {
-  #   managed_storage_configuration {
-  #     fargate_ephemeral_storage_kms_key_id = local.kms_master_key_id
-  #     kms_key_id                           = local.kms_master_key_id
-  #   }
-  # }
+module "cluster" {
+  source   = "github.com/CMSgov/cdap//terraform/modules/cluster?ref=e06f4acfea302df22c210549effa2e91bc3eff0d"
+  platform = module.platform
 }
 
 # Chatbot Guardrail Policy
@@ -89,7 +75,7 @@ resource "aws_cloudwatch_event_rule" "this" {
   "source": ["aws.ecs"],
   "detail-type": ["ECS Task State Change"],
   "detail": {
-    "clusterArn": ["${aws_ecs_cluster.this.arn}"],
+    "clusterArn": ["${module.cluster.this.arn}"],
     "lastStatus": ["RUNNING"]
   }
 }

--- a/ops/services/20-microservices/properties.tf
+++ b/ops/services/20-microservices/properties.tf
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "properties" {
 
 resource "aws_ecs_service" "properties" {
   name                 = "${local.service_prefix}-properties"
-  cluster              = aws_ecs_cluster.this.id
+  cluster              = module.cluster.this.id
   task_definition      = aws_ecs_task_definition.properties.arn
   desired_count        = 1
   launch_type          = "FARGATE"

--- a/ops/services/30-api/README.md
+++ b/ops/services/30-api/README.md
@@ -56,6 +56,7 @@ This module is responsible for deploying the EC2-backed ECS cluster that hosts t
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | github.com/CMSgov/cdap//terraform/modules/cluster | e06f4acfea302df22c210549effa2e91bc3eff0d |
 | <a name="module_platform"></a> [platform](#module\_platform) | github.com/CMSgov/cdap//terraform/modules/platform | ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66 |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
@@ -73,7 +74,6 @@ This module is responsible for deploying the EC2-backed ECS cluster that hosts t
 | [aws_cloudwatch_metric_alarm.healthy_host_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.http_code_elb_5xx_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.target_response_time](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_ecs_cluster.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_service.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_lb.ab2d_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -216,13 +216,9 @@ resource "aws_security_group_rule" "efs_ingress" {
   security_group_id        = data.aws_security_group.efs.id
 }
 
-resource "aws_ecs_cluster" "ab2d_api" {
-  name = "${local.service_prefix}-${local.service}"
-
-  setting {
-    name  = "containerInsights"
-    value = module.platform.is_ephemeral_env ? "disabled" : "enabled"
-  }
+module "cluster" {
+  source   = "github.com/CMSgov/cdap//terraform/modules/cluster?ref=e06f4acfea302df22c210549effa2e91bc3eff0d"
+  platform = module.platform
 }
 
 resource "aws_ecs_task_definition" "api" {
@@ -331,7 +327,7 @@ resource "aws_ecs_task_definition" "api" {
 
 resource "aws_ecs_service" "api" {
   name                               = "${local.service_prefix}-${local.service}"
-  cluster                            = aws_ecs_cluster.ab2d_api.id
+  cluster                            = module.cluster.this.id
   task_definition                    = coalesce(var.override_task_definition_arn, aws_ecs_task_definition.api.arn)
   launch_type                        = "FARGATE"
   desired_count                      = local.api_desired_instances

--- a/ops/services/30-worker/README.md
+++ b/ops/services/30-worker/README.md
@@ -58,6 +58,7 @@ This module is responsible for creating the EC2-backed ECS Cluster and related r
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cluster"></a> [cluster](#module\_cluster) | github.com/CMSgov/cdap//terraform/modules/cluster | e06f4acfea302df22c210549effa2e91bc3eff0d |
 | <a name="module_data_db_writer_instance"></a> [data\_db\_writer\_instance](#module\_data\_db\_writer\_instance) | github.com/CMSgov/beneficiary-fhir-data//ops/terraform-modules/general/data-db-writer-instance | 2.211.0 |
 | <a name="module_platform"></a> [platform](#module\_platform) | github.com/CMSgov/cdap//terraform/modules/platform | ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66 |
 
@@ -70,7 +71,6 @@ This module is responsible for creating the EC2-backed ECS Cluster and related r
 
 | Name | Type |
 |------|------|
-| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 | [aws_ecs_service.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_security_group_rule.db_access_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6904

## 🛠 Changes
This change makes use of the CDAP-managed cluster module instead of directly configuring `aws_ecs_cluster` resources and effectively configures the clusters to use the prescriptive, environment-specific CMK for each cluster.

## ℹ️ Context
Post-greenfield migration, post-fargate migration cleanup.

## 🧪 Validation
This was applied to `dev` and `test` environments. We encountered some unrelated issues, particularly in `test`, but those have since been remedied. The necessary imports have already been executed which makes this a very low risk change taking effect on the next deployment to `sandbox` and `prod` environments.