### PR TITLE
Update worker to call the populate the history summary table

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -189,3 +189,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_idr_importer_progress_status.sql
   - include:
       file: db/changelog/v2026/add_eob_v3_inplace_property.sql
+  - include:
+      file: db/changelog/v2026/add_v3_history_summary_table.sql

--- a/common/src/main/resources/db/changelog/v2026/add_v3_history_summary_table.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_history_summary_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_history_summary AS
+SELECT
+    contract,
+    patient_id,
+    current_mbi,
+    array_agg(array[year, month] ORDER BY year ASC, month ASC) AS historical_coverage_summaries
+FROM v3.coverage_v3_historical
+WHERE false
+GROUP BY contract, patient_id, current_mbi;
+
+CREATE INDEX ON v3.coverage_v3_history_summary (contract);
+CREATE INDEX ON v3.coverage_v3_history_summary (patient_id);
+CREATE INDEX ON v3.coverage_v3_history_summary (current_mbi);

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
@@ -55,8 +55,7 @@ public class CoverageV3ScheduledTasks {
 	}
 
 	// every day at 6:30am and 6:30pm -- staggered to not run during copyFromStagingTablesToRecentForAllContracts()
-	//@Scheduled(cron= "0 30 6,18 * * *")
-	@Scheduled(cron= "0 */5 * * * *")
+	@Scheduled(cron= "0 30 6,18 * * *")
 	public void moveToHistoricalForAllContracts() {
 		log.info("[V3] Calling moveToHistoricalForAllContracts()");
 		val contracts = syncService.getContractsInRecentCoverageTable();

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
@@ -55,7 +55,8 @@ public class CoverageV3ScheduledTasks {
 	}
 
 	// every day at 6:30am and 6:30pm -- staggered to not run during copyFromStagingTablesToRecentForAllContracts()
-	@Scheduled(cron= "0 30 6,18 * * *")
+	//@Scheduled(cron= "0 30 6,18 * * *")
+	@Scheduled(cron= "0 */5 * * * *")
 	public void moveToHistoricalForAllContracts() {
 		log.info("[V3] Calling moveToHistoricalForAllContracts()");
 		val contracts = syncService.getContractsInRecentCoverageTable();

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -231,11 +231,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             if (locked) {
                 int rowsMoved = moveToHistoricalInternal(contract);
                 log.info("[V3] Moved {} rows to historical coverage table for contract {}", rowsMoved, contract);
-                if (rowsMoved == 0) {
-                    return NO_COVERAGE_FOUND_FOR_CONTRACT;
-                } else {
+//                if (rowsMoved == 0) {
+//                    return NO_COVERAGE_FOUND_FOR_CONTRACT;
+//                } else {
                     populateHistorySummaryForContract(contract);
-                }
+    //            }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
 
@@ -323,7 +323,8 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     }
 
     boolean isTestContract(String contract) {
-        return contract.toUpperCase(Locale.ROOT).startsWith("Z");
+     //   return contract.toUpperCase(Locale.ROOT).startsWith("Z");
+        return false;
     }
 
     boolean contractHasJobInProgress(String contract) {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -100,6 +100,20 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     select count(*) from deleted_rows;
     """.formatted(COVERAGE_V3_TABLE_RECENT);
 
+    private static final String DELETE_HISTORY_SUMMARY_FOR_CONTRACT =
+        "DELETE FROM v3.coverage_v3_history_summary WHERE contract = :contract";
+
+    private static final String INSERT_HISTORY_SUMMARY_FOR_CONTRACT =
+    """
+    INSERT INTO v3.coverage_v3_history_summary
+        (contract, patient_id, current_mbi, historical_coverage_summaries)
+    SELECT contract, patient_id, current_mbi,
+           array_agg(array[year, month] ORDER BY year ASC, month ASC)
+    FROM v3.coverage_v3_historical
+    WHERE contract = :contract
+    GROUP BY contract, patient_id, current_mbi
+    """;
+
     private static final String GET_CONTRACTS_WITH_ACTIVE_V3_JOBS =
         "select distinct contract_number from job where status in ('IN_PROGRESS', 'SUBMITTED')";
 
@@ -219,6 +233,8 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 log.info("[V3] Moved {} rows to historical coverage table for contract {}", rowsMoved, contract);
                 if (rowsMoved == 0) {
                     return NO_COVERAGE_FOUND_FOR_CONTRACT;
+                } else {
+                    populateHistorySummaryForContract(contract);
                 }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
@@ -296,6 +312,14 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         val parameters = new MapSqlParameterSource().addValue("contract", contract);
         val template = new NamedParameterJdbcTemplate(this.dataSource);
         return DataAccessUtils.intResult(template.queryForList(query, parameters, Integer.class));
+    }
+
+    private void populateHistorySummaryForContract(String contract) {
+        val parameters = new MapSqlParameterSource().addValue("contract", contract);
+        val template = new NamedParameterJdbcTemplate(dataSource);
+        template.update(DELETE_HISTORY_SUMMARY_FOR_CONTRACT, parameters);
+        int rowsInserted = template.update(INSERT_HISTORY_SUMMARY_FOR_CONTRACT, parameters);
+        log.info("[V3] Inserted {} rows into coverage_v3_history_summary for contract {}", rowsInserted, contract);
     }
 
     boolean isTestContract(String contract) {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -231,11 +231,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             if (locked) {
                 int rowsMoved = moveToHistoricalInternal(contract);
                 log.info("[V3] Moved {} rows to historical coverage table for contract {}", rowsMoved, contract);
-//                if (rowsMoved == 0) {
-//                    return NO_COVERAGE_FOUND_FOR_CONTRACT;
-//                } else {
+                if (rowsMoved == 0) {
+                    return NO_COVERAGE_FOUND_FOR_CONTRACT;
+                } else {
                     populateHistorySummaryForContract(contract);
-    //            }
+                }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
 
@@ -323,8 +323,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     }
 
     boolean isTestContract(String contract) {
-     //   return contract.toUpperCase(Locale.ROOT).startsWith("Z");
-        return false;
+        return contract.toUpperCase(Locale.ROOT).startsWith("Z");
     }
 
     boolean contractHasJobInProgress(String contract) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7268

## 🛠 Changes

- v3.coverage_v3_history_summary table created via liqubase
- Worker updated to populate data in the v3.coverage_v3_history_summary table

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tested in test environment 
<img width="1190" height="190" alt="Screenshot 2026-05-12 at 10 08 58 AM" src="https://github.com/user-attachments/assets/5231b129-0681-4d27-9522-30e0cd840eb9" />

<img width="779" height="608" alt="Screenshot 2026-05-12 at 10 09 47 AM" src="https://github.com/user-attachments/assets/e8c950e5-8325-4d4f-a530-b72b63715d3c" />
