### PR TITLE
AB2D-7158-Patch codeql 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [ "main", "codeql-fix" ]
+    branches: [ "main" ]
     
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,17 +36,5 @@ jobs:
           languages: java
           build-mode: none
 
-      - name: Set env vars from AWS params in BCDA management account
-        uses: cmsgov/cdap/actions/aws-params-env-action@main
-        with:
-          params: |
-            ARTIFACTORY_URL=/artifactory/url
-            ARTIFACTORY_USER=/artifactory/user
-            ARTIFACTORY_PASSWORD=/artifactory/password
-
-      - name: Build package
-        run: mvn -U clean package -s settings.xml -Dcheckstyle.skip -DskipTests -Dusername="${ARTIFACTORY_USER}" -Dpassword="${ARTIFACTORY_PASSWORD}" -Drepository_url="${ARTIFACTORY_URL}"
-
-
       - name: Run CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,12 @@ name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
-
+    branches: [ "main", "codeql-fix" ]
+    
 jobs:
   analyze:
     name: CodeQL scan
-    runs-on: codebuild-ab2d-non-prod-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
## 🎫 Ticket

Based on https://jira.cms.gov/browse/AB2D-7158

## 🛠 Changes

Remove build from codeql, switch runner to github runner. This prevents Artifactory access, but we don't need it anyway, since codeql doesn't build anyway. The package creation step is unnecessary for codeql.

If we still want to run the package step just to test it, we can do that seperately. If coverage of generated code is needed, we'll need to figure out something else.

## ℹ️ Context
 
Codeql has no ARM support. It has to run on a codebuild with the correct architecture support. 

## 🧪 Validation

https://github.com/CMSgov/ab2d/actions/runs/24745178298/job/72394853501