### PR TITLE
AB2D-7269 Pin aurora engine version to default latest

### DIFF
--- a/ops/services/10-core/database.tf
+++ b/ops/services/10-core/database.tf
@@ -1,5 +1,5 @@
 module "db" {
-  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=231b7d4f1e607b61b58ec497120b6188a998ef1f"
+  source = "github.com/CMSgov/cdap//terraform/modules/aurora?ref=b0e43ec5b235d8fddc9cf2aaf3440b73e185d47f"
 
   snapshot_identifier = var.aurora_snapshot
   deletion_protection = true


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7269

## 🛠 Changes

Updates aurora module version to the most recent commit, which includes changes to ensure the engine_version in tofu always matches the state in AWS. https://github.com/CMSgov/cdap/commit/b0e43ec5b235d8fddc9cf2aaf3440b73e185d47f

## ℹ️ Context
We started seeing errors with the aurora module stemming from automatic version updates from AWS's side. This is nothing we can change, so we should dynamically retrieve the most up-to-date default version that AWS will force upon the instances anyway, to save ourselves the headache.

## 🧪 Validation

Confirmed that the version matches with the version that was updated to
automatically (AB2D DEV):
```
module.db.aws_rds_cluster_instance.this[0]: Refreshing state... [id=[ab2d-dev-0](https://jira.cms.gov/browse/AB2D-dev-0)]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
