### PR TITLE
AB2D-7205 Add necessary changes for ephemeral environments

### DIFF
--- a/ops/services/10-config/values/ephemeral.yaml
+++ b/ops/services/10-config/values/ephemeral.yaml
@@ -15,6 +15,9 @@ copy:
   - /ab2d/${env}/core/sensitive/okta_jwt_issuer
   - /ab2d/${env}/worker/nonsensitive/bfd_keystore_location
   - /ab2d/${env}/worker/sensitive/bfd_keystore_password
+  - /ab2d/${env}/worker/sensitive/bfd_keystore_base64
+  - /ab2d/${env}/worker/nonsensitive/bfd_truststore_cert
+  - /ab2d/${env}/worker/nonsensitive/bfd_v3_truststore_cert
   - /ab2d/${env}/api/sensitive/tls_private_key
   - /ab2d/${env}/api/nonsensitive/tls_public_cert
 values:

--- a/ops/services/10-core/iam.tf
+++ b/ops/services/10-core/iam.tf
@@ -210,7 +210,7 @@ resource "aws_iam_role" "idr_db_importer_task_execution" {
 }
 
 resource "aws_iam_policy" "idr_db_importer_task_execution" {
-  name = "${local.app}-${local.parent_env}-idr-db-importer-task-execution"
+  name = "${local.app}-${local.env}-idr-db-importer-task-execution"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -34,7 +34,7 @@ locals {
   region_name        = module.platform.primary_region.name
   vpc_id             = module.platform.vpc_id
   splunk_alert_email = lookup(module.platform.ssm.splunk, "alert-email", { value : null }).value
-  slack_queue_env    = local.parent_env
+  slack_queue_env    = local.parent_env == "test" || local.parent_env == "dev" ? "test" : "prod"
 }
 
 resource "aws_s3_bucket" "main_bucket" {

--- a/ops/services/10-core/main.tf
+++ b/ops/services/10-core/main.tf
@@ -34,7 +34,7 @@ locals {
   region_name        = module.platform.primary_region.name
   vpc_id             = module.platform.vpc_id
   splunk_alert_email = lookup(module.platform.ssm.splunk, "alert-email", { value : null }).value
-  slack_queue_env    = local.env == "test" || local.env == "dev" ? "test" : "prod"
+  slack_queue_env    = local.parent_env
 }
 
 resource "aws_s3_bucket" "main_bucket" {
@@ -374,7 +374,7 @@ module "idr_db_importer_bucket" {
 
   additional_bucket_policies = [data.aws_iam_policy_document.idr_db_importer_additional_bucket_policy.json]
   app                        = module.platform.app
-  env                        = module.platform.env
+  env                        = local.parent_env
   name                       = "${module.platform.app}-${module.platform.env}-idr-db-importer"
   ssm_parameter              = "/ab2d/${module.platform.env}/core/nonsensitive/idr-db-importer-bucket"
 }

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -165,7 +165,7 @@ resource "aws_security_group_rule" "load_balancer_access_nat" {
 }
 
 resource "aws_security_group_rule" "pdp" { #TODO: Consider updating this to formally yield to the web acls informed by the ip sets below
-  for_each = nonsensitive(local.pdp_map)
+  for_each = !module.platform.is_ephemeral_env ? nonsensitive(local.pdp_map) : tomap({})
 
   type              = "ingress"
   description       = "${replace(each.key, "-", " ")}: ${each.value["contracts"]}"

--- a/ops/services/30-idr-db-importer/main.tf
+++ b/ops/services/30-idr-db-importer/main.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_task_definition" "idr_db_importer" {
             value = local.env
           }
         ],
-          local.env == "prod" ? [
+        local.env == "prod" ? [
           {
             name  = "IDR_SNOWFLAKE_URL"
             value = "jdbc:snowflake://cms-idr.privatelink.snowflakecomputing.com"
@@ -146,7 +146,7 @@ resource "aws_scheduler_schedule" "idr_db_importer" {
 }
 
 resource "aws_iam_role" "idr_db_importer_eventbridge_scheduler" {
-  name = "idr-db-importer-cron-scheduler-role"
+  name = "${local.service_prefix}-idr-db-importer-cron-scheduler-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -163,7 +163,7 @@ resource "aws_iam_role" "idr_db_importer_eventbridge_scheduler" {
 }
 
 resource "aws_iam_policy" "idr_db_importer_eventbridge_scheduler" {
-  name = "idr-db-importer-cron-scheduler-policy"
+  name = "${local.service_prefix}-idr-db-importer-cron-scheduler-policy"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/ops/services/30-lambda/data.tf
+++ b/ops/services/30-lambda/data.tf
@@ -43,13 +43,6 @@ data "aws_security_group" "microservices_lambda" {
   name = "${local.service_prefix}-microservices-lambda"
 }
 
-data "aws_security_group" "microservices_lb" {
-  filter {
-    name   = "tag:Name"
-    values = ["${local.service_prefix}-microservices-lb"]
-  }
-}
-
 data "aws_security_group" "efs_sg" {
   filter {
     name   = "tag:Name"

--- a/ops/services/30-lambda/main.tf
+++ b/ops/services/30-lambda/main.tf
@@ -63,7 +63,7 @@ locals {
   slack_webhook_ab2d_slack_alerts = module.platform.ssm.webhooks.ab2d-slack-alerts.value
   contracts_service_url           = module.platform.ssm.contracts.url.value
 
-  microservices_lb = data.aws_security_group.microservices_lb.id
+  microservices_lb = aws_security_group.microservices_lb.id
   cloudfront_id    = data.aws_ec2_managed_prefix_list.cloudfront.id
 
 
@@ -82,6 +82,22 @@ locals {
 provider "artifactory" {
   url          = module.platform.ssm.artifactory.url.value
   access_token = module.platform.ssm.artifactory.token.value
+}
+
+resource "aws_security_group" "microservices_lb" {
+  name   = "${local.service_prefix}-microservices-lb"
+  vpc_id = module.platform.vpc_id
+
+  tags = { Name = "${local.service_prefix}-microservices-lb" }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "lambda_sg_ingress_access" {
+  from_port                    = 80
+  to_port                      = 80
+  ip_protocol                  = "tcp"
+  description                  = "inbound access for lambda to microservices"
+  referenced_security_group_id = data.aws_security_group.microservices_lambda.id
+  security_group_id            = aws_security_group.microservices_lb.id
 }
 
 resource "aws_lambda_function" "slack_lambda" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7205

## 🛠 Changes

Adds the following:
- BFD truststore parameters
- Updated naming for IDR IAM roles
- Added security group management of orphaned microservices into `30-lambda` as it still had a dependency

## ℹ️ Context

These changes are necessary for standing up an ephemeral environment

## 🧪 Validation

Environment was stood up and stable, and E2E tests passed pointed at the ephemeral ALB.
https://github.com/CMSgov/ab2d/actions/runs/24367112711

Will need to import `aws_security_group.microservices_lb` on tofu-apply of `30-lambda` in non-ephemeral environments as it already exists in those environments
```
tofu import aws_security_group.microservices_lb <security_group_id>
tofu import aws_vpc_security_group_ingress_rule.lambda_sg_ingress_access <security_group_rule_id>
```