### PR TITLE
AB2D-7180 lambda arm64 migration

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), env.AB2D_ENV) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
 
@@ -56,7 +56,7 @@ jobs:
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
   
       - name: Install tofu
-        uses: cmsgov/cdap/actions/setup-tenv@8343fb96563ce4b74c4dececee9b268f42bd4a40
+        uses: cmsgov/cdap/actions/setup-tenv@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
 
       - name: Tofu plan and apply
         working-directory: ops/services/30-lambda/

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), env.AB2D_ENV) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
 

--- a/.github/workflows/opt-out-import-deploy.yml
+++ b/.github/workflows/opt-out-import-deploy.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{contains(fromJSON('["dev", "test"]'), inputs.environment) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT}}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:

--- a/.github/workflows/opt-out-import-unit.yml
+++ b/.github/workflows/opt-out-import-unit.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:

--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         working-directory: ./lambdas
-    runs-on: codebuild-ab2d-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       build_version: ${{ steps.publish_lambdas.outputs.build_version }}
     env:

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'com.jfrog.artifactory' version '4.29.0' apply false
-    id "org.sonarqube" version "3.5.0.2730"
+    id "org.sonarqube" version "5.1.0.4882"
     id 'org.cyclonedx.bom' version '2.0.0' apply true
 }
 version = "1.1.4"

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.sonarqube" version "3.5.0.2730"
     id 'org.cyclonedx.bom' version '2.0.0' apply true
 }
-version = "1.1.3"
+version = "1.1.4"
 group = "gov.cms.ab2d"
 
 dependencies {

--- a/lambdas/settings.gradle
+++ b/lambdas/settings.gradle
@@ -1,7 +1,4 @@
 rootProject.name = 'ab2d-lambdas'
 include 'metrics-lambda', 'audit', 'coverage-counts', 'database-management', 'lambda-lib', 'lambda-test-utils'
-include 'lambda-test-utils'
 include 'retrieve-hpms-counts'
 include 'optout'
-include 'attribution-data-file-share'
-

--- a/ops/services/30-lambda/main.tf
+++ b/ops/services/30-lambda/main.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=f4c14d47cc20e7f6de9112d7155af1213c9bca5a"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app          = local.app
@@ -91,6 +91,9 @@ resource "aws_lambda_function" "slack_lambda" {
   handler       = "data_load_lambda.load_data"
   runtime       = "python3.12"
   timeout       = 600
+  architectures = [
+    "arm64",
+  ]
   environment {
     variables = {
       SLACK_WEBHOOK_URL = local.slack_webhook_ab2d_slack_alerts
@@ -110,6 +113,9 @@ resource "aws_lambda_function" "metrics_transform" {
   runtime          = "java11"
   memory_size      = 256
   timeout          = 600
+  architectures = [
+    "arm64",
+  ]
   environment {
     variables = {
       environment        = local.benv
@@ -128,6 +134,9 @@ resource "aws_lambda_function" "audit" {
   handler          = "gov.cms.ab2d.audit.AuditEventHandler"
   runtime          = "java11"
   timeout          = 600
+  architectures = [
+    "arm64",
+  ]
   vpc_config {
     security_group_ids = [local.efs_security_group_id, aws_security_group.audit_lambda.id]
     subnet_ids         = local.node_subnet_ids
@@ -224,6 +233,9 @@ resource "aws_lambda_function" "audit_svc_monitoring" {
   runtime       = "python3.12"
   timeout       = 600
   description   = "Lambda function that monitors the Audit srvice lambda and sends alert to slack"
+  architectures = [
+    "arm64",
+  ]
   tags          = { code = "https://github.com/CMSgov/ab2d/blob/main/ops/services/30-lambda/code/monitoring_audit_svc.py" }
   environment {
     variables = {
@@ -266,6 +278,9 @@ resource "aws_lambda_function" "coverage_count" {
   runtime          = "java11"
   timeout          = 600
   memory_size      = 1024
+  architectures = [
+    "arm64",
+  ]
   environment {
     variables = {
       environment       = local.benv
@@ -309,6 +324,9 @@ resource "aws_lambda_function" "database_management" {
   runtime          = "java11"
   timeout          = 600
   memory_size      = 256
+  architectures = [
+    "arm64",
+  ]
   vpc_config {
     security_group_ids = [local.db_sg_id, aws_security_group.database_lambda.id]
     subnet_ids         = local.node_subnet_ids
@@ -339,6 +357,9 @@ resource "aws_lambda_function" "hpms_counts" {
   runtime          = "java11"
   timeout          = 600
   memory_size      = 256
+  architectures = [
+    "arm64",
+  ]
   vpc_config {
     security_group_ids = [local.microservices_lb, data.aws_security_group.microservices_lambda.id]
     subnet_ids         = local.node_subnet_ids

--- a/ops/services/30-lambda/main.tf
+++ b/ops/services/30-lambda/main.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "slack_lambda" {
   filename      = data.archive_file.python_lambda_package.output_path
   function_name = "${local.service_prefix}-slack-alerts"
   role          = aws_iam_role.slack_lambda.arn
-  handler       = "data_load_lambda.load_data"
+  handler       = "slack_lambda.lambda_handler"
   runtime       = "python3.12"
   timeout       = 600
   architectures = [
@@ -232,7 +232,7 @@ resource "aws_lambda_function" "audit_svc_monitoring" {
   role          = aws_iam_role.microservices_lambda.arn
   runtime       = "python3.12"
   timeout       = 600
-  description   = "Lambda function that monitors the Audit srvice lambda and sends alert to slack"
+  description   = "Lambda function that monitors the Audit service lambda and sends alert to slack"
   architectures = [
     "arm64",
   ]

--- a/ops/services/30-lambda/optout-import.tf
+++ b/ops/services/30-lambda/optout-import.tf
@@ -124,7 +124,7 @@ resource "aws_lambda_function" "import" {
   s3_key            = data.aws_s3_object.import[local.env].key
   s3_object_version = data.aws_s3_object.import[local.env].version_id
   architectures = [
-    "x86_64",
+    "arm64",
   ]
   description                    = "Ingests the most recent beneficiary opt-out list from BFD"
   function_name                  = "${local.service_prefix}-opt-out-import"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7180

## 🛠 Changes

Updates architecture for the lambdas to use arm64, and also fixes a minor issue with a handler.

## ℹ️ Context

Part of a greater initiative to migrate coderunners to run/build on arm64 architecture. See [here](https://confluence.cms.gov/spaces/ODI/pages/1527722964/DevSecOps_Strategy_ARM64) for more info.

The lambdas run natively on arm64.

## 🧪 Validation

https://github.com/CMSgov/ab2d/actions/runs/24409711016
https://github.com/CMSgov/ab2d/actions/runs/24408903342

The deploy works, and the architecture of the lambdas is converted to arm64, checked with:
aws lambda get-function-configuration --function-name <lambda name> --query "Architectures"
