### PR TITLE
AB2D-7304 Default service-date to attestation date through present when no value provided

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -357,7 +357,6 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         List<String> serviceDates = request.getServiceDates();
 
         if (serviceDates != null && !serviceDates.isEmpty()) {
-            log.error("----------------- serviceDate: " + serviceDates);
             return serviceDates;
         }
 
@@ -366,7 +365,6 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         if (attTime == null) {
             return serviceDates;
         }
-        log.error("----------------- attTime: " + List.of(SERVICE_DATE_GE_PREFIX + attTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE)));
         return List.of(SERVICE_DATE_GE_PREFIX + attTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -56,6 +57,12 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
      * Note: Will likely be removed after DataDog migration (?)
      */
     private static final boolean ENABLE_BFD_METRICS = true;
+
+    /**
+     * FHIR search prefix for an inclusive ("greater than or equal") lower bound used when defaulting the
+     * service-date filter to the contract's attestation date.
+     */
+    private static final String SERVICE_DATE_GE_PREFIX = "ge";
 
     private final BFDClient bfdClient;
     private final SQSEventClient logManager;
@@ -196,7 +203,7 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         // Guarantee that since and until dates provided with job don't violate AB2D requirements
         OffsetDateTime sinceTime = getSinceTime(request);
         OffsetDateTime untilTime = getUntilTime(request, sinceTime);
-        List<String> serviceDates = request.getServiceDates();
+        List<String> serviceDates = getServiceDates(request);
 
         final BfdMetricsUtility.BfdRequestMetric bfdMetric = bfdMetricsEnabled()
             ? new BfdMetricsUtility.BfdRequestMetric()
@@ -344,6 +351,23 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
         }
 
         return sinceTime;
+    }
+
+    private List<String> getServiceDates(PatientClaimsRequest request) {
+        List<String> serviceDates = request.getServiceDates();
+
+        if (serviceDates != null && !serviceDates.isEmpty()) {
+            log.error("----------------- serviceDate: " + serviceDates);
+            return serviceDates;
+        }
+
+        // No service-date provided: default the lower bound to the (inclusive) attestation date
+        OffsetDateTime attTime = request.getAttTime();
+        if (attTime == null) {
+            return serviceDates;
+        }
+        log.error("----------------- attTime: " + List.of(SERVICE_DATE_GE_PREFIX + attTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE)));
+        return List.of(SERVICE_DATE_GE_PREFIX + attTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
     private OffsetDateTime getUntilTime(PatientClaimsRequest request, OffsetDateTime updatedSinceTime) {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -37,7 +37,10 @@ import gov.cms.ab2d.worker.service.JobChannelService;
 import gov.cms.ab2d.worker.util.HealthCheck;
 import java.io.File;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.LongStream;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
@@ -270,6 +273,45 @@ class JobProcessorIntegrationTest extends JobCleanup {
         assertEquals(COMPLETED_PERCENT, processedJob.getStatusMessage());
         assertNotNull(processedJob.getExpiresAt());
         assertNotNull(processedJob.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("When a job has no service-date, the service-date lower bound defaults to the contract attestation date")
+    void whenNoServiceDate_thenServiceDateDefaultsToAttestationDate() {
+        // Job created in setUp has no service-date. The worker resolves the contract through ContractWorkerClient,
+        // so the attestation date used for the default service-date lower bound is whatever that client returns.
+        OffsetDateTime attestedOn = contractWorkerClient.getContractByContractNumber(contract.getContractNumber()).getAttestedOn();
+        String expectedServiceDate = "ge" + attestedOn.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+
+        var processedJob = cut.process(job.getJobUuid());
+        assertEquals(JobStatus.SUCCESSFUL, processedJob.getStatus());
+
+        ArgumentCaptor<List<String>> serviceDatesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockBfdClient, atLeastOnce()).requestEOBFromServer(eq(STU3), anyLong(), any(), any(),
+                serviceDatesCaptor.capture(), anyString());
+
+        Set<List<String>> distinctServiceDates = new HashSet<>(serviceDatesCaptor.getAllValues());
+        assertEquals(Set.of(List.of(expectedServiceDate)), distinctServiceDates,
+                "Expected every BFD request to default service-date to the inclusive attestation date " + expectedServiceDate);
+    }
+
+    @Test
+    @DisplayName("When a job has an explicit service-date, it is passed to BFD unmodified")
+    void whenServiceDateProvided_thenServiceDateUsedUnmodified() {
+        List<String> providedServiceDates = List.of("gt2021-06-01", "le2021-12-31");
+        job.setServiceDates(providedServiceDates);
+        jobRepository.saveAndFlush(job);
+
+        var processedJob = cut.process(job.getJobUuid());
+        assertEquals(JobStatus.SUCCESSFUL, processedJob.getStatus());
+
+        ArgumentCaptor<List<String>> serviceDatesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockBfdClient, atLeastOnce()).requestEOBFromServer(eq(STU3), anyLong(), any(), any(),
+                serviceDatesCaptor.capture(), anyString());
+
+        assertTrue(serviceDatesCaptor.getAllValues().stream()
+                        .allMatch(serviceDates -> providedServiceDates.equals(serviceDates)),
+                "Expected every BFD request to use the provided service-date filter unmodified");
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
@@ -69,7 +69,7 @@ class PatientClaimsProcessorUnitTest {
 
     // Default service-date lower bound is the inclusive attestation date when no service-date filter is supplied
     private static final List<String> EARLY_ATT_SERVICE_DATES = List.of("ge1970-01-01");
-    private static final List<String> LATER_ATT_SERVICE_DATES = List.of("ge20201-02-15");
+    private static final List<String> LATER_ATT_SERVICE_DATES = List.of("ge2020-02-15");
     private CoverageSummary coverageSummary;
 
     private final Token noOpToken = new Token() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorUnitTest.java
@@ -66,6 +66,10 @@ class PatientClaimsProcessorUnitTest {
     private static final OffsetDateTime EARLY_ATT_DATE = OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     private static final OffsetDateTime EARLY_SINCE_DATE = OffsetDateTime.of(2020, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC);
     private static final OffsetDateTime LATER_ATT_DATE = OffsetDateTime.of(2020, 2, 15, 0, 0, 0, 0, ZoneOffset.UTC);
+
+    // Default service-date lower bound is the inclusive attestation date when no service-date filter is supplied
+    private static final List<String> EARLY_ATT_SERVICE_DATES = List.of("ge1970-01-01");
+    private static final List<String> LATER_ATT_SERVICE_DATES = List.of("ge20201-02-15");
     private CoverageSummary coverageSummary;
 
     private final Token noOpToken = new Token() {
@@ -151,7 +155,7 @@ class PatientClaimsProcessorUnitTest {
 
         PatientClaimsRequest request2 = new PatientClaimsRequest(List.of(coverageSummary), LATER_ATT_DATE, LATER_ATT_DATE, null, null,"client", "job",
                 contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request2.getAttTime(), null, null, contractDTO.getContractNumber())).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request2.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractDTO.getContractNumber())).thenReturn(bundle1);
 
         cut.process(request2).get();
     }
@@ -159,7 +163,7 @@ class PatientClaimsProcessorUnitTest {
     @Test
     void process_whenPatientHasSinglePageOfClaimsData() throws ExecutionException, InterruptedException {
         org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
 
         ProgressTrackerUpdate trackerUpdate = cut.process(request).get();
         assertNotNull(trackerUpdate);
@@ -169,7 +173,7 @@ class PatientClaimsProcessorUnitTest {
         assertEquals(1, trackerUpdate.getPatientWithEobCount());
         assertEquals(0, trackerUpdate.getPatientFailureCount());
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
@@ -180,7 +184,7 @@ class PatientClaimsProcessorUnitTest {
 
         org.hl7.fhir.dstu3.model.Bundle bundle2 = EobTestDataUtil.createBundle(eob.copy());
 
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
         when(mockBfdClient.requestNextBundleFromServer(STU3, bundle1, contractNum)).thenReturn(bundle2);
 
         ProgressTrackerUpdate trackerUpdate = cut.process(request).get();
@@ -191,28 +195,28 @@ class PatientClaimsProcessorUnitTest {
         assertEquals(1, trackerUpdate.getPatientWithEobCount());
         assertEquals(0, trackerUpdate.getPatientFailureCount());
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
     @Test
     void process_whenBfdClientThrowsException() {
         org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum)).thenThrow(new RuntimeException("Test Exception"));
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum)).thenThrow(new RuntimeException("Test Exception"));
 
         var exceptionThrown = assertThrows(ExecutionException.class,
                 () -> cut.process(request).get());
 
         assertTrue(exceptionThrown.getCause().getMessage().startsWith("Test Exception"));
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(),null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
     @Test
     void process_whenPatientHasNoEOBClaimsData() throws ExecutionException, InterruptedException {
         org.hl7.fhir.dstu3.model.Bundle bundle1 = new org.hl7.fhir.dstu3.model.Bundle();
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(),null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
 
         ProgressTrackerUpdate trackerUpdate = cut.process(request).get();
         assertNotNull(trackerUpdate);
@@ -222,7 +226,7 @@ class PatientClaimsProcessorUnitTest {
         assertEquals(0, trackerUpdate.getPatientWithEobCount());
         assertEquals(0, trackerUpdate.getPatientFailureCount());
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, request.getAttTime(), null, LATER_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
@@ -237,11 +241,11 @@ class PatientClaimsProcessorUnitTest {
                 contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
 
         org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
 
         cut.process(request).get();
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
@@ -254,11 +258,11 @@ class PatientClaimsProcessorUnitTest {
                 contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
 
         org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, null, null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, null, null, EARLY_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
 
         cut.process(request).get();
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, null, null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, null, null, EARLY_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
     }
 
@@ -271,12 +275,61 @@ class PatientClaimsProcessorUnitTest {
                 contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
 
         org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
-        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, null,null, null, contractNum)).thenReturn(bundle1);
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, null, null, EARLY_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
 
         cut.process(request).get();
 
-        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, null,null, null, contractNum);
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, null, null, EARLY_ATT_SERVICE_DATES, contractNum);
         verify(mockBfdClient, never()).requestNextBundleFromServer(STU3, bundle1, contractNum);
+    }
+
+    @Test
+    void process_whenNoServiceDateProvided_thenDefaultsToInclusiveAttestationDate() throws ExecutionException, InterruptedException {
+        // No service-date filter supplied: the lower bound should default to the (inclusive) attestation date
+        coverageSummary = new CoverageSummary(createIdentifierWithoutMbi(PATIENT_ID), null, List.of(TestUtil.getOpenRange()));
+
+        request = new PatientClaimsRequest(List.of(coverageSummary), LATER_ATT_DATE, null, null, null, "client", "job",
+                contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
+
+        org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
+
+        cut.process(request).get();
+
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum);
+    }
+
+    @Test
+    void process_whenEmptyServiceDateProvided_thenDefaultsToInclusiveAttestationDate() throws ExecutionException, InterruptedException {
+        // An empty service-date list is treated the same as none provided
+        coverageSummary = new CoverageSummary(createIdentifierWithoutMbi(PATIENT_ID), null, List.of(TestUtil.getOpenRange()));
+
+        request = new PatientClaimsRequest(List.of(coverageSummary), LATER_ATT_DATE, null, null, List.of(), "client", "job",
+                contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
+
+        org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum)).thenReturn(bundle1);
+
+        cut.process(request).get();
+
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, LATER_ATT_SERVICE_DATES, contractNum);
+    }
+
+    @Test
+    void process_whenServiceDateProvided_thenUsedUnmodified() throws ExecutionException, InterruptedException {
+        // Explicit service-date filter supplied: it must be passed through to BFD unmodified
+        coverageSummary = new CoverageSummary(createIdentifierWithoutMbi(PATIENT_ID), null, List.of(TestUtil.getOpenRange()));
+
+        List<String> providedServiceDates = List.of("gt2021-06-01", "le2021-12-31");
+        request = new PatientClaimsRequest(List.of(coverageSummary), LATER_ATT_DATE, null, null, providedServiceDates, "client", "job",
+                contractNum, Contract.ContractType.NORMAL, noOpToken, STU3, tmpEfsMountDir.getAbsolutePath());
+
+        org.hl7.fhir.dstu3.model.Bundle bundle1 = EobTestDataUtil.createBundle(eob.copy());
+        when(mockBfdClient.requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, providedServiceDates, contractNum)).thenReturn(bundle1);
+
+        cut.process(request).get();
+
+        verify(mockBfdClient).requestEOBFromServer(STU3, PATIENT_ID, LATER_ATT_DATE, null, providedServiceDates, contractNum);
     }
 
     private void createOutputFiles() throws IOException {


### PR DESCRIPTION

## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7304

## 🛠 Changes

If request lacks service-date, then  inclusive `ge<attestationDate>` will be used instead
 
## ℹ️ Context

If the service date is not provided, we should use the attestation date from the `contract.contract` table to request only the claims the PDP is eligible for, instead of retrieving all claims and then filtering them manually.

## 🧪 Validation

Tested in dev environment.
Started a job for Z0001 contract without since, until and service dates

<img width="1192" height="188" alt="Screenshot 2026-06-10 at 4 32 43 PM" src="https://github.com/user-attachments/assets/c71086e4-d0a0-4ab8-b450-3c52784b44d9" />

(Temporary log line. Error status is just for visibility)

