### PR TITLE
AB2D-7158 migrate coderunner to arm64

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   analyze:
     name: CodeQL scan
-    runs-on: codebuild-ab2d-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
 
     permissions:
       contents: read

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -73,7 +73,12 @@ jobs:
           KEYSTORE_FILE_NAME="ab2d_${{ env.AB2D_ENV }}_keystore"
           aws s3 cp s3://$MAIN_BUCKET/$KEYSTORE_FILE_NAME $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
-
+      - name: DNS Diag
+        run: |
+          cat /etc/resolv.conf
+          getent hosts sandbox.fhir.bfd.cmscloud.gov || true
+          getent hosts github.com || true
+          nslookup sandbox.fhir.bfd.cmscloud.gov || true
       - name: Run e2e-bfd-test
         env:
           AB2D_BFD_URL: 'https://sandbox.fhir.bfd.cmscloud.gov'

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
       AB2D_V2_ENABLED: 'true'

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run e2e-bfd-test
         env:
-          AB2D_BFD_URL: 'https://prod-sbx.fhir.bfd.cmscloud.local'
+          AB2D_BFD_URL: 'https://sandbox.fhir.bfd.cmscloud.gov'
           AB2D_BFD_URL_V3: 'https://sandbox.fhirv3.bfd.cmscloud.local'
         run: |
           mvn test -s settings.xml -Dcheckstyle.skip -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AB2D_V2_ENABLED: 'true'
       AB2D_V3_ENABLED: ${{ inputs.v3_enabled }}

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ inputs.environment == 'sandbox' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}
       AB2D_ENV: ${{ inputs.environment || 'dev' }}

--- a/.github/workflows/libs-build.yml
+++ b/.github/workflows/libs-build.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ secrets.NON_PROD_ACCOUNT }}
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/libs-publish.yml
+++ b/.github/workflows/libs-publish.yml
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
   publish:
     needs: build
-    runs-on: codebuild-ab2d-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       FORCE_PUBLISH: ${{ inputs.forcePublish }}

--- a/.github/workflows/libs-sonarqube.yml
+++ b/.github/workflows/libs-sonarqube.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   sonarqube:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     needs: workflow
     if: needs.workflow.outputs.files || github.event_name == 'push'
     env:

--- a/.github/workflows/start-job.yml
+++ b/.github/workflows/start-job.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   start-job:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
 
     env:
       CONTRACT_NUMBER: ${{ inputs.contractNumber }}

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -32,7 +32,7 @@ jobs:
             grep -P "${workflow_files_re}" \
           && echo "files=true" >> $GITHUB_OUTPUT || echo "files=" >> $GITHUB_OUTPUT
   test:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     needs: workflow
     if: needs.workflow.outputs.files || github.event_name == 'push'
     env:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7158

## 🛠 Changes

Moves all remaining runners to the new arm64 codebuild

## ℹ️ Context

Part of a greater initiative to migrate coderunners to run/build on arm64 architecture. See [here](https://confluence.cms.gov/spaces/ODI/pages/1527722964/DevSecOps_Strategy_ARM64) for more info.

## 🧪 Validation

Ongoing