### PR TITLE
AB2D-7223 Worker and API to Java 25

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
           cache: maven
 
       - name: Set env vars from AWS params in BCDA management account

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
 
       - name: Set env vars from AWS params in BCDA management account
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v3
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "25"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/e2e-bfd-test.yml
+++ b/.github/workflows/e2e-bfd-test.yml
@@ -46,10 +46,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
 
       - name: Set env vars from AWS params
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
 
       - name: Set env vars from AWS params
         uses: cmsgov/cdap/actions/aws-params-env-action@main

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -44,9 +44,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: temurin
           cache: maven
 

--- a/.github/workflows/unit-integration-test.yml
+++ b/.github/workflows/unit-integration-test.yml
@@ -45,9 +45,9 @@ jobs:
           fetch-depth: 0  # Get entire history for SonarQube
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: temurin
           cache: maven
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-al2023-jdk
+FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-api
 ADD target/api-*-SNAPSHOT.jar /usr/src/ab2d-api/api.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-api/newrelic/newrelic.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       timeout: 5s
       retries: 40
   build:
-    image: maven:3-openjdk-17
+    image: maven:3.9-amazoncorretto-25
     working_dir: /usr/src/mymaven
     # Not necessary to run mvn package since we anticipate that project
     # has already built so we don't need to run this command

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <project.root>${basedir}</project.root>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <hapi.version>8.4.0</hapi.version>
         <mockito.core.version>5.16.1</mockito.core.version>
         <okhttp3.version>5.0.0</okhttp3.version>
@@ -39,7 +39,7 @@
         <postgresql.version>42.7.7</postgresql.version>
 
         <!-- Maven plugin versions -->
-        <jacoco.version>0.8.10</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
         <maven.assembly.plugin.version>2.3</maven.assembly.plugin.version>
 
@@ -197,6 +197,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 #AWS Corretto and AL2
-FROM amazoncorretto:21-al2023-jdk
+FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-worker
 ADD target/worker-*-SNAPSHOT-exe.jar /usr/src/ab2d-worker/worker.jar
 ADD target/newrelic/newrelic.jar /usr/src/ab2d-worker/newrelic/newrelic.jar

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.root>${basedir}/..</project.root>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <sonar.coverage.exclusions>**/PatientClaimsProcessorImpl.java,**/ContractProcessorImpl.java,**/CoverageDriverImpl.java,**/JobProcessorImpl.java</sonar.coverage.exclusions>
     </properties>
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7223

## 🛠 Changes

Updates docker, build files, and workflows to use Java 25.

## ℹ️ Context

The worker and api previously ran on Java 17, which is an older and outdated version of Java. Upgrading to the newer version brings more features, and better performance. 

## 🧪 Validation

Workflows pass: 
https://github.com/CMSgov/ab2d/actions?query=branch%3AAB2D-7223%2Fjava-25-api-worker

Successfully deployed to dev, tested with an example job that produced expected output.
