### PR TITLE
AB2D-7276 microservices java25

### DIFF
--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -48,8 +48,8 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '25'
 
       - name: Assume role in target account
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/workflows/contracts-sonarqube.yml
+++ b/.github/workflows/contracts-sonarqube.yml
@@ -24,8 +24,8 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '25'
 
       - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:

--- a/.github/workflows/events-build.yml
+++ b/.github/workflows/events-build.yml
@@ -49,8 +49,8 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '25'
 
       - name: Assume role in target account
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/workflows/events-sonarqube.yml
+++ b/.github/workflows/events-sonarqube.yml
@@ -24,8 +24,8 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '17'
+          distribution: 'temurin'
+          java-version: '25'
 
       - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-contracts
-ADD build/libs/ab2d-contracts-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
+ADD build/libs/contracts-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
 
 CMD java \
     -XX:+UseContainerSupport \

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,7 +1,6 @@
 FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-contracts
-ADD build/libs/contracts-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
-CMD java -jar /usr/src/ab2d-contracts/ab2d-contracts.jar
+ADD build/libs/ab2d-contracts-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
 
 CMD java \
     -XX:+UseContainerSupport \

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21.0.10-alpine3.23
+FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-contracts
 ADD build/libs/contracts-*.jar /usr/src/ab2d-contracts/ab2d-contracts.jar
 CMD java -jar /usr/src/ab2d-contracts/ab2d-contracts.jar

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -80,20 +80,3 @@ bootJar {
 test {
     useJUnitPlatform()
 }
-
-repositories {
-    mavenCentral()
-    mavenLocal()
-    def artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: System.getProperty("artifactory_contextUrl")
-    if (artifactoryUrl) {
-        maven {
-            println("Using Artifactory URL in build.gradle: ${artifactoryUrl}/ab2d-main")
-            url = "${artifactoryUrl}/ab2d-main"
-            credentials {
-                username = System.getenv("ARTIFACTORY_USER") ?: System.getProperty("username")
-                password = System.getenv("ARTIFACTORY_PASSWORD") ?: System.getProperty("password")
-            }
-        }
-    }
-
-}

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -1,11 +1,12 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.14'
-    id 'com.jfrog.artifactory' version '5.2.5' apply false
     id "org.sonarqube" version "7.3.0.8198"
     id 'maven-publish'
-    id 'org.cyclonedx.bom' version '2.0.0' apply true
+    id 'org.cyclonedx.bom' version '3.0.0' apply true
 }
+
+apply from: "${rootDir}/../gradle/ab2d-shared.gradle"
 
 version="2.0.1"
 group = "gov.cms.ab2d"
@@ -52,26 +53,24 @@ allprojects {
         annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     }
 
-    cyclonedxBom {
-        // includeConfigs is the list of configuration names to include when generating the BOM (leave empty to include every configuration)
+    cyclonedxDirectBom {
         includeConfigs = ["runtimeClasspath"]
-        // skipConfigs is a list of configuration names to exclude when generating the BOM
         skipConfigs = ["compileClasspath", "testCompileClasspath"]
-        // Specified the type of project being built. Defaults to 'library'
-        projectType = "library"
-        // Specified the version of the CycloneDX specification to use. Defaults to 1.4.
-        schemaVersion = "1.4"
-        // Boms destination directory (defaults to build/reports)
-        destination = file("build/reports")
-        // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
-        outputName = "bom"
-        // The file format generated, can be xml, json or all for generating both
-        outputFormat = "all"
-        // Exclude BOM Serial Number
-        includeBomSerialNumber = false
-        // Override component version
-        componentVersion = "2.0.0"
     }
+
+    cyclonedxBom {
+        projectType = "library"
+        schemaVersion = "VERSION_14"
+        includeBomSerialNumber = false
+        componentVersion = "2.0.0"
+        jsonOutput = file("build/reports/bom.json")
+        xmlOutput = file("build/reports/bom.xml")
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 bootJar {

--- a/contracts/docker-compose.yml
+++ b/contracts/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 5s
       retries: 5
   build:
-    image: maven:3-openjdk-17
+    image: eclipse-temurin:25-jdk-alpine
     working_dir: /usr/src/mymaven
     # Not necessary to run mvn package since we anticipate that project
     # has already built so we don't need to run this command

--- a/events/Dockerfile
+++ b/events/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21.0.10-alpine3.23
+FROM amazoncorretto:25-al2023-jdk
 WORKDIR /usr/src/ab2d-events
 ADD build/libs/*.jar /usr/src/ab2d-events/ab2d-event.jar
 

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -3,11 +3,12 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'org.springframework.boot' version '3.5.14'
-    id 'com.jfrog.artifactory' version '5.2.5' apply false
     id "org.sonarqube" version "7.3.0.8198"
     id 'maven-publish'
     id 'org.cyclonedx.bom' version '2.0.0' apply true
 }
+
+apply from: "${rootDir}/../gradle/ab2d-shared.gradle"
 
 version="2.0.1"
 group = "gov.cms.ab2d"
@@ -53,6 +54,7 @@ allprojects {
         testImplementation "commons-io:commons-io:2.18.0"
         testImplementation "org.springframework.data:spring-data-jpa"
         testImplementation "org.liquibase:liquibase-core:${liquibaseVersion}"
+        testImplementation "org.testcontainers:testcontainers:${testContainerVersion}"
         testImplementation "org.testcontainers:localstack:${testContainerVersion}"
         testImplementation "org.testcontainers:postgresql:${testContainerVersion}"
         testImplementation "org.testcontainers:junit-jupiter:${testContainerVersion}"
@@ -90,6 +92,10 @@ allprojects {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
+}
 jacocoTestReport {
     reports {
         xml.required.set(true)

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -118,18 +118,3 @@ sonarqube {
         property "sonar.java.binaries", "${layout.buildDirectory.get().asFile}/classes"
     }
 }
-
-repositories {
-    mavenCentral()
-    mavenLocal()
-    def artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: System.getProperty("artifactory_contextUrl")
-    if (artifactoryUrl) {
-        maven {
-            url = "${artifactoryUrl}/ab2d-main"
-            credentials {
-                username = System.getenv("ARTIFACTORY_USER") ?: System.getProperty("username")
-                password = System.getenv("ARTIFACTORY_PASSWORD") ?: System.getProperty("password")
-            }
-        }
-    }
-}

--- a/events/docker-compose.yml
+++ b/events/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       timeout: 5s
       retries: 5
   build:
-    image: maven:3-openjdk-17
+    image: eclipse-temurin:25-jdk-alpine
     working_dir: /usr/src/mymaven
     # Not necessary to run mvn package since we anticipate that project
     # has already built so we don't need to run this command

--- a/gradle/ab2d-shared.gradle
+++ b/gradle/ab2d-shared.gradle
@@ -1,0 +1,28 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven {
+        def artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: System.getProperty("artifactory_contextUrl")
+        url = "${artifactoryUrl}/ab2d-main"
+        credentials {
+            username = System.getenv("ARTIFACTORY_USER") ?: System.getProperty("username")
+            password = System.getenv("ARTIFACTORY_PASSWORD") ?: System.getProperty("password")
+        }
+    }
+}
+
+tasks.withType(Test).configureEach {
+    testLogging {
+        events TestLogEvent.FAILED,
+                TestLogEvent.SKIPPED,
+                TestLogEvent.STANDARD_OUT,
+                TestLogEvent.STANDARD_ERROR
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+}

--- a/lambdas/metrics-lambda/build.gradle
+++ b/lambdas/metrics-lambda/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'gov.cms.ab2d:ab2d-events-client:1.11.2'
+    implementation 'gov.cms.ab2d:ab2d-events-client:3.3.13'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'

--- a/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
+++ b/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
@@ -11,10 +11,8 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.util.StringUtils;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.ab2d.eventclient.events.MetricsEvent;
@@ -42,15 +40,12 @@ public class CloudwatchEventHandler implements RequestHandler<SNSEvent, String> 
     private static final String SQS_QUEUE_URL = System.getenv("AWS_SQS_EVENTS_URL");
     private static final String QUEUE_NAME = deriveSqsQueueName(SQS_QUEUE_URL);
 
-    // AWS sends an object that's not wrapped with type info. The event service expects the wrapper.
-    // Since there's not an easy way to enable/disable type wrapper just have 2 mappers.
     private final ObjectMapper inputMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .registerModule(new JodaModule())
             .registerModule(new JavaTimeModule());
 
     private final ObjectMapper outputMapper = new ObjectMapper()
-            .activateDefaultTyping(LaissezFaireSubTypeValidator.instance, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.WRAPPER_ARRAY)
             .registerModule(new JodaModule())
             .registerModule(new JavaTimeModule());
 

--- a/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
+++ b/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.ab2d.eventclient.events.MetricsEvent;
 import gov.cms.ab2d.eventclient.messages.GeneralSQSMessage;
+import gov.cms.ab2d.eventclient.messages.SQSMessages;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -108,13 +109,15 @@ public class CloudwatchEventHandler implements RequestHandler<SNSEvent, String> 
             service = Optional.ofNullable(alarm.getAlarmName())
                     .orElseThrow(() -> new EventDataException("AlarmName is null"))
                     .replace(environment, "");
-            request.setMessageBody(outputMapper.writeValueAsString(new GeneralSQSMessage(MetricsEvent.builder()
+            // declare type so it doesn't get ignored later
+            SQSMessages sqsMessage = new GeneralSQSMessage(MetricsEvent.builder()
                     .service(service)
                     .eventDescription(alarm.getAlarmDescription())
                     .timeOfEvent(time)
                     //This might need more work later if AWS is sending unknown states regularly
                     .stateType(from(alarm.getNewStateValue()))
-                    .build())));
+                    .build());
+            request.setMessageBody(outputMapper.writeValueAsString(sqsMessage));
         } catch (Exception e) {
             log.log(String.format("Handling lambda failed %s", exceptionToString(e)));
             return;

--- a/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
+++ b/lambdas/metrics-lambda/src/main/java/gov/cms/ab2d/metrics/CloudwatchEventHandler.java
@@ -11,13 +11,14 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.util.StringUtils;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.ab2d.eventclient.events.MetricsEvent;
 import gov.cms.ab2d.eventclient.messages.GeneralSQSMessage;
-import gov.cms.ab2d.eventclient.messages.SQSMessages;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -47,6 +48,7 @@ public class CloudwatchEventHandler implements RequestHandler<SNSEvent, String> 
             .registerModule(new JavaTimeModule());
 
     private final ObjectMapper outputMapper = new ObjectMapper()
+            .activateDefaultTyping(LaissezFaireSubTypeValidator.instance, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.WRAPPER_ARRAY)
             .registerModule(new JodaModule())
             .registerModule(new JavaTimeModule());
 
@@ -109,15 +111,13 @@ public class CloudwatchEventHandler implements RequestHandler<SNSEvent, String> 
             service = Optional.ofNullable(alarm.getAlarmName())
                     .orElseThrow(() -> new EventDataException("AlarmName is null"))
                     .replace(environment, "");
-            // declare type so it doesn't get ignored later
-            SQSMessages sqsMessage = new GeneralSQSMessage(MetricsEvent.builder()
+            request.setMessageBody(outputMapper.writeValueAsString(new GeneralSQSMessage(MetricsEvent.builder()
                     .service(service)
                     .eventDescription(alarm.getAlarmDescription())
                     .timeOfEvent(time)
                     //This might need more work later if AWS is sending unknown states regularly
                     .stateType(from(alarm.getNewStateValue()))
-                    .build());
-            request.setMessageBody(outputMapper.writeValueAsString(sqsMessage));
+                    .build())));
         } catch (Exception e) {
             log.log(String.format("Handling lambda failed %s", exceptionToString(e)));
             return;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7276

## 🛠 Changes

Update Contracts & Events to use Java 25

- Updates to workflows, gradle files, and dockerfiles
- Bumps versions of incompatible libraries for Gradle 9
- Removal of "gov.cms.ab2d.plugin", functionality of which was moved to "ab2d-shared.gradle"

## ℹ️ Context

Updating the Java version increases performance and security, as well as aligns the Contracts/Events services with the rest of the project

## 🧪 Validation

Passing tests and successful deploy to dev

