### PR TITLE
AB2D-7222 Added temporary property eob.v3.inplace.enabled

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
@@ -42,4 +42,7 @@ public final class PropertyConstants {
 
     public static final String V3_IDR_IMPORTER_STATUS = "v3.idr-importer.status";
 
+    // When true, R4V3 EOB processing uses in-place mutation instead of copy-based construction
+    public static final String EOB_V3_IN_PLACE = "eob.v3.inplace.enabled";
+
 }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -187,3 +187,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_tables_partitions.sql
   - include:
       file: db/changelog/v2026/add_v3_idr_importer_progress_status.sql
+  - include:
+      file: db/changelog/v2026/add_eob_v3_inplace_property.sql

--- a/common/src/main/resources/db/changelog/v2026/add_eob_v3_inplace_property.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_eob_v3_inplace_property.sql
@@ -1,0 +1,5 @@
+INSERT INTO property.properties (id, key, value, created, modified)
+SELECT (SELECT COALESCE(MAX(id),0)+1 FROM property.properties),
+       'eob.v3.inplace.enabled', 'false', now(), now()
+    WHERE NOT EXISTS (SELECT 1 FROM property.properties WHERE key = 'eob.v3.inplace.enabled'); -- gitleaks:allow
+


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7222

## 🛠 Changes

Created a temporary property `eob.v3.inplace.enabled` in the properties table to switch between EOB processing using the copy-paste approach and the in-place approach

## ℹ️ Context

The current implementation of v3- EOB processing relies heavily on copy-based object construction (e.g., creating new ExplanationOfBenefit instances and copying fields manually).

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
