### PR TITLE
AB2D-7181 migrate idr importer to arm64

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
   # Build job - only runs when needed
   build:
-    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     needs: setup
     if: needs.setup.outputs.should_build == 'true'
     permissions:

--- a/.github/workflows/idr-db-importer-build.yml
+++ b/.github/workflows/idr-db-importer-build.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   build:
-    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ inputs.is_prod && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       image_tag: ${{ steps.build_image.outputs.image_tag }}
 

--- a/.github/workflows/idr-db-importer-build.yml
+++ b/.github/workflows/idr-db-importer-build.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   build:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       image_tag: ${{ steps.build_image.outputs.image_tag }}
 

--- a/.github/workflows/idr-db-importer-sonarqube.yml
+++ b/.github/workflows/idr-db-importer-sonarqube.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   sonarqube:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tofu-apply.yml
+++ b/.github/workflows/tofu-apply.yml
@@ -71,7 +71,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       APP: ab2d
       ENV: ${{ inputs.environment }}
@@ -79,9 +79,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
-      - uses: cmsgov/cdap/actions/setup-tenv@8343fb96563ce4b74c4dececee9b268f42bd4a40
-      - uses: cmsgov/cdap/actions/setup-sops@84a6bcee5b70d63c44f8fec4f9b542cb5ec29a54
-      - uses: cmsgov/cdap/actions/setup-yq@328406d6e1d435b4e3da598bcdab22e576c3945e
+      - uses: cmsgov/cdap/actions/setup-tenv@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
+      - uses: cmsgov/cdap/actions/setup-sops@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
+      - uses: cmsgov/cdap/actions/setup-yq@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
       - uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:
           role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/ab2d-${{ inputs.environment }}-github-actions

--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -71,7 +71,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       APP: ab2d
       ENV: ${{ inputs.environment }}
@@ -79,9 +79,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159  # v3.9.2
-      - uses: cmsgov/cdap/actions/setup-tenv@8343fb96563ce4b74c4dececee9b268f42bd4a40
-      - uses: cmsgov/cdap/actions/setup-sops@84a6bcee5b70d63c44f8fec4f9b542cb5ec29a54
-      - uses: cmsgov/cdap/actions/setup-yq@328406d6e1d435b4e3da598bcdab22e576c3945e
+      - uses: cmsgov/cdap/actions/setup-tenv@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
+      - uses: cmsgov/cdap/actions/setup-sops@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
+      - uses: cmsgov/cdap/actions/setup-yq@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
       - uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:
           role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/ab2d-${{ inputs.environment }}-github-actions

--- a/ops/services/30-idr-db-importer/main.tf
+++ b/ops/services/30-idr-db-importer/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=f4c14d47cc20e7f6de9112d7155af1213c9bca5a"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app         = local.app
@@ -33,7 +33,10 @@ resource "aws_ecs_task_definition" "idr_db_importer" {
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   task_role_arn            = data.aws_iam_role.idr_db_importer_task.arn
-
+  runtime_platform {
+      cpu_architecture = "ARM64"
+      operating_system_family = "LINUX"
+  }
   container_definitions = nonsensitive(jsonencode([
     {
       image                  = "${local.image_repo_uri}:${var.image_tag}"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7181

## 🛠 Changes

Updates architecture for IDR importer to use arm64, and also fixes a minor issue with a handler.
Updates refs in tofu apply and plan workflows as well.

## ℹ️ Context

Part of a greater initiative to migrate coderunners to run/build on arm64 architecture. See [here](https://confluence.cms.gov/spaces/ODI/pages/1527722964/DevSecOps_Strategy_ARM64) for more info.

## 🧪 Validation

Build + deploy succeeds, with the task running on ARM64 architecture. Logs show that the task starts up, then fails on dev due to missing s3 bucket. But that's been happening for weeks prior to the arm changes. 