### PR TITLE
AB2D-7286 Add history summary coverage period table, audit logging, coverage checks for v3

### DIFF
--- a/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
+++ b/common/src/main/java/gov/cms/ab2d/common/util/PropertyConstants.java
@@ -48,4 +48,9 @@ public final class PropertyConstants {
     public static final String EOB_V3_IN_PLACE = "eob.v3.inplace.enabled";
 
     public static final String BFD_METRICS_ENABLED = "bfd.metrics.enabled";
+
+    public static final String V3_COVERAGE_PERIOD_CHECK_ENABLED = "v3.coverage-check.enabled";
+
+    public static final String V3_AUDIT_LOGGING_ENABLED = "v3.audit-logging.enabled";
+
 }

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -197,3 +197,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_coverage_period_history_summary.sql
   - include:
       file: db/changelog/v2026/add_v3_audit_logging.sql
+  - include:
+      file: db/changelog/v2026/add_v3_coverage_check_enabled.sql

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -196,4 +196,4 @@ databaseChangeLog:
   - include:
       file: db/changelog/v2026/add_v3_coverage_period_history_summary.sql
   - include:
-      file: db/changelog/v2026/add_v3_audit_table.sql
+      file: db/changelog/v2026/add_v3_audit_logging.sql

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -193,3 +193,7 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_history_summary_table.sql
   - include:
       file: db/changelog/v2026/add_bfd_metrics_enabled_property.sql
+  - include:
+      file: db/changelog/v2026/add_v3_coverage_period_history_summary.sql
+  - include:
+      file: db/changelog/v2026/add_v3_audit_table.sql

--- a/common/src/main/resources/db/changelog/v2026/add_v3_audit_logging.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_audit_logging.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_audit (
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    action TEXT NOT NULL,
+    result TEXT,
+    contract TEXT,
+    log TEXT NOT NULL,
+    data JSONB
+);
+
+INSERT INTO property.properties (id, key, value, created, modified)
+SELECT (SELECT COALESCE(MAX(id),0)+1 FROM property.properties),
+       'v3.audit-logging.enabled', 'true', now(), now()
+    WHERE NOT EXISTS (SELECT 1 FROM property.properties WHERE key = 'v3.audit-logging.enabled'); -- gitleaks:allow

--- a/common/src/main/resources/db/changelog/v2026/add_v3_audit_table.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_audit_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_audit (
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    action TEXT NOT NULL,
+    contract TEXT,
+    log NOT NULL,
+    data JSONB
+);

--- a/common/src/main/resources/db/changelog/v2026/add_v3_audit_table.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_audit_table.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS v3.coverage_v3_audit (
-    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    action TEXT NOT NULL,
-    contract TEXT,
-    log NOT NULL,
-    data JSONB
-);

--- a/common/src/main/resources/db/changelog/v2026/add_v3_coverage_check_enabled.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_coverage_check_enabled.sql
@@ -1,0 +1,4 @@
+INSERT INTO property.properties (id, key, value, created, modified)
+SELECT (SELECT COALESCE(MAX(id),0)+1 FROM property.properties),
+       'v3.coverage-check.enabled', 'true', now(), now()
+    WHERE NOT EXISTS (SELECT 1 FROM property.properties WHERE key = 'v3.coverage-check.enabled'); -- gitleaks:allow

--- a/common/src/main/resources/db/changelog/v2026/add_v3_coverage_period_history_summary.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_v3_coverage_period_history_summary.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_history_summary_coverage_periods (
+    contract TEXT NOT NULL,
+    year INT NOT NULL,
+    month INT NOT NULL,
+    UNIQUE (contract, year, month)
+);

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/query/GetCoverageV3Count.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/query/GetCoverageV3Count.java
@@ -52,6 +52,7 @@ public class GetCoverageV3Count extends CoverageV3BaseQuery {
 		return map;
 	}
 
+	@Deprecated
 	private static class CoverageV3CountRowMapper implements RowMapper<CoverageV3Count> {
 		@Override
 		public CoverageV3Count mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ScheduledTasks.java
@@ -87,7 +87,7 @@ public class CoverageV3ScheduledTasks {
 		coverageV3Service.checkForAggregatedTablesToBeDeleted();
 	}
 
-	@Scheduled(cron = "0 0/3 * * * *") // TEMPORARY: every 3 minutes (revert to "0 0 3 * * *" - daily at 3am)
+	@Scheduled(cron = "0 0 3 * * *") // daily at 3am
 	public void purgeInactiveContractsFromHistorySummary() {
 		log.info("[V3] Purging history summary rows for contracts inactive > 2 years");
 		int deleted = syncService.deleteInactiveContractsFromHistorySummary();

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3Service.java
@@ -1,7 +1,9 @@
 package gov.cms.ab2d.coverage.service.v3;
 
+import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.CoveragePagingRequest;
 import gov.cms.ab2d.coverage.model.CoveragePagingResult;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Periods;
 
@@ -14,7 +16,7 @@ public interface CoverageV3Service {
     CoveragePagingResult pageCoverage(CoveragePagingRequest request);
     CoverageV3SyncResult moveFromStagingToRecentCoverage(String contract, CoverageV3SyncSource source);
     CoverageV3SyncResult moveOldCoverageToHistoricalCoverage(String contract, CoverageV3SyncSource source);
-    Map<String, List<CoverageV3Count>> getCoverageCount();
+    Map<String, List<YearMonthRecord>> getCoveragePeriods(List<ContractDTO> contracts);
     boolean idrImportInProgress();
     // called before starting a v3 job
     void createAggregatedAttributionTable(String contract);

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.*;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Periods;
@@ -9,16 +10,19 @@ import gov.cms.ab2d.coverage.repository.CoverageServiceRepository;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
@@ -98,11 +102,34 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
     }
 
 
-
     @Override
-    public Map<String, List<CoverageV3Count>>  getCoverageCount() {
-        return new GetCoverageV3Count(dataSource).coverageCounts();
+    public Map<String, List<YearMonthRecord>> getCoveragePeriods(List<ContractDTO> contracts) {
+        val result = new HashMap<String, List<YearMonthRecord>>();
+        val template = new NamedParameterJdbcTemplate(dataSource);
+        val query =
+        """
+        SELECT year, month
+        FROM v3.coverage_v3_history_summary_coverage_periods
+        WHERE contract = :contract
+        UNION
+        SELECT DISTINCT year, month
+        FROM v3.coverage_v3
+        WHERE contract = :contract
+        ORDER BY year DESC, month DESC
+        """;
+
+        for (ContractDTO contract : contracts) {
+            val parameters = new MapSqlParameterSource().addValue("contract", contract.getContractNumber());
+            val coveragePeriods = template.query(query, parameters, (rs, rowNum) -> new YearMonthRecord(
+                rs.getInt(1),
+                rs.getInt(2))
+            );
+            result.put(contract.getContractNumber(), coveragePeriods);
+        }
+
+        return result;
     }
+
 
     @Override
     public boolean idrImportInProgress() {
@@ -211,7 +238,6 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
 	    return coverageV3SyncService.moveToHistorical(contract, source);
     }
 
-
     @Override
     public int countBeneficiariesByCoveragePeriod(final CoverageV3Periods periods, final String contract) {
         return executeTimedQuery(
@@ -224,6 +250,7 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
                     .countBeneficiaries(contract, periods, isOptOutOn())
         );
     }
+
 
     private List<CoverageSummary> queryAggregatedCoverageMembership(CoveragePagingRequest page, long limit) {
         return executeTimedQuery(

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncService.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncService.java
@@ -1,10 +1,13 @@
 package gov.cms.ab2d.coverage.service.v3;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.function.Supplier;
 
 public interface CoverageV3SyncService {
 	CoverageV3SyncResult copyFromStagingTablesToRecent(String contract, CoverageV3SyncSource source);
 	CoverageV3SyncResult moveToHistorical(String contract, CoverageV3SyncSource source);
+
 
 	List<String> getContractsWithActiveV3Jobs();
 
@@ -16,4 +19,5 @@ public interface CoverageV3SyncService {
 
 	int deleteInactiveContractsFromHistorySummary();
 
+	Supplier<LocalDate> CUT_OFF_DATE_FOR_INACTIVE_CONTRACT = () -> LocalDate.now().minusYears(2);
 }

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncService.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncService.java
@@ -6,8 +6,8 @@ import java.util.function.Supplier;
 
 public interface CoverageV3SyncService {
 	CoverageV3SyncResult copyFromStagingTablesToRecent(String contract, CoverageV3SyncSource source);
-	CoverageV3SyncResult moveToHistorical(String contract, CoverageV3SyncSource source);
 
+	CoverageV3SyncResult moveToHistorical(String contract, CoverageV3SyncSource source);
 
 	List<String> getContractsWithActiveV3Jobs();
 

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -319,7 +319,6 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
         if (isTestContract(contract)) {
             result = NO_COVERAGE_FOUND_FOR_CONTRACT;
-            audit.log(action, result, contract, null, null);
             return result;
         } else if (source == CRON_JOB && contractHasJobInProgress(contract)) {
             result = JOB_IN_PROGRESS_FOR_CONTRACT;

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -1,6 +1,8 @@
 package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction;
+import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,14 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 
-import java.time.LocalDate;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static gov.cms.ab2d.common.util.PropertyConstants.*;
 import static gov.cms.ab2d.coverage.service.v3.CoverageV3ServiceImpl.executeTimedQuery;
 import static gov.cms.ab2d.coverage.service.v3.CoverageV3SyncSource.CRON_JOB;
 import static gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult.*;
+import static gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction.COPY_FROM_STAGING;
+import static gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction.COPY_TO_HISTORICAL;
 import static java.lang.String.format;
 
 @Slf4j
@@ -29,6 +34,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
     private final CoverageV3LockWrapper recentCoverageLock;
     private final CoverageV3LockWrapper historicalCoverageLock;
+    private final CoverageV3AuditLog audit;
     private final PropertiesService propertiesService;
     private final DataSource dataSource;
 
@@ -36,10 +42,12 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             DataSource dataSource,
             @Qualifier("recentCoverageLock") CoverageV3LockWrapper recentCoverageLock,
             @Qualifier("historicalCoverageLock") CoverageV3LockWrapper historicalCoverageLock,
+            CoverageV3AuditLog audit,
             PropertiesService propertiesService) {
         this.dataSource = dataSource;
         this.recentCoverageLock = recentCoverageLock;
         this.historicalCoverageLock = historicalCoverageLock;
+        this.audit = audit;
         this.propertiesService = propertiesService;
     }
 
@@ -58,7 +66,6 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     )
     select count(*) from deleted_rows
     """;
-
 
     private static final String COPY_FROM_STAGING_TO_COVERAGE_V3 =
     """
@@ -120,7 +127,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     """;
 
     private static final String GET_CONTRACTS_WITH_ACTIVE_V3_JOBS =
-        "select distinct contract_number from job where status in ('IN_PROGRESS', 'SUBMITTED')";
+        "select distinct contract_number from job where status in ('IN_PROGRESS', 'SUBMITTED') and fhir_version='R4V3'" ;
 
     private static final String IS_CONTRACT_ATTESTED =
         "select count(*) from contract.contract where contract_number = :contract and attested_on is not null";
@@ -157,17 +164,47 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     select contract from deleted_rows;
     """;
 
+    private static final String POPULATE_HISTORY_SUMMARY_COVERAGE_PERIODS_FOR_CONTRACT =
+    """
+    WITH
+    coverage_periods_unparsed AS (
+        SELECT DISTINCT json_array_elements(to_json(historical_coverage_summaries))::TEXT as text
+        FROM v3.coverage_v3_history_summary
+        WHERE contract='{0}'
+    ),
+    coverage_periods_parsed AS (
+        SELECT
+        '{0}' as contract,
+        split_part(translate(text, '[]', ''), ',', 1)::INT AS year,
+        split_part(translate(text, '[]', ''), ',', 2)::INT AS month
+        FROM coverage_periods_unparsed
+        ORDER BY year ASC, month ASC
+    )
+    
+    INSERT INTO v3.coverage_v3_history_summary_coverage_periods
+    SELECT * FROM coverage_periods_parsed
+    ON CONFLICT (contract, year, month)
+    DO NOTHING
+    """;
+
     @Transactional
     public CoverageV3SyncResult copyFromStagingTablesToRecent(String contract, CoverageV3SyncSource source) {
+        val action = COPY_FROM_STAGING;
+        CoverageV3SyncResult result = null;
+
         if (isTestContract(contract)) {
             return NO_COVERAGE_FOUND_FOR_CONTRACT;
         } else if (!isContractAttested(contract)) {
             log.info("[V3] Contract {} is not attested; skipping staging copy", contract);
             return NO_COVERAGE_FOUND_FOR_CONTRACT;
         } else if (idrImporterInProgress()) {
-            return IDR_IMPORTER_IN_PROGRESS;
+            result = IDR_IMPORTER_IN_PROGRESS;
+            audit.log(action, result, contract, null, null);
+            return result;
         } else if (source == CRON_JOB && contractHasJobInProgress(contract)) {
-            return JOB_IN_PROGRESS_FOR_CONTRACT;
+            result = JOB_IN_PROGRESS_FOR_CONTRACT;
+            audit.log(action, result, contract, null, null);
+            return result;
         }
 
         val rowsInStaging = executeTimedQuery(
@@ -175,8 +212,13 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             () -> getCoveragePeriodCountForCoverageV3Staging(contract)
         );
         log.info("[V3] Found {} rows in staging table for contract {}", rowsInStaging, contract);
+
         if (rowsInStaging == 0) {
-            return NO_COVERAGE_FOUND_FOR_CONTRACT;
+            result = NO_COVERAGE_FOUND_FOR_CONTRACT;
+            audit.log(action, result, contract, null, Map.of("rowsInStaging", 0));
+            return result;
+        } else {
+            audit.log(action, null, contract, null, Map.of("rowsInStaging", rowsInStaging));
         }
 
         val lock = recentCoverageLock.getCoverageLock(contract);
@@ -185,8 +227,10 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             if (locked) {
                 return copyFromStagingToRecentCoverageTable(contract, rowsInStaging);
             } else {
+                result = UNABLE_TO_ACQUIRE_LOCK_FOR_CONTRACT;
                 log.info("[V3] Unable to acquire lock for contract {}", contract);
-                return UNABLE_TO_ACQUIRE_LOCK_FOR_CONTRACT;
+                audit.log(action, result, contract, null, null);
+                return result;
             }
         } finally {
             if (locked) {
@@ -196,11 +240,15 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     }
 
     private CoverageV3SyncResult copyFromStagingToRecentCoverageTable(final String contract, final int rowsInStaging) {
+        val action = COPY_FROM_STAGING;
+        CoverageV3SyncResult result = null;
+
         val rowsInCoverageBeforeCopy = executeTimedQuery(
                 format("[V3] getCoveragePeriodCountForCoverageV3 contract=%s", contract),
                 () -> getCoveragePeriodCountForCoverageV3(contract)
         );
         log.info("Found {} rows in coverage table for contract {}", rowsInCoverageBeforeCopy, contract);
+        audit.log(action, null, contract, null, Map.of("rowsInCoverageBeforeCopy", rowsInCoverageBeforeCopy));
 
         log.info("[V3] Preparing to delete rows in coverage table for contract {}...", contract);
         val rowsInCoverageDeleted = executeTimedQuery(
@@ -208,6 +256,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 () -> deleteFromCoverageAndGetRowsDeleted(contract)
         );
         log.info("[V3] Deleted {} rows in coverage table for contract {}", rowsInCoverageDeleted, contract);
+        audit.log(action, null, contract, null, Map.of("rowsInCoverageDeleted", rowsInCoverageDeleted));
 
         log.info("[V3] Preparing to copy rows from staging to coverage for contract {}...", contract);
         val rowsInserted = executeTimedQuery(
@@ -215,12 +264,14 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 () -> copyFromStagingToCoverage(contract)
         );
         log.info("[V3] Copied {} rows from staging to coverage for contract {}", rowsInserted, contract);
+        audit.log(action, null, contract, null, Map.of("rowsInserted", rowsInserted));
 
         val rowsInCoverageAfterCopy = executeTimedQuery(
                 format("[V3] getCoveragePeriodCountForCoverageV3 contract=%s", contract),
                 () -> getCoveragePeriodCountForCoverageV3(contract)
         );
         log.info("[V3] Coverage table now contains {} rows for contract {}", rowsInCoverageAfterCopy, contract);
+        audit.log(action, null, contract, null, Map.of("rowsInCoverageAfterCopy", rowsInCoverageAfterCopy));
 
         if (rowsInStaging != rowsInCoverageAfterCopy) {
             log.error("[V3] Row count in staging ({}) != row count in coverage ({}) for contract {}",
@@ -228,7 +279,9 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                     rowsInCoverageBeforeCopy,
                     contract
             );
-            return SYNC_FAILED_FOR_CONTRACT;
+            result = SYNC_FAILED_FOR_CONTRACT;
+            audit.log(action, result, contract, "rowsInStaging does not match rowsInCoverageBeforeCopy", Map.of("rowsInStaging", rowsInStaging, "rowsInCoverageBeforeCopy", rowsInCoverageBeforeCopy));
+            return result;
         }
 
         log.info("[V3] Preparing to delete rows in staging for contract {}", contract);
@@ -236,6 +289,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 format("[V3] deleteFromStagingAndGetRowsDeleted contract=%s", contract),
                 () -> deleteFromStagingAndGetRowsDeleted(contract)
         );
+        audit.log(action, result, contract, null, Map.of("rowsInStagingDeleted", rowsInStagingDeleted));
 
         if (!rowsInStagingDeleted.equals(rowsInCoverageAfterCopy)) {
             log.error("[V3] Row count deleted from staging ({}) != row count in coverage ({}) for contract {}",
@@ -243,20 +297,32 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                     rowsInCoverageAfterCopy,
                     contract
             );
-            return SYNC_FAILED_FOR_CONTRACT;
+            result = SYNC_FAILED_FOR_CONTRACT;
+            audit.log(action, result, contract, "rowsInStagingDeleted does not match rowsInCoverageAfterCopy",
+                    Map.of("rowsInStagingDeleted", rowsInStagingDeleted, "rowsInCoverageAfterCopy", rowsInCoverageAfterCopy));
+            return result;
         }
 
         log.info("[V3] Coverage data successfully copied from staging table for contract {}", contract);
-        return SYNC_SUCCESSFUL_FOR_CONTRACT;
+        result = SYNC_SUCCESSFUL_FOR_CONTRACT;
+        audit.log(action, result, contract, null, Map.of("rowsInStagingDeleted", rowsInStagingDeleted, "rowsInCoverageAfterCopy", rowsInCoverageAfterCopy));
+        return result;
     }
 
     // Set query timeout of 1 hour, otherwise large contracts may cause org.springframework.dao.QueryTimeoutException
     @Transactional(timeout=3600)
     public CoverageV3SyncResult moveToHistorical(String contract, CoverageV3SyncSource source) {
+        val action = COPY_TO_HISTORICAL;
+        CoverageV3SyncResult result = null;
+
         if (isTestContract(contract)) {
-            return NO_COVERAGE_FOUND_FOR_CONTRACT;
+            result = NO_COVERAGE_FOUND_FOR_CONTRACT;
+            audit.log(action, result, contract, null, null);
+            return result;
         } else if (source == CRON_JOB && contractHasJobInProgress(contract)) {
-            return JOB_IN_PROGRESS_FOR_CONTRACT;
+            result = JOB_IN_PROGRESS_FOR_CONTRACT;
+            audit.log(action, result, contract, null, null);
+            return result;
         }
 
         val lock = historicalCoverageLock.getCoverageLock(contract);
@@ -266,21 +332,32 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 int rowsMoved = moveToHistoricalInternal(contract);
                 log.info("[V3] Moved {} rows to historical coverage table for contract {}", rowsMoved, contract);
                 if (rowsMoved == 0) {
+                    // skip audit logging to prevent noise - this operation would only copy records > 0 once a month
                     return NO_COVERAGE_FOUND_FOR_CONTRACT;
                 } else {
+                    audit.log(action, null, contract, null, Map.of("rowsMoved", rowsMoved));
                     populateHistorySummaryForContract(contract);
+                    audit.log(action, null, contract, "Populated history summary table", null);
+                    populateHistorySummaryCoveragePeriodsForContract(contract);
+                    audit.log(action, null, contract, "Populated history summary coverage period table", null);
                 }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
 
                 if (rowsDeleted != rowsMoved) {
-                    return SYNC_FAILED_FOR_CONTRACT;
+                    result = SYNC_FAILED_FOR_CONTRACT;
+                    audit.log(action, result, contract, "rowsDeleted does not match rowsMoved", Map.of("rowsDeleted", rowsDeleted, "rowsMoved", rowsMoved));
+                    return result;
                 } else {
-                    return SYNC_SUCCESSFUL_FOR_CONTRACT;
+                    result = SYNC_SUCCESSFUL_FOR_CONTRACT;
+                    audit.log(action, result, contract, null, Map.of("rowsDeleted", rowsDeleted, "rowsMoved", rowsMoved));
+                    return result;
                 }
             } else {
                 log.info("[V3] Unable to acquire lock for contract {}", contract);
-                return UNABLE_TO_ACQUIRE_LOCK_FOR_CONTRACT;
+                result = UNABLE_TO_ACQUIRE_LOCK_FOR_CONTRACT;
+                audit.log(action, result, contract, null, null);
+                return result;
             }
         } finally {
             if (locked) {
@@ -288,7 +365,6 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             }
         }
     }
-
 
     @Override
     public List<String> getContractsInRecentCoverageTable() {
@@ -380,7 +456,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     @Override
     @Transactional
     public int deleteInactiveContractsFromHistorySummary() {
-        LocalDate cutoff = LocalDate.now().minusYears(2);
+        val cutoff = CUT_OFF_DATE_FOR_INACTIVE_CONTRACT.get();
         val parameters = new MapSqlParameterSource().addValue("cutoff", cutoff);
         val template = new NamedParameterJdbcTemplate(this.dataSource);
 
@@ -389,8 +465,16 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
         List<String> deletedContracts = template.queryForList(DELETE_INACTIVE_CONTRACTS_FROM_HISTORY_SUMMARY, parameters, String.class);
         log.info("[V3] Deleted {} rows from coverage_v3_history_summary for unattested contracts or contracts ended > 2 years ago", deletedContracts.size());
+        audit.log(CoverageV3AuditAction.DELETE_INACTIVE_CONTACTS, null, null, null, Map.of("deletedContracts", deletedContracts));
         return deletedContracts.size();
     }
+
+    private void populateHistorySummaryCoveragePeriodsForContract(String contract) {
+        val template = new JdbcTemplate(this.dataSource);
+        val query = MessageFormat.format(POPULATE_HISTORY_SUMMARY_COVERAGE_PERIODS_FOR_CONTRACT, contract);
+        template.execute(query);
+    }
+
 
 
 }

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -131,6 +131,33 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         "select distinct contract from %s"
         .formatted(COVERAGE_V3_TABLE_RECENT);
 
+    private static final String SELECT_DISTINCT_CONTRACTS_FROM_HISTORY_SUMMARY =
+        "select distinct contract from v3.coverage_v3_history_summary";
+
+    // TODO CLEAN THIS UP
+    // TODO what happens if this can't be updated because a job is in progress? delete coverage periods and check for
+    private static final String POPULATE_HISTORY_SUMMARY_COVERAGE_PERIODS_FOR_CONTRACT =
+    """
+    WITH
+    coverage_periods_unparsed AS (
+        SELECT DISTINCT json_array_elements(to_json(historical_coverage_summaries))::TEXT as text
+        FROM v3.coverage_v3_history_summary
+        WHERE contract='{0}'
+    ),
+    coverage_periods_parsed AS (
+        SELECT
+        '{0}' as contract,
+        split_part(translate(text, '[]', ''), ',', 1)::INT AS year,
+        split_part(translate(text, '[]', ''), ',', 2)::INT AS month
+        FROM coverage_periods_unparsed
+        ORDER BY year ASC, month ASC
+    )
+    
+    INSERT INTO v3.coverage_v3_history_summary_coverage_periods
+    SELECT * FROM coverage_periods_parsed
+    ON CONFLICT (contract, year, month)
+    DO NOTHING;
+    """;
 
 
     @Transactional

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -170,11 +170,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     coverage_periods_unparsed AS (
         SELECT DISTINCT json_array_elements(to_json(historical_coverage_summaries))::TEXT as text
         FROM v3.coverage_v3_history_summary
-        WHERE contract='{0}'
+        WHERE contract='%s'
     ),
     coverage_periods_parsed AS (
         SELECT
-        '{0}' as contract,
+        '%s' as contract,
         split_part(translate(text, '[]', ''), ',', 1)::INT AS year,
         split_part(translate(text, '[]', ''), ',', 2)::INT AS month
         FROM coverage_periods_unparsed
@@ -196,7 +196,9 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             return NO_COVERAGE_FOUND_FOR_CONTRACT;
         } else if (!isContractAttested(contract)) {
             log.info("[V3] Contract {} is not attested; skipping staging copy", contract);
-            return NO_COVERAGE_FOUND_FOR_CONTRACT;
+            result = NO_COVERAGE_FOUND_FOR_CONTRACT;
+            audit.log(action, result, contract, "Contract is not attested", null);
+            return result;
         } else if (idrImporterInProgress()) {
             result = IDR_IMPORTER_IN_PROGRESS;
             audit.log(action, result, contract, null, null);
@@ -336,10 +338,23 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                     return NO_COVERAGE_FOUND_FOR_CONTRACT;
                 } else {
                     audit.log(action, null, contract, null, Map.of("rowsMoved", rowsMoved));
-                    populateHistorySummaryForContract(contract);
-                    audit.log(action, null, contract, "Populated history summary table", null);
-                    populateHistorySummaryCoveragePeriodsForContract(contract);
-                    audit.log(action, null, contract, "Populated history summary coverage period table", null);
+
+                    try {
+                        populateHistorySummaryForContract(contract);
+                        audit.log(action, null, contract, "Populated history summary table", null);
+                    } catch (Exception e) {
+                        audit.log(action, null, contract, "Failed to populate history summary table", null);
+                        throw e;
+                    }
+
+                    try {
+                        populateHistorySummaryCoveragePeriodsForContract(contract);
+                        audit.log(action, null, contract, "Populated history summary coverage period table", null);
+                    } catch (Exception e) {
+                        audit.log(action, null, contract, "Failed to populate history summary coverage period table", null);
+                        throw e;
+                    }
+
                 }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
@@ -424,7 +439,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         return DataAccessUtils.intResult(template.queryForList(query, parameters, Integer.class));
     }
 
-    private void populateHistorySummaryForContract(String contract) {
+    void populateHistorySummaryForContract(String contract) {
         val parameters = new MapSqlParameterSource().addValue("contract", contract);
         val template = new NamedParameterJdbcTemplate(dataSource);
         template.update(DELETE_HISTORY_SUMMARY_FOR_CONTRACT, parameters);
@@ -469,12 +484,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         return deletedContracts.size();
     }
 
-    private void populateHistorySummaryCoveragePeriodsForContract(String contract) {
+    void populateHistorySummaryCoveragePeriodsForContract(String contract) {
         val template = new JdbcTemplate(this.dataSource);
-        val query = MessageFormat.format(POPULATE_HISTORY_SUMMARY_COVERAGE_PERIODS_FOR_CONTRACT, contract);
+        // Note: Using String.format here because MessageFormat.format requires escaping all string literals
+        val query = POPULATE_HISTORY_SUMMARY_COVERAGE_PERIODS_FOR_CONTRACT.formatted(contract, contract);
         template.execute(query);
     }
-
-
 
 }

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditAction.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditAction.java
@@ -1,0 +1,7 @@
+package gov.cms.ab2d.coverage.service.v3.audit;
+
+public enum CoverageV3AuditAction {
+	COPY_FROM_STAGING,
+	COPY_TO_HISTORICAL,
+	DELETE_INACTIVE_CONTACTS;
+}

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLog.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLog.java
@@ -1,0 +1,7 @@
+package gov.cms.ab2d.coverage.service.v3.audit;
+
+import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult;
+
+public interface CoverageV3AuditLog {
+	void log(CoverageV3AuditAction action, CoverageV3SyncResult result, String contract, String log, Object data);
+}

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImpl.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.common.util.PropertyConstants;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -43,9 +44,13 @@ public class CoverageV3AuditLogImpl implements CoverageV3AuditLog {
 
 		MapSqlParameterSource parameters = null;
 		try {
+			val resultAsString = result != null
+				? result.toString()
+				: "";
+
 			parameters = new MapSqlParameterSource()
 				.addValue("action", action.toString())
-				.addValue("result", Optional.ofNullable(result.toString()).orElse(""))
+				.addValue("result", resultAsString)
 				.addValue("contract", Optional.ofNullable(contract).orElse(""))
 				.addValue("log", Optional.ofNullable(logText).orElse(""))
 				.addValue("data", toJson(data));

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImpl.java
@@ -1,0 +1,70 @@
+package gov.cms.ab2d.coverage.service.v3.audit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.PropertyConstants;
+import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class CoverageV3AuditLogImpl implements CoverageV3AuditLog {
+
+	private static final String INSERT_AUDIT_LOG =
+	"""
+	INSERT INTO v3.coverage_v3_audit(action, result, contract, log, data)
+	VALUES (:action, :result, :contract, :log, :data::jsonb)
+	""";
+
+	private final ObjectMapper mapper;
+	private final NamedParameterJdbcTemplate template;
+	private final PropertiesService propertiesService;
+
+	public CoverageV3AuditLogImpl(DataSource dataSource, PropertiesService propertiesService) {
+		this.mapper = new ObjectMapper();
+		this.template = new NamedParameterJdbcTemplate(dataSource);
+		this.propertiesService = propertiesService;
+	}
+
+	@Transactional
+	@Override
+	public void log(CoverageV3AuditAction action, CoverageV3SyncResult result, String contract, String logText, Object data) {
+		if (!propertiesService.isToggleOn(PropertyConstants.V3_AUDIT_LOGGING_ENABLED, false)) {
+			return;
+		}
+
+		MapSqlParameterSource parameters = null;
+		try {
+			parameters = new MapSqlParameterSource()
+				.addValue("action", action.toString())
+				.addValue("result", Optional.ofNullable(result.toString()).orElse(""))
+				.addValue("contract", Optional.ofNullable(contract).orElse(""))
+				.addValue("log", Optional.ofNullable(logText).orElse(""))
+				.addValue("data", toJson(data));
+
+			template.update(INSERT_AUDIT_LOG, parameters);
+		} catch (Exception e) {
+			log.error("Error inserting audit log ({})", parameters, e);
+		}
+	}
+
+	private String toJson(Object data) {
+		if (data != null) {
+			try {
+				return mapper.writeValueAsString(data);
+			} catch (JsonProcessingException e) {
+				log.error("Error serializing to JSON", e);
+			}
+		}
+		return "{}";
+	}
+
+}

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImplTest.java
@@ -1,7 +1,10 @@
 package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
+import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,12 +12,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.OutputStream;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 @Testcontainers
 @ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class CoverageV3ServiceImplTest {
@@ -23,41 +33,73 @@ class CoverageV3ServiceImplTest {
     private static final CoverageV3PostgresContainer container = new CoverageV3PostgresContainer();
 
     @Mock
-    CoverageV3SyncServiceImpl syncService;
-    @Mock
     PropertiesService propertiesService;
 
+    @Mock
+    Lock lock;
+
+    @Mock
+    CoverageV3LockWrapper lockWrapper;
+
+    @Mock
+    CoverageV3AuditLog audit;
+
     CoverageV3ServiceImpl service;
+
+    CoverageV3SyncServiceImpl syncService;
 
     @BeforeEach
     void setUp() {
         service = new CoverageV3ServiceImpl(container.getDataSource(), propertiesService, syncService);
+        syncService = new CoverageV3SyncServiceImpl(container.getDataSource(), lockWrapper, lockWrapper, audit, propertiesService);
     }
 
-    // TODO Temporary -- remove
     @Test
     void test() {
         assertTrue(
             service.shouldDeleteAggregatedTable(
-                "coverage_v3_aggregated_s5601",
-                List.of("S4802")
+                "coverage_v3_aggregated_z0000",
+                List.of("z0001")
             )
         );
 
         assertFalse(
             service.shouldDeleteAggregatedTable(
-                    "coverage_v3_aggregated_s5601",
-                    List.of("s5601")
+                "coverage_v3_aggregated_z0001",
+                List.of("z0001")
             )
         );
 
         assertFalse(
             service.shouldDeleteAggregatedTable(
-                    "coverage_v3_aggregated_s5601",
-                    List.of("S5601")
+                "coverage_v3_aggregated_z0001",
+                List.of("Z0001")
             )
         );
     }
 
+
+    @Test
+    void blah() {
+        val contractZ9999 = "Z9999";
+        val contractDtoZ9999 = new ContractDTO();
+        contractDtoZ9999.setContractNumber(contractZ9999);
+
+        val contractZ7777 = "Z7777";
+        val contractDtoZ7777 = new ContractDTO();
+        contractDtoZ7777.setContractNumber(contractZ7777);
+
+        syncService.populateHistorySummaryForContract(contractZ9999);
+        syncService.populateHistorySummaryCoveragePeriodsForContract(contractZ9999);
+
+        syncService.populateHistorySummaryForContract(contractZ7777);
+        syncService.populateHistorySummaryCoveragePeriodsForContract(contractZ7777);
+
+        val coveragePeriods = service.getCoveragePeriods(List.of(contractDtoZ9999, contractDtoZ7777));
+
+        assertEquals(coveragePeriods.get("Z7777").toString(), "[YearMonthRecord(year=2026, month=2), YearMonthRecord(year=2026, month=1), YearMonthRecord(year=2025, month=12)]");
+        assertEquals(coveragePeriods.get("Z9999").toString(), "[YearMonthRecord(year=2026, month=2), YearMonthRecord(year=2026, month=1), YearMonthRecord(year=2025, month=12), YearMonthRecord(year=2025, month=11), YearMonthRecord(year=2025, month=10), YearMonthRecord(year=2025, month=9)]");
+
+    }
 
 }

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -1,0 +1,142 @@
+package gov.cms.ab2d.coverage.service.v3;
+
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
+import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
+import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLogImpl;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+
+import static gov.cms.ab2d.common.util.PropertyConstants.V3_AUDIT_LOGGING_ENABLED;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class CoverageV3SyncServiceImplTest {
+
+	@Container
+	private static final CoverageV3PostgresContainer container = new CoverageV3PostgresContainer();
+
+	CoverageV3SyncServiceImpl service;
+	CoverageV3AuditLog audit;
+
+	@Mock
+	PropertiesService propertiesService;
+
+	@Mock
+	CoverageV3LockWrapper lockWrapper;
+
+	@Mock
+	Lock lock;
+
+	@BeforeEach
+	void setup() {
+
+		audit = new CoverageV3AuditLogImpl(container.getDataSource(), propertiesService);
+
+		service = new CoverageV3SyncServiceImpl(
+			container.getDataSource(),
+			lockWrapper,
+			lockWrapper,
+			audit,
+			propertiesService
+		) {
+			@Override
+			boolean isTestContract(String contract) {
+				return false;
+			}
+
+			@Override
+			boolean isContractAttested(String contract) {
+				return true;
+			}
+		};
+
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+
+		new JdbcTemplate(container.getDataSource()).execute("truncate v3.coverage_v3_audit");
+	}
+
+	@Test
+	void moveToHistorical_Z0001_testAuditLogs() {
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		service.moveToHistorical("Z0001", CoverageV3SyncSource.CRON_JOB);
+
+		val rows = getAuditLogs();
+
+		assertAuditLogEquals(rows.get(0),
+		"""
+		{action=COPY_TO_HISTORICAL, result=JOB_IN_PROGRESS_FOR_CONTRACT, contract=Z0001, log=, data={}}
+		""");
+	}
+
+	@Test
+	void moveToHistorical_Z1234_testAuditLogs() {
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
+		when(lock.tryLock()).thenReturn(true);
+		service.moveToHistorical("Z1234", CoverageV3SyncSource.CRON_JOB);
+
+		val rows = getAuditLogs();
+
+		assertAuditLogEquals(rows.get(0),
+		"""
+		{action=COPY_TO_HISTORICAL, result=, contract=Z1234, log=, data={"rowsMoved": 3}}
+		""");
+
+		assertAuditLogEquals(rows.get(1),
+		"""
+		{action=COPY_TO_HISTORICAL, result=, contract=Z1234, log=Populated history summary table, data={}}
+		""");
+
+		assertAuditLogEquals(rows.get(2),
+		"""
+		{action=COPY_TO_HISTORICAL, result=, contract=Z1234, log=Populated history summary coverage period table, data={}}
+		""");
+
+	}
+
+	@Test
+	void moveToStaging_Z9999_testAuditLogs() {
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
+		when(lock.tryLock()).thenReturn(true);
+		service.copyFromStagingTablesToRecent("Z9999", CoverageV3SyncSource.CRON_JOB);
+
+		val rows = new JdbcTemplate(container.getDataSource()).queryForList("select * from v3.coverage_v3_audit");
+
+		assertAuditLogEquals(rows.get(6),
+		"""
+		{action=COPY_FROM_STAGING, result=SYNC_SUCCESSFUL_FOR_CONTRACT, contract=Z9999, log=, data={"rowsInStagingDeleted": 4, "rowsInCoverageAfterCopy": 4}}
+		""");
+
+	}
+
+	void assertAuditLogEquals(Map<String, Object> result, String string) {
+		// remove id and timestamp to simplify comparisons
+		result.remove("timestamp");
+		result.remove("id");
+		string = string.trim();
+		assertEquals(result.toString().trim(), string.trim());
+	}
+
+	List<Map<String, Object>>  getAuditLogs() {
+		return new JdbcTemplate(container.getDataSource()).queryForList("select * from v3.coverage_v3_audit");
+	}
+
+}

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/audit/CoverageV3AuditLogImplTest.java
@@ -1,0 +1,71 @@
+package gov.cms.ab2d.coverage.service.v3.audit;
+
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.PropertyConstants;
+import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
+import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult;
+import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncServiceImpl;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static gov.cms.ab2d.common.util.PropertyConstants.*;
+import static gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class CoverageV3AuditLogImplTest {
+
+	@Container
+	private static final CoverageV3PostgresContainer container = new CoverageV3PostgresContainer();
+
+	@Mock
+	PropertiesService propertiesService;
+
+	CoverageV3AuditLogImpl audit;
+
+	@BeforeEach
+	void setup() {
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		audit = new CoverageV3AuditLogImpl(container.getDataSource(), propertiesService);
+	}
+
+	@Test
+	void testAuditInputFields() {
+		audit.log(CoverageV3AuditAction.COPY_FROM_STAGING, null, "Z0001", null, null);
+		audit.log(CoverageV3AuditAction.COPY_FROM_STAGING, JOB_IN_PROGRESS_FOR_CONTRACT, "Z0002", null, null);
+		audit.log(CoverageV3AuditAction.COPY_FROM_STAGING, IDR_IMPORTER_IN_PROGRESS, "Z0003", "IDR importer in progress", null);
+		audit.log(CoverageV3AuditAction.COPY_FROM_STAGING, SYNC_SUCCESSFUL_FOR_CONTRACT, "Z0004", null, Map.of("rowsMoved", 999));
+
+		val rows = new JdbcTemplate(container.getDataSource()).queryForList("select * from v3.coverage_v3_audit");
+		assertEquals(4, rows.size());
+
+		assertEquals("COPY_FROM_STAGING", rows.get(0).get("action"));
+		assertEquals("", rows.get(0).get("result"));
+		assertEquals("Z0001", rows.get(0).get("contract"));
+		assertEquals("", rows.get(0).get("log"));
+		assertEquals("{}", rows.get(0).get("data").toString());
+
+		assertEquals("IDR importer in progress", rows.get(2).get("log"));
+
+		assertEquals("COPY_FROM_STAGING", rows.get(3).get("action"));
+		assertEquals("Z0004", rows.get(3).get("contract"));
+		assertEquals("", rows.get(3).get("log"));
+		assertEquals("{\"rowsMoved\": 999}", rows.get(3).get("data").toString());
+
+	}
+
+}

--- a/coverage/src/test/resources/v3/init.sql
+++ b/coverage/src/test/resources/v3/init.sql
@@ -227,3 +227,20 @@ VALUES
     ('NULLEND', 105, 'P105', array[array[2025, 2]]),
     ('UNATT1',  106, 'P106', array[array[2024, 1]])
 ;
+
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_history_summary_coverage_periods (
+    contract TEXT NOT NULL,
+    year INT NOT NULL,
+    month INT NOT NULL,
+    UNIQUE (contract, year, month)
+);
+
+CREATE TABLE IF NOT EXISTS v3.coverage_v3_audit (
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    action TEXT NOT NULL,
+    result TEXT,
+    contract TEXT,
+    log TEXT NOT NULL,
+    data JSONB
+);

--- a/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/config/JobHandler.java
@@ -132,7 +132,6 @@ public class JobHandler implements MessageHandler {
         }
 
         val contract = getContractNumber(submittedJob);
-        // Note: `moveOldCoverageToHistoricalCoverage` is mostly irrelevant now that v3.coverage_v3_history_summary exists
         log.info("Calling moveOldCoverageToHistoricalCoverage() for contract {}", contract);
         coverageV3Service.moveOldCoverageToHistoricalCoverage(contract, JOB_HANDLER);
         log.info("Calling moveFromStagingToRecentCoverage() for contract {}", contract);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
@@ -4,7 +4,6 @@ import com.newrelic.api.agent.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.common.util.DateUtil;
-import gov.cms.ab2d.common.util.PropertyConstants;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.*;
@@ -15,7 +14,7 @@ import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncService;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import gov.cms.ab2d.worker.processor.coverage.check.*;
-import gov.cms.ab2d.worker.processor.coverage.check.v3.CoverageV3PresentCheck;
+import gov.cms.ab2d.worker.processor.coverage.check.v3.CoverageV3CoveragePeriodsPresentCheck;
 import gov.cms.ab2d.worker.service.coveragesnapshot.CoverageSnapshotService;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -774,7 +773,7 @@ public class CoverageDriverImpl implements CoverageDriver {
         val coveragePeriods = coverageV3Service.getCoveragePeriods(enabledContracts);
 
         long passingContracts = enabledContracts.stream()
-            .filter(new CoverageV3PresentCheck(coverageV3Service, coveragePeriods, issues))
+            .filter(new CoverageV3CoveragePeriodsPresentCheck(coverageV3Service, coveragePeriods, issues))
             .count();
 
         String message = String.format("Verified that %d contracts pass all coverage checks out of %d",

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverImpl.java
@@ -4,25 +4,25 @@ import com.newrelic.api.agent.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.common.util.DateUtil;
+import gov.cms.ab2d.common.util.PropertyConstants;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.*;
 import gov.cms.ab2d.coverage.repository.CoverageSearchRepository;
 import gov.cms.ab2d.coverage.service.CoverageService;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
+import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncService;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import gov.cms.ab2d.worker.processor.coverage.check.*;
+import gov.cms.ab2d.worker.processor.coverage.check.v3.CoverageV3PresentCheck;
 import gov.cms.ab2d.worker.service.coveragesnapshot.CoverageSnapshotService;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
@@ -746,25 +746,35 @@ public class CoverageDriverImpl implements CoverageDriver {
     }
 
     @Override
-    @Deprecated
     public void verifyCoverageV3() {
-        // To be revisited in AB2D-7272
+        if (!propertiesService.isToggleOn(V3_COVERAGE_PERIOD_CHECK_ENABLED, false)) {
+            log.info("[V3] Coverage period checks are disabled - skipping");
+            return;
+        }
 
-        /*
         val issues = new ArrayList<String>();
+        val hpmsEndDateCutOff = CoverageV3SyncService.CUT_OFF_DATE_FOR_INACTIVE_CONTRACT.get();
 
-        // Only filter contracts that matter
-        List<ContractDTO> enabledContracts = pdpClientService.getAllEnabledContracts()
+        val enabledContracts = pdpClientService.getAllEnabledContracts()
             .stream()
             .filter(contract -> !contract.isTestContract())
             .filter(contract -> contractNotBeingUpdatedV3(issues, contract))
+            .filter(contract -> {
+                val endDate = contract.getHpmsEndDate();
+                if (endDate == null) {
+                    return true;
+                } else {
+                    return !endDate.toLocalDate().isBefore(hpmsEndDateCutOff);
+                }
+            })
             .map(Contract::toDTO)
             .toList();
 
-        val coverageCounts = coverageV3Service.getCoverageCount();
+
+        val coveragePeriods = coverageV3Service.getCoveragePeriods(enabledContracts);
 
         long passingContracts = enabledContracts.stream()
-            .filter(new CoverageV3PresentCheck(coverageV3Service, coverageCounts, issues))
+            .filter(new CoverageV3PresentCheck(coverageV3Service, coveragePeriods, issues))
             .count();
 
         String message = String.format("Verified that %d contracts pass all coverage checks out of %d",
@@ -774,7 +784,6 @@ public class CoverageDriverImpl implements CoverageDriver {
         if (!issues.isEmpty()) {
             throw new CoverageVerificationException(message, issues);
         }
-        */
     }
 
     private boolean contractNotBeingUpdatedV3(List<String> issues, Contract contract) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CheckPredicate.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CheckPredicate.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.worker.processor.coverage.check.v3;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.YearMonthRecord;
-import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import lombok.AllArgsConstructor;
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CheckPredicate.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CheckPredicate.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.worker.processor.coverage.check.v3;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,6 @@ import java.util.function.Predicate;
 public abstract class CoverageV3CheckPredicate implements Predicate<ContractDTO> {
 
     protected final CoverageV3Service coverageService;
-    protected final Map<String, List<CoverageV3Count>> coverageCounts;
+    protected final Map<String, List<YearMonthRecord>> coverageCounts;
     protected final List<String> issues;
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CoveragePeriodsPresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3CoveragePeriodsPresentCheck.java
@@ -2,7 +2,6 @@ package gov.cms.ab2d.worker.processor.coverage.check.v3;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.YearMonthRecord;
-import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import jakarta.validation.constraints.NotNull;
@@ -21,9 +20,9 @@ import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getEndDateTim
  * Verifies enabled contracts have the expected number of coverage periods based on attestation date
  */
 @Slf4j
-public class CoverageV3PresentCheck extends CoverageV3CheckPredicate {
+public class CoverageV3CoveragePeriodsPresentCheck extends CoverageV3CheckPredicate {
 
-    public CoverageV3PresentCheck(CoverageV3Service coverageService, Map<String, List<YearMonthRecord>> coverageCounts, List<String> issues) {
+    public CoverageV3CoveragePeriodsPresentCheck(CoverageV3Service coverageService, Map<String, List<YearMonthRecord>> coverageCounts, List<String> issues) {
         super(coverageService, coverageCounts, issues);
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheck.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheck.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.worker.processor.coverage.check.v3;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
@@ -16,10 +17,13 @@ import java.util.Map;
 import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getAttestationTime;
 import static gov.cms.ab2d.worker.processor.coverage.CoverageUtils.getEndDateTime;
 
+/**
+ * Verifies enabled contracts have the expected number of coverage periods based on attestation date
+ */
 @Slf4j
 public class CoverageV3PresentCheck extends CoverageV3CheckPredicate {
 
-    public CoverageV3PresentCheck(CoverageV3Service coverageService, Map<String, List<CoverageV3Count>> coverageCounts, List<String> issues) {
+    public CoverageV3PresentCheck(CoverageV3Service coverageService, Map<String, List<YearMonthRecord>> coverageCounts, List<String> issues) {
         super(coverageService, coverageCounts, issues);
     }
 
@@ -39,7 +43,7 @@ public class CoverageV3PresentCheck extends CoverageV3CheckPredicate {
         return noEnrollmentIssues.isEmpty();
     }
 
-    private List<String> listCoveragePeriodsMissingEnrollment(ContractDTO contract, List<CoverageV3Count> coverageCounts) {
+    private List<String> listCoveragePeriodsMissingEnrollment(ContractDTO contract, List<YearMonthRecord> coverageCounts) {
 
         List<String> noEnrollment = new ArrayList<>();
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/quartz/v3/CoverageV3CheckQuartzJob.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/quartz/v3/CoverageV3CheckQuartzJob.java
@@ -40,10 +40,6 @@ public class CoverageV3CheckQuartzJob extends QuartzJobBean {
             log.info("[V3] Skipping enrollment verification because AB2D is already in maintenance mode");
         }
 
-        // Note: This process uses a query that causes the database to run out of disk space...
-        // To be updated in AB2D-7272
-
-        /*
         try {
             driver.verifyCoverageV3();
         } catch (CoverageVerificationException exception) {
@@ -59,6 +55,5 @@ public class CoverageV3CheckQuartzJob extends QuartzJobBean {
 
             throw new JobExecutionException(exception);
         }
-         */
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheckTest.java
@@ -10,7 +10,11 @@ import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncService;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -18,14 +22,18 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 
 @Testcontainers
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class CoverageV3PresentCheckTest {
 
 	@Container
 	private static final CoverageV3PostgresContainer container = new CoverageV3PostgresContainer();
 
-	private CoverageV3PresentCheck check;
+	private CoverageV3CoveragePeriodsPresentCheck check;
 	private CoverageV3Service coverageService;
 
 	@BeforeEach
@@ -35,11 +43,10 @@ class CoverageV3PresentCheckTest {
 			Mockito.mock(PropertiesService.class),
 			Mockito.mock(CoverageV3SyncService.class)
 		);
-
 	}
 
 	@Test
-	void test() {
+	void testCoveragCheck_Z1234(CapturedOutput out) {
 		val issues = new ArrayList<String>();
 		val contractNumber = "Z1234";
 		val contractDto = new ContractDTO();
@@ -47,8 +54,19 @@ class CoverageV3PresentCheckTest {
 		contractDto.setContractNumber(contractNumber);
 		contractDto.setAttestedOn(OffsetDateTime.parse("2025-09-30T00:00:00+00:00")); // 2025-09-01
 		val coverageCounts = coverageService.getCoveragePeriods(List.of(contractDto));
-		check = new CoverageV3PresentCheck(coverageService, coverageCounts, issues);
+
+		check = new CoverageV3CoveragePeriodsPresentCheck(coverageService, coverageCounts, issues);
 		check.test(contractDto);
+
+		assertTrue(out.getOut().contains("[V3] Z1234-2025-9 no enrollment found"));
+		assertTrue(out.getOut().contains("[V3] Z1234-2025-10 no enrollment found"));
+		assertTrue(out.getOut().contains("[V3] Z1234-2025-11 no enrollment found"));
+
+		assertFalse(out.getOut().contains("[V3] Z1234-2025-12 no enrollment found"));
+		assertFalse(out.getOut().contains("[V3] Z1234-2026-1 no enrollment found"));
+		assertFalse(out.getOut().contains("[V3] Z1234-2026-2 no enrollment found"));
+
+
 	}
 
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/v3/CoverageV3PresentCheckTest.java
@@ -4,7 +4,6 @@ import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
-import gov.cms.ab2d.coverage.model.ContractForCoverageDTO;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3ServiceImpl;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3SyncService;
@@ -17,6 +16,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 
 @Testcontainers
@@ -41,13 +41,12 @@ class CoverageV3PresentCheckTest {
 	@Test
 	void test() {
 		val issues = new ArrayList<String>();
-		val coverageCounts = coverageService.getCoverageCount();
 		val contractNumber = "Z1234";
 		val contractDto = new ContractDTO();
 		contractDto.setContractType(Contract.ContractType.CLASSIC_TEST);
 		contractDto.setContractNumber(contractNumber);
 		contractDto.setAttestedOn(OffsetDateTime.parse("2025-09-30T00:00:00+00:00")); // 2025-09-01
-
+		val coverageCounts = coverageService.getCoveragePeriods(List.of(contractDto));
 		check = new CoverageV3PresentCheck(coverageService, coverageCounts, issues);
 		check.test(contractDto);
 	}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7286

## 🛠 Changes

- Add `coverage_v3_history_summary_coverage_periods` to calculate coverage periods used by the coverage checks
- Add coverage checks for v3 to determine if any periods are missing
- Add audit logging for activity related to (a) copying from staging to recent coverage and (b) copying from recent coverage table to historical coverage table


## ℹ️ Context

Both audit logging and the coverage period checks can be disabled by updating the properties table.  

## 🧪 Validation

Tested with integration tests. None of this is testable in dev/test/sandbox. 
