### PR TITLE
AB2D-7284 Fix cron job logic for cleaning up unused aggregated tables

### DIFF
--- a/coverage/src/main/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembership.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembership.java
@@ -151,8 +151,12 @@ public class GetAggregatedCoverageMembership extends CoverageV3BaseQuery {
         return rowCount;
     }
 
-    public void deleteAggregatedTable(final String contract, final Optional<String> jobUuid) {
+    public void deleteAggregatedTableForContract(final String contract, final Optional<String> jobUuid) {
         val tableName = MessageFormat.format(AGGREGATED_TABLE_NAME, contract);
+        deleteAggregatedTable(tableName, jobUuid);
+    }
+
+    public void deleteAggregatedTable(final String tableName, final Optional<String> jobUuid) {
         if (jobUuid.isEmpty()) {
             log.info("Preparing to delete table {}", tableName);
         } else {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
@@ -27,6 +27,6 @@ public interface CoverageV3Service {
     int getDistinctPatientCount(String contract);
     // NOTE: Assumes job has been kicked off and aggregated table exists -- this is a slow process and will be updated in AB2D-7272
     int getCoveragePeriodsInAggregatedTable(String contract);
-    // used to find/delete tables from jobs cancelled manually (not via the API)
+    // used to find/delete tables from jobs not properly cleaned up
     void checkForAggregatedTablesToBeDeleted();
 }

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
@@ -18,9 +18,11 @@ public interface CoverageV3Service {
     boolean idrImportInProgress();
     // called before starting a v3 job
     void createAggregatedAttributionTable(String contract);
-    // called when v3 job is completed, failed, or cancelled via API in which case job UUID will be provided
-    // also called by cron job to periodically clean up old tables if job was cancelled manually (in which case job UUID is not provided)
-    void deleteAggregatedAttributionTable(String contract, Optional<String> jobUuid);
+    // called when v3 job is completed, failed, or cancelled via API or manually in which case job UUID will be provided
+    void deleteAggregatedTableForContract(String contract, Optional<String> jobUuid);
+    // called by cron job to periodically clean up any old tables (in which case job UUID is not provided)
+    void deleteAggregatedTable(String aggregatedTable);
+
     // NOTE: Assumes job has been kicked off and aggregated table exists
     int getDistinctPatientCount(String contract);
     // NOTE: Assumes job has been kicked off and aggregated table exists -- this is a slow process and will be updated in AB2D-7272

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
@@ -115,7 +115,7 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
     }
 
     @Override
-    public void deleteAggregatedAttributionTable(String contract, Optional<String> jobUuid) {
+    public void deleteAggregatedTableForContract(String contract, Optional<String> jobUuid) {
         val aggregatedTable = MessageFormat.format(GetAggregatedCoverageMembership.AGGREGATED_TABLE_NAME, contract.toLowerCase());
         if (keepAggregatedTable(aggregatedTable)) {
             if (jobUuid.isEmpty()) {
@@ -124,8 +124,13 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
                 log.info("Skipping deletion for aggregated table {} related to job {}", aggregatedTable, jobUuid.get());
             }
         } else {
-            new GetAggregatedCoverageMembership(dataSource).deleteAggregatedTable(contract, jobUuid);
+            new GetAggregatedCoverageMembership(dataSource).deleteAggregatedTableForContract(contract, jobUuid);
         }
+    }
+
+    @Override
+    public void deleteAggregatedTable(String aggregatedTable) {
+        new GetAggregatedCoverageMembership(dataSource).deleteAggregatedTable(aggregatedTable, Optional.empty());
     }
 
     @Override
@@ -153,9 +158,10 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
         val contractsWithActiveJobs = coverageV3SyncService.getContractsWithActiveV3Jobs();
 
         for (String aggregatedTable : aggregatedTables) {
+            aggregatedTable = "v3." + aggregatedTable;
             if (shouldDeleteAggregatedTable(aggregatedTable, contractsWithActiveJobs)) {
                 log.info("Deleting unused aggregated table {}", aggregatedTable);
-                deleteAggregatedAttributionTable(aggregatedTable, Optional.empty());
+                deleteAggregatedTable(aggregatedTable);
                 log.info("Deleted table {}", aggregatedTable);
             }
         }
@@ -178,15 +184,15 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
         return propertiesService.isToggleOn("%s.keep".formatted(tableName), false);
     }
 
-    boolean shouldDeleteAggregatedTable(final String tableName, final List<String> contactsWithActiveJobs) {
-        for (String contactsWithActiveJob : contactsWithActiveJobs) {
+    boolean shouldDeleteAggregatedTable(final String tableName, final List<String> contractsWithActiveJobs) {
+        for (String contractWithActiveJob : contractsWithActiveJobs) {
             val keepTable = keepAggregatedTable(tableName);
             if (keepTable) {
                 log.info("Skipping deletion for aggregated table {}", tableName);
                 return false;
             }
 
-            if (tableName.toLowerCase().endsWith(contactsWithActiveJob.toLowerCase())) {
+            if (tableName.toLowerCase().endsWith(contractWithActiveJob.toLowerCase())) {
                 return false;
             }
         }

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -45,7 +46,7 @@ class GetAggregatedCoverageMembershipTest {
 	);
 
 	@ParameterizedTest
-	@ValueSource(strings = {"Z1234", "Z0000", "Z7777"})
+	@ValueSource(strings = { "Z1234", "Z0000", "Z7777"  })
 	void test(String contract, CapturedOutput output) throws Exception {
 		GetAggregatedCoverageMembership aggregatedMembership = new GetAggregatedCoverageMembership(container.getDataSource());
 		aggregatedMembership.createAggregatedAttributionTable(contract);
@@ -79,7 +80,6 @@ class GetAggregatedCoverageMembershipTest {
 		assertTrue(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_" + contract));
 		assertFalse(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_Z9999"));
 		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
-
 
 		aggregatedMembership.createAggregatedAttributionTable(contract);
 		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.of("555"));
@@ -162,11 +162,9 @@ class GetAggregatedCoverageMembershipTest {
 
 	boolean tableExists(String tableName) throws Exception {
 		val query = "SELECT to_regclass('%s') IS NOT NULL".formatted(tableName);
-		try (val statement = container.getDataSource().getConnection().prepareStatement(query)) {
-			val resultSet = statement.executeQuery();
-			resultSet.next();
-			return resultSet.getBoolean(1);
-		}
+		return new JdbcTemplate(container.getDataSource()).queryForObject(query, Boolean.class);
 	}
+
+
 
 }

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
@@ -80,10 +80,12 @@ class GetAggregatedCoverageMembershipTest {
 		assertFalse(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_Z9999"));
 		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
 
+
 		aggregatedMembership.createAggregatedAttributionTable(contract);
-		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.of("1234"));
+		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.of("555"));
 		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
 
+		assertTrue(output.getOut().contains("Preparing to delete table v3.coverage_v3_aggregated_%s related to job 555".formatted(contract)));
 	}
 
 	@Test

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/query/GetAggregatedCoverageMembershipTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.sql.ResultSet;
 import java.util.*;
 
 import static org.mockito.Mockito.when;
@@ -45,7 +46,7 @@ class GetAggregatedCoverageMembershipTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = {"Z1234", "Z0000", "Z7777"})
-	void test(String contract, CapturedOutput output) {
+	void test(String contract, CapturedOutput output) throws Exception {
 		GetAggregatedCoverageMembership aggregatedMembership = new GetAggregatedCoverageMembership(container.getDataSource());
 		aggregatedMembership.createAggregatedAttributionTable(contract);
 
@@ -61,19 +62,27 @@ class GetAggregatedCoverageMembershipTest {
 			coverageSummaries = aggregatedMembership.fetchAggregatedData(contractDto, 1, Optional.of(lastPatientId));
 		}
 
+		aggregatedMembership.createAggregatedAttributionTable(contract);
 		// Should delete if exists
-		aggregatedMembership.deleteAggregatedTable(contract, Optional.empty());
+		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.empty());
 		// And not fail if it doesn't exist
-		aggregatedMembership.deleteAggregatedTable(contract, Optional.empty());
+		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.empty());
+		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
 
 		aggregatedMembership.createAggregatedAttributionTable("Z9999");
 		when(syncService.getContractsWithActiveV3Jobs()).thenReturn(List.of("Z9999"));
 
 		aggregatedMembership.createAggregatedAttributionTable(contract);
+		assertTrue(tableExists("v3.coverage_v3_aggregated_" + contract));
 
 		coverageV3Service.checkForAggregatedTablesToBeDeleted();
-		assertTrue(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_coverage_v3_aggregated_" + contract.toLowerCase()));
-		assertFalse(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_coverage_v3_aggregated_z9999"));
+		assertTrue(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_" + contract));
+		assertFalse(output.getOut().contains("Deleted table v3.coverage_v3_aggregated_Z9999"));
+		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
+
+		aggregatedMembership.createAggregatedAttributionTable(contract);
+		aggregatedMembership.deleteAggregatedTableForContract(contract, Optional.of("1234"));
+		assertFalse(tableExists("v3.coverage_v3_aggregated_" + contract));
 
 	}
 
@@ -147,6 +156,15 @@ class GetAggregatedCoverageMembershipTest {
 		assertTrue(output.getOut().contains("Processing duplicate patient at row number 7"));
 		assertTrue(output.getOut().contains("Processing duplicate patient at row number 8"));
 		assertTrue(output.getOut().contains("Reduced duplicate patient records into record from row number 6"));
+	}
+
+	boolean tableExists(String tableName) throws Exception {
+		val query = "SELECT to_regclass('%s') IS NOT NULL".formatted(tableName);
+		try (val statement = container.getDataSource().getConnection().prepareStatement(query)) {
+			val resultSet = statement.executeQuery();
+			resultSet.next();
+			return resultSet.getBoolean(1);
+		}
 	}
 
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobProcessorImpl.java
@@ -101,7 +101,7 @@ public class JobProcessorImpl implements JobProcessor {
                 deleteExistingDirectory(outputDirPath, job);
             }
             if (job.getFhirVersion() == FhirVersion.R4V3) {
-                coverageV3Service.deleteAggregatedAttributionTable(job.getContractNumber(), Optional.of(jobUuid));
+                coverageV3Service.deleteAggregatedTableForContract(job.getContractNumber(), Optional.of(jobUuid));
             }
         } catch (Exception e) {
             String contract = job.getContractNumber();
@@ -125,7 +125,7 @@ public class JobProcessorImpl implements JobProcessor {
             log.info("Job: [{}] FAILED", jobUuid);
             jobRepository.save(job);
             if (job.getFhirVersion() == FhirVersion.R4V3) {
-                coverageV3Service.deleteAggregatedAttributionTable(contract, Optional.of(jobUuid));
+                coverageV3Service.deleteAggregatedTableForContract(contract, Optional.of(jobUuid));
             }
         }
 
@@ -358,7 +358,7 @@ public class JobProcessorImpl implements JobProcessor {
         jobRepository.save(job);
         log.info("Job: [{}] is DONE", job.getJobUuid());
         if (job.getFhirVersion() == FhirVersion.R4V3) {
-            coverageV3Service.deleteAggregatedAttributionTable(job.getContractNumber(), Optional.of(job.getJobUuid()));
+            coverageV3Service.deleteAggregatedTableForContract(job.getContractNumber(), Optional.of(job.getJobUuid()));
         }
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorImpl.java
@@ -6,12 +6,10 @@ import gov.cms.ab2d.fhir.FhirVersion;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.repository.JobRepository;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +56,7 @@ public class CancelStuckJobsProcessorImpl implements CancelStuckJobsProcessor {
             stuckJob.setStatus(CANCELLED);
             jobRepository.save(stuckJob);
             if (stuckJob.getFhirVersion() == FhirVersion.R4V3) {
-                coverageV3Service.deleteAggregatedAttributionTable(stuckJob.getContractNumber(), Optional.of(stuckJob.getJobUuid()));
+                coverageV3Service.deleteAggregatedTableForContract(stuckJob.getContractNumber(), Optional.of(stuckJob.getJobUuid()));
             }
         }
     }


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-7284

## 🛠 Changes

Fix bug related to cron job for cleaning up unused aggregated tables 

## ℹ️ Context

This cron job handles cases where:
- Aggregated table was retained for debugging purposes (e.g. if property **v3.coverage_v3_aggregated_Z0001=true** existed when the job complete) but the property was later set to false 
- Job was in progress and worker was restarted

This cron job is **not** necessary if a job is cancelled manually as the worker handles cleanup propertly (unlike I previously thought) 

## 🧪 Validation

Updated existing test case with a few more assertions 
