### PR TITLE
PLT-1342: drop default force_ssl 

### DIFF
--- a/ops/services/10-core/database.tf
+++ b/ops/services/10-core/database.tf
@@ -42,11 +42,6 @@ module "db" {
   cluster_parameters = [
     {
       apply_method = "immediate"
-      name         = "rds.force_ssl"
-      value        = 1
-    },
-    {
-      apply_method = "immediate"
       name         = "backslash_quote"
       value        = "safe_encoding"
     },


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1342

## 🛠 Changes

dropping default force_ssl 

## ℹ️ Context

default force_ssl cluster parameter is now being set in aurora module in cdap repo and there for the need to drop it here

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
