### PR TITLE
AB2D-6876 Fix SonarQube code coverage for contracts

### DIFF
--- a/.github/workflows/contracts-sonarqube.yml
+++ b/.github/workflows/contracts-sonarqube.yml
@@ -45,6 +45,9 @@ jobs:
             HPMS_AUTH_KEY_ID=/ab2d/dev/core/sensitive/hpms_auth_key_id
             HPMS_AUTH_KEY_SECRET=/ab2d/dev/core/sensitive/hpms_auth_key_secret
 
+      - name: Run tests
+        run: ./gradlew clean test --info
+
       - name: SonarQube Analysis
         run: |
           ./gradlew sonar \

--- a/.github/workflows/contracts-sonarqube.yml
+++ b/.github/workflows/contracts-sonarqube.yml
@@ -1,4 +1,4 @@
-name: SonarQube
+name: Contracts SonarQube
 
 on:
   workflow_call:

--- a/.github/workflows/events-sonarqube.yml
+++ b/.github/workflows/events-sonarqube.yml
@@ -1,4 +1,4 @@
-name: SonarQube
+name: Events SonarQube
 
 on:
   workflow_call:

--- a/.github/workflows/events-sonarqube.yml
+++ b/.github/workflows/events-sonarqube.yml
@@ -48,7 +48,7 @@ jobs:
 #      - name: Run tests
 #        run: ./gradlew clean test --info
 
-      - name: SonarQube Analysis # TODO Uncomment previous step to run tests which are currently broken to populate code coverage
+      - name: SonarQube Analysis # TODO Uncomment previous step to run tests (currently broken) in order to populate code coverage
         run: |
           ./gradlew sonar \
             -Dsonar.ci.autoconfig.disabled=true \

--- a/.github/workflows/events-sonarqube.yml
+++ b/.github/workflows/events-sonarqube.yml
@@ -45,6 +45,9 @@ jobs:
             HPMS_AUTH_KEY_ID=/ab2d/dev/core/sensitive/hpms_auth_key_id
             HPMS_AUTH_KEY_SECRET=/ab2d/dev/core/sensitive/hpms_auth_key_secret
 
+      - name: Run tests
+        run: ./gradlew clean test --info
+
       - name: SonarQube Analysis
         run: |
           ./gradlew sonar \

--- a/.github/workflows/events-sonarqube.yml
+++ b/.github/workflows/events-sonarqube.yml
@@ -45,10 +45,10 @@ jobs:
             HPMS_AUTH_KEY_ID=/ab2d/dev/core/sensitive/hpms_auth_key_id
             HPMS_AUTH_KEY_SECRET=/ab2d/dev/core/sensitive/hpms_auth_key_secret
 
-      - name: Run tests
-        run: ./gradlew clean test --info
+#      - name: Run tests
+#        run: ./gradlew clean test --info
 
-      - name: SonarQube Analysis
+      - name: SonarQube Analysis # TODO Uncomment previous step to run tests which are currently broken to populate code coverage
         run: |
           ./gradlew sonar \
             -Dsonar.ci.autoconfig.disabled=true \

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -50,6 +50,7 @@ allprojects {
         testImplementation "org.springframework.data:spring-data-jpa"
         testImplementation "org.liquibase:liquibase-core:${liquibaseVersion}"
         testImplementation "org.testcontainers:localstack:${testContainerVersion}"
+        testRuntimeOnly "org.junit.platform:junit-platform-launcher"
         compileOnly "org.cyclonedx:cyclonedx-gradle-plugin:1.4.0"
         compileOnly 'org.cyclonedx:cyclonedx-core-java:10.2.1'
     }

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -46,11 +46,11 @@ allprojects {
         runtimeOnly "javax.xml.bind:jaxb-api:2.4.0-b180830.0359"
         runtimeOnly 'org.postgresql:postgresql:42.7.3'
         testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+        testRuntimeOnly "org.junit.platform:junit-platform-launcher"
         testImplementation "commons-io:commons-io:2.18.0"
         testImplementation "org.springframework.data:spring-data-jpa"
         testImplementation "org.liquibase:liquibase-core:${liquibaseVersion}"
         testImplementation "org.testcontainers:localstack:${testContainerVersion}"
-        testRuntimeOnly "org.junit.platform:junit-platform-launcher"
         compileOnly "org.cyclonedx:cyclonedx-gradle-plugin:1.4.0"
         compileOnly 'org.cyclonedx:cyclonedx-core-java:10.2.1'
     }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6876

- Run tests before SonarQube step for contracts
- Add `junit-platform-launcher` dependency to run tests for events
- Rename contracts + events SonarQube workflows for clarity 


## ℹ️ Context

- SonarQube code coverage wasn't being populated. Running tests beforehand fixes that. 

## 🧪 Validation

SonarQube code coverage is now being populated for contracts: 
<img width="1119" height="662" alt="image" src="https://github.com/user-attachments/assets/a614e39c-52b2-46cc-abda-e5bc5e2e2d60" />
 
