### PR TITLE
AB2D-6911 Add S3 lifecycle configuration

### DIFF
--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -104,6 +104,22 @@ resource "aws_s3_bucket_policy" "main_bucket" {
   policy = data.aws_iam_policy_document.main_bucket.json
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "main_bucket" {
+  bucket = aws_s3_bucket.main_bucket.id
+
+  rule {
+    id     = "noncurrent-ia"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+  }
+}
+
 data "aws_efs_file_system" "efs" {
   count = module.platform.is_ephemeral_env ? 1 : 0
 

--- a/ops/services/15-web/bucket.tf
+++ b/ops/services/15-web/bucket.tf
@@ -67,6 +67,22 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  rule {
+    id     = "noncurrent-ia"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+  }
+}
+
 resource "aws_ssm_parameter" "bucket" {
   name  = "/ab2d/${local.env}/web/nonsensitive/s3-bucket"
   value = aws_s3_bucket.this.id


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6911

## 🛠 Changes

Address SecurityHub findings by implementing lifecycle configuations. See:
- [[S3.13] S3 general purpose buckets should have Lifecycle configurations](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-13)


Add lifecycle configuration that transitions non-current objects in these buckets to IA after 30 days.
- **ab2d-\<env\>-website**
- **ab2d-\<env\>-main**

## ℹ️ Context

Note that these buckets were created manually. As a result, lifecycle configurations have to be created manually within AWS Console for each environment. 
- **ab2d-\<env\>-opt-out-import-function**
- **ab2d-\<env\>-opt-out-export-function** 


## 🧪 Validation

Verified the tofu commands below generated the expected plan for these modules for the **dev** environment.
- 10-core
- 15-web

```
tofu init -var=parent_env=dev -reconfigure
tofu workspace select -var=parent_env=dev -or-create=true dev
tofu plan -var=parent_env=dev -out=tfplan
```

