### PR TITLE
AB2D-7158 migrate to arm64 coderunner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   analyze:
     name: CodeQL scan
-    runs-on: codebuild-ab2d-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
 
     permissions:
       contents: read

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -73,7 +73,12 @@ jobs:
           KEYSTORE_FILE_NAME="ab2d_${{ env.AB2D_ENV }}_keystore"
           aws s3 cp s3://$MAIN_BUCKET/$KEYSTORE_FILE_NAME $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
-
+      - name: DNS Diag
+        run: |
+          cat /etc/resolv.conf
+          getent hosts sandbox.fhir.bfd.cmscloud.gov || true
+          getent hosts github.com || true
+          nslookup sandbox.fhir.bfd.cmscloud.gov || true
       - name: Run e2e-bfd-test
         env:
           AB2D_BFD_URL: 'https://sandbox.fhir.bfd.cmscloud.gov'

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -73,15 +73,9 @@ jobs:
           KEYSTORE_FILE_NAME="ab2d_${{ env.AB2D_ENV }}_keystore"
           aws s3 cp s3://$MAIN_BUCKET/$KEYSTORE_FILE_NAME $AB2D_BFD_KEYSTORE_LOCATION
           test -f $AB2D_BFD_KEYSTORE_LOCATION && echo "created keystore file"
-      - name: DNS Diag
-        run: |
-          cat /etc/resolv.conf
-          getent hosts sandbox.fhir.bfd.cmscloud.gov || true
-          getent hosts github.com || true
-          nslookup sandbox.fhir.bfd.cmscloud.gov || true
       - name: Run e2e-bfd-test
         env:
-          AB2D_BFD_URL: 'https://sandbox.fhir.bfd.cmscloud.gov'
+          AB2D_BFD_URL: 'https://prod-sbx.fhir.bfd.cmscloud.local'
           AB2D_BFD_URL_V3: 'https://sandbox.fhirv3.bfd.cmscloud.local'
         run: |
           mvn test -s settings.xml -Dcheckstyle.skip -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AB2D_BFD_KEYSTORE_LOCATION: "${{ github.workspace }}/opt/ab2d/ab2d_bfd_keystore"
       AB2D_V2_ENABLED: 'true'

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run e2e-bfd-test
         env:
-          AB2D_BFD_URL: 'https://prod-sbx.fhir.bfd.cmscloud.local'
+          AB2D_BFD_URL: 'https://sandbox.fhir.bfd.cmscloud.gov'
           AB2D_BFD_URL_V3: 'https://sandbox.fhirv3.bfd.cmscloud.local'
         run: |
           mvn test -s settings.xml -Dcheckstyle.skip -pl e2e-bfd-test -am -Dtest=EndToEndBfdTests -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -91,11 +91,9 @@ jobs:
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret
       - name: diagnostic
         run: |
-          curl -4 -s https://checkip.amazonaws.com; echo
-          getent hosts test.ab2d.cms.gov
-          curl -sv --max-time 10 https://test.ab2d.cms.gov/health || true
-          getent hosts test.idp.idm.cms.gov
-          curl -sv --max-time 10 https://test.idp.idm.cms.gov/ 2>&1 | head -40 || true
+          locale || true
+          echo "___"
+          java -XshowSettings:properties -version 2>&1 | grep -iE 'file.encoding|sun.jnu.encoding|user.language|user.country'
       - name: Run e2e-test
         env:
          E2E_ENVIRONMENT: ${{ inputs.environment == 'dev' && 'DEV' || inputs.environment == 'test' && 'IMPL' || inputs.environment == 'sandbox' && 'SBX' }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -98,5 +98,8 @@ jobs:
         env:
          E2E_ENVIRONMENT: ${{ inputs.environment == 'dev' && 'DEV' || inputs.environment == 'test' && 'IMPL' || inputs.environment == 'sandbox' && 'SBX' }}
          API_BASE_URL: ${{ inputs.api_base_url }}
+         LANG: C.UTF-8
+         LC_ALL: C.UTF-8
+         JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"
         run: |
           mvn test -s settings.xml -Dcheckstyle.skip -pl e2e-test -am -Dtest=TestRunner -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dusername=$ARTIFACTORY_USER -Dpassword=$ARTIFACTORY_PASSWORD -Drepository_url=$ARTIFACTORY_URL --no-transfer-progress

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -91,10 +91,11 @@ jobs:
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret
       - name: diagnostic
         run: |
+          curl -4 -s https://checkip.amazonaws.com; echo
           getent hosts test.ab2d.cms.gov
-          curl --v --max-time 10 https://test.ab2d.cms.gov/health || true
+          curl -sv --max-time 10 https://test.ab2d.cms.gov/health || true
           getent hosts test.idp.idm.cms.gov
-          curl -v --max-time 10 https://test.idp.idm.cms.gov/ || true
+          curl -sv --max-time 10 https://test.idp.idm.cms.gov/ 2>&1 | head -40 || true
       - name: Run e2e-test
         env:
          E2E_ENVIRONMENT: ${{ inputs.environment == 'dev' && 'DEV' || inputs.environment == 'test' && 'IMPL' || inputs.environment == 'sandbox' && 'SBX' }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -89,11 +89,6 @@ jobs:
             OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
             SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-1000-id
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret
-      - name: diagnostic
-        run: |
-          locale || true
-          echo "___"
-          java -XshowSettings:properties -version 2>&1 | grep -iE 'file.encoding|sun.jnu.encoding|user.language|user.country'
       - name: Run e2e-test
         env:
          E2E_ENVIRONMENT: ${{ inputs.environment == 'dev' && 'DEV' || inputs.environment == 'test' && 'IMPL' || inputs.environment == 'sandbox' && 'SBX' }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AB2D_V2_ENABLED: 'true'
       AB2D_V3_ENABLED: ${{ inputs.v3_enabled }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -89,7 +89,12 @@ jobs:
             OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
             SECONDARY_USER_OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-1000-id
             SECONDARY_USER_OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-1000-secret
-
+      - name: diagnostic
+        run: |
+          getent hosts test.ab2d.cms.gov
+          curl --v --max-time 10 https://test.ab2d.cms.gov/health || true
+          getent hosts test.idp.idm.cms.gov
+          curl -v --max-time 10 https://test.idp.idm.cms.gov/ || true
       - name: Run e2e-test
         env:
          E2E_ENVIRONMENT: ${{ inputs.environment == 'dev' && 'DEV' || inputs.environment == 'test' && 'IMPL' || inputs.environment == 'sandbox' && 'SBX' }}

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -58,6 +58,11 @@ jobs:
           params: |
             OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-100-id
             OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
+      - name: Diagnostic
+        env:
+          ENV: ${{inputs.environment || 'test' }}
+        run: |
+          curl -v --max-time 10 "https://${ENV}.ab2d.cms.gov/health" || true
       - name: Run Inferno
         id: run
         env:

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: codebuild-ab2d-${{ contains(fromJSON('["sandbox"]'), inputs.environment) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ inputs.environment == 'sandbox' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}
-      AB2D_ENV: ${{ inputs.environment || 'test' }}
+      AB2D_ENV: ${{ inputs.environment || 'dev' }}
 
     name: run fhir scan
     steps:
@@ -58,15 +58,18 @@ jobs:
           params: |
             OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-100-id
             OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
-
+      - name: Diagnostic
+        env:
+          ENV: ${{inputs.environment || 'test' }}
+        run: |
+          curl -v --max-time 10 "https://${ENV}.ab2d.cms.gov/health" || true
       - name: Run Inferno
         id: run
         env:
-          ENV: ${{ inputs.environment || 'test' }}
+          ENV: ${{ inputs.environment || 'dev' }}
           BASE_URL: ${{ inputs.api_base_url }}
         run: |
           cd ${GITHUB_WORKSPACE} 
-          
           docker build -t inferno:1 https://github.com/inferno-framework/bulk-data-test-kit.git#5bd61db090c5911792f33e12dca6981d7e22f9a0
           docker compose -f fhir-test/docker-compose.inferno.yml run inferno bundle exec inferno migrate
           docker compose -f fhir-test/docker-compose.inferno.yml up -d

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -58,11 +58,6 @@ jobs:
           params: |
             OKTA_CLIENT_ID=/ab2d/mgmt/okta/sensitive/test-pdp-100-id
             OKTA_CLIENT_PASSWORD=/ab2d/mgmt/okta/sensitive/test-pdp-100-secret
-      - name: Diagnostic
-        env:
-          ENV: ${{inputs.environment || 'test' }}
-        run: |
-          curl -v --max-time 10 "https://${ENV}.ab2d.cms.gov/health" || true
       - name: Run Inferno
         id: run
         env:

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ inputs.environment == 'sandbox' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}
       AB2D_ENV: ${{ inputs.environment || 'dev' }}

--- a/.github/workflows/fhir-test.yml
+++ b/.github/workflows/fhir-test.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/fhir-test.yml
-    inputs:
-      environment:
-        type: string
-        default: test
   workflow_call:
     inputs:
       environment:
@@ -38,10 +34,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["sandbox"]'), inputs.environment) && 'prod' || 'non-prod'}}-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ inputs.environment == 'sandbox' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}
-      AB2D_ENV: ${{ inputs.environment || 'dev' }}
+      AB2D_ENV: ${{ inputs.environment || 'test' }}
 
     name: run fhir scan
     steps:

--- a/.github/workflows/libs-build.yml
+++ b/.github/workflows/libs-build.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       AWS_ACCOUNT: ${{ secrets.NON_PROD_ACCOUNT }}
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/libs-publish.yml
+++ b/.github/workflows/libs-publish.yml
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
   publish:
     needs: build
-    runs-on: codebuild-ab2d-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       FORCE_PUBLISH: ${{ inputs.forcePublish }}

--- a/.github/workflows/libs-sonarqube.yml
+++ b/.github/workflows/libs-sonarqube.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   sonarqube:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     needs: workflow
     if: needs.workflow.outputs.files || github.event_name == 'push'
     env:

--- a/.github/workflows/start-job.yml
+++ b/.github/workflows/start-job.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   start-job:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && 'non-prod' || 'prod'}}-${{github.run_id}}-${{github.run_attempt}}
 
     env:
       CONTRACT_NUMBER: ${{ inputs.contractNumber }}

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -32,7 +32,7 @@ jobs:
             grep -P "${workflow_files_re}" \
           && echo "files=true" >> $GITHUB_OUTPUT || echo "files=" >> $GITHUB_OUTPUT
   test:
-    runs-on: codebuild-ab2d-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-ab2d-non-prod-${{github.run_id}}-${{github.run_attempt}}
     needs: workflow
     if: needs.workflow.outputs.files || github.event_name == 'push'
     env:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7158

## 🛠 Changes

Moves all remaining runners to the new arm64 codebuild. 
Small note: Due to file encoding differences on ARM64, the checksum does not match when checked by the tests. This can be fixed by explicitly passing in UTF-8 for the charset. This issue will resolve itself on updating Java version, or having the runner itself specify the lang. For right now, though, passing it in via ENV should work fine.

## ℹ️ Context

Part of a greater initiative to migrate coderunners to run/build on arm64 architecture. See [here](https://confluence.cms.gov/spaces/ODI/pages/1527722964/DevSecOps_Strategy_ARM64) for more info.

## 🧪 Validation

The workflows run successfully
https://github.com/CMSgov/ab2d/actions/runs/24743182118
https://github.com/CMSgov/ab2d/actions/runs/24738091276
https://github.com/CMSgov/ab2d/actions/runs/24692103320
https://github.com/CMSgov/ab2d/actions/runs/24533937036
https://github.com/CMSgov/ab2d/actions/runs/24586266721