### PR TITLE
PLT-1229: SecHub warning: ELB.17: Application and Network Load Balancers with listeners should use recommended security policies

### DIFF
--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -55,6 +55,7 @@ locals {
   alb_listener_port            = 443
   alb_listener_protocol        = "HTTPS"
   alb_ssl_policy               = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+  api_desired_instances        = module.platform.parent_env == "prod" ? 2 : 1
   bfd_insights                 = "none" #FIXME?
   container_port               = 8443
   db_name_arn                  = module.platform.ssm.core.database_name.arn


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1229

## 🛠 Changes

ELBSecurityPolicy was updated

## ℹ️ Context

we received a SecHub warning: ELB.17: Application and Network Load Balancers with listeners should use recommended security policies

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

see checks