### PR TITLE
Update artifactory access token in sops

### DIFF
--- a/ops/services/00-bootstrap/values/prod.sopsw.yaml
+++ b/ops/services/00-bootstrap/values/prod.sopsw.yaml
@@ -24,7 +24,7 @@
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/regence-oregon: ENC[AES256_GCM,data:kT0yl0uk0kI/H2WdMaWdTQ==,iv:hUYmx6ZkDUnUpvzLkHsulGtxuemVIYnlWTMImeAxfK0=,tag:Ufy687xbNTe3yzBIILA5zw==,type:str]
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/silverscript: ENC[AES256_GCM,data:8EpalRwzzOF9O7eNAH+AShV+yZl+iAAtrNLcJ4TsPkRYyNPSfI8xz7thw/SM5j62AdKOQQ/3s00A1w+g0ieM2S9EHD8iFz26Q+G66R8a6p4SEwi95qSGfUXRGdHPwMNvrHGjZwcmiL5pjejHSlK/YNDD,iv:27m73uhcLRmsJXXSXIFjzPgvqxStkEbgSoqDBqJAxzw=,tag:CtbyDfStb32Vl1B1ALvkqg==,type:str]
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/united-health: ENC[AES256_GCM,data:sBxLipXrFkMyCO41XlFkBYLxQiuuTKBK+FIsERnTh6hx8amEbXN9EQO2qlpoJZD3aAO7Ur2Lz/i13VYPlpMRFBNzXJD04d9rqkU1HyGf,iv:UTYqaNapaSfKszCm1ifA/3eWNZkGy/S92VVQxVOvruQ=,tag:skNfntPgb93FYnFFkLM2Fg==,type:str]
-/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:Zs4JrgK+AZ1wz52GuB3OZpMjublg4w2/+KVIAuqhjTxNeakt9tbpvsTf4iami46fNscNYaU9EKHLI0ilzeDR9e+H8CSVk6dGHBhSYnnJzUK490ADNSt7BVTl7LNnqDqriuHBAGz/Akce4BeSkEfFlpxOdXZTNHzCxmD+PR3r15U19Ewq6yZmcfZx2RviCQCehsyIuzVDrKVVBeFc8jn5RHXOlNnfEtGN0nFKQ19F0YnQDM99rGI1LgouETjI4zIY2x/nLEIkDNHBH1jxIyz+34QkQaa4hTKTvA3N8rWXkoRaV+l3KWdo3cmxTWg/0qro8b3rcvYkQ0rYIU+BVMsEYx7kVpgCMW1VzcyNRmeTW46+WYG0tHryENDeWvkCpxM0/DaSVxL596rCq7C7wFuLTbUvlMz+lmc5wn9PeHgkqCICxXNxxCud4368GnMUJj2ZAMcNzH/ah1ZjHC2DRUNFVx5D8R44llcmgc7i+NXgR+yE9Je93CRj+YKjKFRgyv61b7DlfAszl/Nuvzi80Ibq3Thl/7AGNJtkG19yf7ctnWs83pSp6Fzzi/eetpWt/wB0/7IluFiyjnUnlyxyLz2tUFEfGLxgnF9HTGfsjeRCcosr2qefa/QL09+BoqgwvXTHJndR9KZ2UH1zgK9gF+qoEfoPetfHHFW951P2/VEFrVB1+iaGgx8mlyPKNdSl6mHDrYyK4FGxvzKyba9zrys75ntS7P24hBVAUBKWhdtRz864uRYJ2/aoDW35Dcudez9C9a2F33A6tF2qWIgAwgPNjglcmnQHsTy9GRE90yZNNGng2P+L8NVm3ATSHgEKVdXroDN4BzBxs13ux1fBRyiLMkFSyMPneqUJhkdB7hzussE204hKSzKPJ1A2lqB7y8OVox1IxjhBtjC/5bWSWibh9NDpm3+co5PuIeIAmCeG1OEqcHCJOZ1Z6EKL06uUnVhWX4bW9zgoiA21v3yiClWklYyQMB4xPma6VL9uBGRJ6OuyxDGbtLTNja2GMXCLyspSXyY77DIrtZ9l+8ve2Cy6,iv:PPMx7c21hjfs48+ts0qSpBr3F0/wFw9szugRt9B9k2I=,tag:oLSeNFfdM6rNIkwgHpE/4Q==,type:str]
+/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:MO3nOI92Wg670vPXvfBSIDGftpmFFpwCXyp0pfAPUYs8vf5Nhs55cB6X6xL2eJ/ytT6C8uWjb9nf/2h4NNfjUzWWbmrvOSlvma8nw2KYL1QPU2TInI+B24amLoKt1kKBZqeJVo+PRH2+zj9HnRlwy2rHWPOKhpCaCMho4wWp4OlTk4iVa9QGGe0Q4TRyLNSXz/cprEIAd5TEAkZNfFW47gWCRZ4WbfWdq38aLWy6acB33pWxnd6NamaFf0ot+Mf6L21I1k6O9po3X8u3V3jcr+n+crETJSxufrpLIsXqQfRKG8b43YSe1NcDuapXc+5kqKyNLMFAvSvCkZp2hJoLBULVMQt9Us6Xg4X56Lzo18TIa1NCFNQMBsWTVq9Yms0rHeHT05rjC5phtVY3cjt3pPsKE17QojV1fEPC7CZiNdZPmBPBrUDv3tGrwBmJCQC4cOVmfexVbAHBxcq8bxytwHEAuSiDAZAxhdZTbcslZvV/MvUeveguI6oWXQvT4pMDu8Zniw2yln1W+eGnHHcwRjyW+v8BLPdgGNui0GB/2n3Haoz2gUkD/uZ1YE5WcYlkmkhK6pY9F6UC4bltc6k5Sez7tei7hnGOcKD59raQxNUXsbNsX05HIsxx4w1u/jaUS7LidcJE6KrL/TA8tR1AvUjYURo7t/sWRXaw9NjXZbzeR/XOtaYEaKjDb9QYJV7rAYggdsjTweCVten6RGF/dFIemC3QaVvJTr0tgY0P8zIZ2CaeA+r+SNfPaD7IuW+qxE3W5iVNwNps3VVL0oLm9HLJdUPFdXqDJZ4NVgFArngqggRxdeBKt1cCEqjUueMtfVwTzuVKHFAAszXqDG6pewLTHNjCRIGuRTGeP1Tor+jDhWWTe6YvuQINOD+EnsApz1LLB6RCb/ox1Ot+BelG+Qj74ILrdca9gf2EDtvG/6TWxPA0sn0rjDNfOXlV1Qq9GRE2ft5PeZRtGjRwdkVgAe1Mm/AL/yFl+2+wVe/7C6y5QhOeTArqQ8aMMgXDk3PFL3QcxsZHMyuN1EmHo4px,iv:6FwAXUkDkrdxtvDN+IHVPbPSpZsKZ+OR5jycZu2lJFc=,tag:MXJ4bN2V3LDdOWIgBMvInw==,type:str]
 /ab2d/mgmt/artifactory/nonsensitive/url: https://artifactory.cloud.cms.gov/artifactory
 /ab2d/mgmt/slack-webhooks/sensitive/ab2d-slack-alerts: ENC[AES256_GCM,data:waCpQX/XxXYYTKMMlSjI+JANTXaOhrpbOOKDjfvAGbEfYo/YyVDEfIal/nrmAtsSlCX4un5wzsahhNy1tZm37Z97pKP23m7v1dWRiq3hLA==,iv:l0EWqKWapuxOSB+qjesk+oaLH9bn22clno+KgPVa6cc=,tag:TaSEyt6EJQisGAp6JIFsWw==,type:str]
 /ab2d/mgmt/slack-webhooks/sensitive/ab2d-security: ENC[AES256_GCM,data:vcCWMy+1z78xRSfms72opb246OlHvdt/ytPfwaWjgx8XuSeAdl3Dbctm99vi/siHxT2X5t7Y+Z7MqcsJ8F6kArv1zmdPkbF5TjIaWexEmw==,iv:tR8iIvIol5BkRYY4VQBStM8gDY3XXjtgUof6vM4uQ5g=,tag:e6NgmJcZJVEzDe84tib2Rg==,type:str]
@@ -37,13 +37,13 @@
 sops:
   kms:
     - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/ab2d-prod
+      aws_profile: ""
       created_at: "2025-06-30T19:15:02Z"
       enc: AQICAHiiBcH1zXWffn77hoG6y6pEPZ+4jjugLfsVfebBM+L/LgHlCl+ZPjCo8JOcN+bft1xHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMgPYKsm4D+zfL36ByAgEQgDtAhv+GhjCNaxDzir/C4y7RDWMunWNoBhCrfkEUYO/LGI7e/Y3NtNwzLgSR87sI+GXER0s9NJ6vtW9+Cg==
-      aws_profile: ""
     - arn: arn:aws:kms:us-west-2:${ACCOUNT_ID}:alias/ab2d-prod
+      aws_profile: ""
       created_at: "2025-06-30T19:15:02Z"
       enc: AQICAHhQOCwYYioO/Y8DTCCF3UDslbqq7E89gMxakADNsQ0frwHZhUFhT3cxecuIluMEm26wAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMn3o8iTDE/yxepTTnAgEQgDsZ1rfL+6FMEpIK10eiNjmMM8E2jNVeGGQbAZSvpnWYdxBUet6iCZtDaHs7Od70oegQvAJjpTbA12+ecQ==
-      aws_profile: ""
-  unencrypted_regex: /nonsensitive/
   mac_only_encrypted: true
-  version: 3.10.2
+  unencrypted_regex: /nonsensitive/
+  version: 3.13.1

--- a/ops/services/00-bootstrap/values/test.sopsw.yaml
+++ b/ops/services/00-bootstrap/values/test.sopsw.yaml
@@ -24,7 +24,7 @@
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/regence-oregon: ENC[AES256_GCM,data:NzJnHjmimIYhWas9rgUynA==,iv:ctKPhkp+Yl1wf3BqJ4kTtHWe53HLgV+bBLAxipbpH3w=,tag:lL/RZJxjeSVLkAESLkWrRg==,type:str]
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/silverscript: ENC[AES256_GCM,data:ytwhodJyFZv1/s6RhLRNgIjptpq6ZfkcHml/Izttm24/cCwOBSIso24HNhO1e4TgLz0lxutLWHVDsdbQy6prIlQWRY4p6Wa/T2JCdmzxl3L2kyFFTI9pvGjnI+LmesQ7Y1Fan+0lfoeoNAIyEW5YoMRG,iv:qd1NcSf0lRjNhM8gQglt8Iyddztd3ITgeVwzZzeddNU=,tag:tSIlvV/FbDit9Dmwn6X+Mw==,type:str]
 /ab2d/mgmt/pdps/sensitive/cidr-blocks-csv/united-health: ENC[AES256_GCM,data:xZC2jGuMahP90BZ2332Jd27pAe5i3gySoHl/ucqqYmXfK3gw0/F+26kUBwM0PwjUL567OyQqDU7y7qXTo9RPYW0OWrTMG83B1kmbvnu9,iv:qSJC8aFiku3kC4Yp6WUqBw0gUA2GtuNF8C1iAG3i3vY=,tag:Xbtxr//hCNEz4SOdfhqz3Q==,type:str]
-/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:Fza3n5j1g2B57Ckn3hG+TgEKyq8MOIX1jF7LOqX20rXVd9ZTC3CB1SejabJ/+l/0dxa+P3EX8A2gtLd7YaKB01wAd0eDwqp4Em9da296GAEr4PqJGllxUjDoPGkW2OssyUbVdhdxB76kzWgQ/IHXLduCCzNDeLTt6koF32GFQ3pnxI2N41QrSoZikRiY8QkBafIPIuVKSk031PozOHNu/gS0kPO5dt9R1HP6oBluqRDGKBl4GOCmmrVupsYtUgu1ZdRr7jz+SoAXzOOXcDF+H3ipr2xQV7VH53Ebrmobt1zOrDgMWC2O1VMDnHV4pp3Tya0yZYeGMOSTU0+/LSdjoxm7wO6nEvKx6fUG/NleI0KAQgtbY+UeqbDtz4DJO/b2niJfvhZCmgdZu8NlUbWi/L2xD/QmNdmssnvJDe95DIUArfND8pJ14OcVGBVjnsrp5m6SenumEPYXLt0JzOkItlEqk3fbeLPQCLbAQcBOxyEMO+3pmCBZ96PrndANKVQBCWPEvW/NwFiL7YxZg63lOwLs54AIzZcxlXB5O0W/sN0HL7St5bhLOGjQW8E3Ruut35IeP5o/bQCFNrRZ6ZEsuYj+KKcQKSrZlByecbaFJppXR7uN9y0fpCjJqFm2qf4q58lETb1b83YkMMHG1tH5nSkEGqZRxuMNV6cr4JiRM8NogNVp3gSUzbfF11G5DpBaUFRuTDNf1hjNns1aOhIM6oZEUR44Sv421gvWslpbj06XsiQZPvxz6wOeVys59BLkhsTy9cQFQaQhDC9ninWE9917iMzfrjXJlizRI9TtBufGV3x+pznXtTaA0J3+8ebeYCwMysV+ALas+3pTRSXBs23RlXq/uaiq2UwLC4VjGcvz9AxvawzNQqdAKJRlnz9dP7nlxdpQYtUrRMnKzzM5Qlq+WY7f2CwZEAGJPZtcI6Et6JciFuKMhhDhI5TnNy/ThxN5h2bkajygggjUD5dTiTm1fi/i3BapUCYduWZPqhtwu2YfPCNOHGgDNu5zvdQ3CZSctffZtGPUf2k8f06Y,iv:mUIzvFO06PK///G+6LIoj+B67075NiiQ9MKGwSbbas0=,tag:ZdNvMdiYC6RrxQYQTf/ndg==,type:str]
+/ab2d/mgmt/artifactory/sensitive/token: ENC[AES256_GCM,data:Jt1NKmcT9Mvik+IEYEKl8LRh8tu06P+hXW8x06BdXJa/Qeyjy8qFUs6lPDIJtgBoI/sCm8UVacx+twA24M64bH4gukj6Q5ho2Q1cURHhHFaHZbdGqsOBaFDj/XrsWzTyL1wqDGzZoWgFh3p8gzyn5I+NRmxgpGZyQT9XMAF3zvX5iSjIsLg/36vcL8qP4VoyF+1KlZvgxiQkbwl6HFma6aBotZl+FPp5UgPg8hm+Gy3G9RuzA69to2Jx5p1h79EeCivMWR6E7TLoS8IB6VRgXzAg9fUWJ+q/URaxmEXsIirJ/ITW87Yf1gKVxyRv4rImip2gxLjJhutEQneSNhgdYWH+BBcYsY4NAJiFe8GEWYuqvu1qd49Qg6/z5lGsBI0Og6KnG7kKjldhiZ5GGNrXhGhBe3zH8KtOtZouCZLqxtJOEws+7WEpRYK+GPZR4Tdf9SAKNt5gZyrFLNk3uWAeMMiQFSNAfVfHETFQEYPyB5nSOGyq/UJWukmmWIVb1GIt80crQpjrORhqtH7iXId1VjYLwYBx4nl/MFU0vihIr/XC5y9L7d0a12cIcofuxeftAwEvPxfQ4MiU+aoeOAk0NihzLlRxy2IYafCaQJu/saqnxn/k6Uz7dh2Gcaapb5EvY1ascKJWdmcZ5x9lu49SZsuff25GfSfYCOA8r34dNUVHi4Q9KWb1lK4hVAxXE8IBsb0QswkK1cITKdP3LWvkJ6hPrrjnKI2kD3/zijpEbcP9u3RRRZzGBKzUpNRGPEPUudIN2kksgxB1GgM5SrBQmV82DSlwXxmxe+lL1AIqBypMSGFgH2MseuCNbLjPiqLoTPBGMWmt+dKEXw/uk4r3NxNCrH3wdOqIXapacMTOpITWEyUSVU0tLXwrgXcbN9I8V2nmumsHdW/Uo7z4R+u3KN6Zi1GCSe8jNgC9mlzp9PZRpF8OvaF2bXwBfnGfZBIv1a7bsq7RfA9DK8XhraCm1P2p+YS6h25KV/tIbw2ugRQL8KKodsSONk33bCjHy7Nxz2ReNd1V7B45JJ35nAsl,iv:yvHBJjv3ypTf+YK1XX6WCxqQH+vKNY4JA2JkbZeH6yg=,tag:QsjwbtK5GqDJJ8ojczfVwA==,type:str]
 /ab2d/mgmt/artifactory/nonsensitive/url: https://artifactory.cloud.cms.gov/artifactory
 /ab2d/mgmt/slack-webhooks/sensitive/ab2d-slack-alerts: ENC[AES256_GCM,data:vuKvjm3mFZE84fq8YXIvP2kR1ke63lndsCbHOfdvGL8bVVseZOqThOCqui/eny8yl8QnrgIPsxZiFJrnx6EBoIy6ZNVl+GMVL9bnANbG1M5jnRxyjxcH3z/8LS4=,iv:LKFo+RKbKQ5wAPRJJCWMroK2q+vK9EsOkCrqWd61l5o=,tag:V45OrJ6L66+b8N7HqdeqVA==,type:str]
 /ab2d/mgmt/slack-webhooks/sensitive/ab2d-security: ENC[AES256_GCM,data:V0zGPxtcaW5nR/aekV+ZYJ+vsEmz7JCE8cK73Ru1+c8J2Aab8sRmjAU4a5NbgRXEtUPSwrAVSpBXsauQQ82c5N5e5qxtY80rvPAcmnZ+jw==,iv:3ad/GlKVHfLQwXGeno0B72C/qtelOVd6oN7xpn0jgxM=,tag:yzWGyRF7RLMoBkrjix5K5A==,type:str]
@@ -37,13 +37,13 @@
 sops:
   kms:
     - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/ab2d-test
+      aws_profile: ""
       created_at: "2025-05-30T19:53:41Z"
       enc: AQICAHieQbEmk17B5WDxP9ZbssNWaBXaOMPBrnVqrvEMaeLytwG0uJB6cG/yKXVUO3Sfrgl2AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMFaG6tAOHorfTGDUUAgEQgDu6Uueh4M5tJnw0FXK8138nJWvYYFJOcGrRyiT7a9c04CBCsW7FwVOxGJjfIqpXsyZp243y5TNzZ5RhJQ==
-      aws_profile: ""
     - arn: arn:aws:kms:us-west-2:${ACCOUNT_ID}:alias/ab2d-test
+      aws_profile: ""
       created_at: "2025-05-30T19:53:41Z"
       enc: AQICAHgJRNGY1npk30Hair/yhcKNRMjEO1Ac57p4o8l/f+IR2AG6Qq0G9cR18A+UMQqxvAQSAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQIr1X2uyp2sflqFWAgEQgDvwAcj/DIH3hP8Spw2XVqOOeCr+FJm4KFaWvyFK+QILbjm6VPvBknXmiwCppSboQtHPC7VXsVhOMXXUTw==
-      aws_profile: ""
-  unencrypted_regex: /nonsensitive/
   mac_only_encrypted: true
-  version: 3.11.0
+  unencrypted_regex: /nonsensitive/
+  version: 3.13.1


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

Updates artifactory token in sops for lambda access token

## ℹ️ Context

This is needed for terraform to access the artifactory provider in the lambdas module. The token expired, so we needed to generate a new one and store it in sops.

## 🧪 Validation

New tokens allow lambdas terraform to apply
