### PR TITLE
AB2D-7306 springboot upgrade

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -69,6 +69,12 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-properties-migrator</artifactId>
             <scope>runtime</scope>
         </dependency>
@@ -100,7 +106,7 @@
         <dependency>
             <groupId>dev.akkinoc.spring.boot</groupId>
             <artifactId>logback-access-spring-boot-starter</artifactId>
-            <version>4.7.0</version>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback.access</groupId>

--- a/api/src/main/java/gov/cms/ab2d/api/SpringBootApp.java
+++ b/api/src/main/java/gov/cms/ab2d/api/SpringBootApp.java
@@ -5,7 +5,7 @@ import gov.cms.ab2d.common.feign.ContractFeignClient;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;

--- a/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/AdminAPI.java
@@ -42,7 +42,7 @@ public class AdminAPI {
     public ResponseEntity<PdpClientDTO> createClient(@RequestBody PdpClientDTO pdpClientDTO) {
         PdpClientDTO client = pdpClientService.createClient(pdpClientDTO);
         log.info("client {} created", client.getOrganization());
-        return new ResponseEntity<>(client, null, HttpStatus.CREATED);
+        return new ResponseEntity<>(client, HttpStatus.CREATED);
     }
 
     @ResponseStatus(value = HttpStatus.OK)
@@ -50,7 +50,7 @@ public class AdminAPI {
     public ResponseEntity<PdpClientDTO> udpateClient(@RequestBody PdpClientDTO pdpClientDTO) {
         PdpClientDTO client = pdpClientService.updateClient(pdpClientDTO);
         log.info("client {} updated", pdpClientDTO.getOrganization());
-        return new ResponseEntity<>(client, null, HttpStatus.OK);
+        return new ResponseEntity<>(client, HttpStatus.OK);
     }
 
     @PostMapping("/job/{contractNumber}")
@@ -68,18 +68,18 @@ public class AdminAPI {
     @ResponseStatus(value = HttpStatus.OK)
     @PutMapping("/client/{contractNumber}/enable")
     public ResponseEntity<PdpClientDTO> enableClient(@PathVariable @NotBlank String contractNumber) {
-        return new ResponseEntity<>(pdpClientService.enableClient(contractNumber), null, HttpStatus.OK);
+        return new ResponseEntity<>(pdpClientService.enableClient(contractNumber), HttpStatus.OK);
     }
 
     @ResponseStatus(value = HttpStatus.OK)
     @PutMapping("/client/{contractNumber}/disable")
     public ResponseEntity<PdpClientDTO> disableClient(@PathVariable @NotBlank String contractNumber) {
-        return new ResponseEntity<>(pdpClientService.disableClient(contractNumber), null, HttpStatus.OK);
+        return new ResponseEntity<>(pdpClientService.disableClient(contractNumber), HttpStatus.OK);
     }
 
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping("/client/{contractNumber}")
     public ResponseEntity<PdpClientDTO> getClient(@PathVariable @NotBlank String contractNumber) {
-        return new ResponseEntity<>(pdpClientService.getClient(contractNumber), null, HttpStatus.OK);
+        return new ResponseEntity<>(pdpClientService.getClient(contractNumber), HttpStatus.OK);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/ErrorHandler.java
@@ -1,8 +1,8 @@
 package gov.cms.ab2d.api.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.okta.jwt.JwtVerificationException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
 import gov.cms.ab2d.api.security.BadJWTTokenException;
 import gov.cms.ab2d.api.security.ClientNotEnabledException;
@@ -132,7 +132,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
                 API_ERROR, description, (String) request.getAttribute(REQUEST_ID));
         eventLogger.logAndAlert(responseEvent, Ab2dEnvironment.PROD_LIST);
 
-        return new ResponseEntity<>(null, null, status);
+        return new ResponseEntity<>(status);
     }
 
     @ExceptionHandler({MissingTokenException.class,
@@ -157,7 +157,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
                 API_ERROR, description, (String) request.getAttribute(REQUEST_ID));
         eventLogger.sendLogs(responseEvent);
 
-        return new ResponseEntity<>(null, null, status);
+        return new ResponseEntity<>(status);
     }
 
     @ExceptionHandler(EndpointNotAvailableException.class)
@@ -177,7 +177,7 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
                 API_ERROR, ex.getClass().getSimpleName(), (String) request.getAttribute(REQUEST_ID)));
         eventLogger.trace("API_MAINT_BLOCKED Maintenance mode blocked API request " + request.getAttribute(REQUEST_ID), Ab2dEnvironment.PROD_LIST);
 
-        return new ResponseEntity<>(null, null, status);
+        return new ResponseEntity<>(status);
     }
 
     @ExceptionHandler(TooManyRequestsException.class)

--- a/api/src/main/java/gov/cms/ab2d/api/controller/MaintenanceModeAPI.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/MaintenanceModeAPI.java
@@ -26,6 +26,6 @@ public class MaintenanceModeAPI {
     @GetMapping(STATUS_ENDPOINT)
     public ResponseEntity<MaintenanceModeResponse> getMaintenanceMode() {
         MaintenanceModeResponse maintenanceModeResponse = new MaintenanceModeResponse(String.valueOf(propertiesService.isToggleOn(PropertyConstants.MAINTENANCE_MODE, false)));
-        return new ResponseEntity<>(maintenanceModeResponse, null, HttpStatus.OK);
+        return new ResponseEntity<>(maintenanceModeResponse, HttpStatus.OK);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/ApiText.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.api.controller.common;
 import static gov.cms.ab2d.api.util.Constants.GENERIC_FHIR_ERR_MSG;
 import static gov.cms.ab2d.common.util.Constants.FHIR_NDJSON_CONTENT_TYPE;
 import static gov.cms.ab2d.common.util.Constants.SINCE_EARLIEST_DATE;
-import static gov.cms.ab2d.common.util.Constants.V3_SINCE_EARLIEST_DATE;
 
 import lombok.experimental.UtilityClass;
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/FileDownloadCommon.java
@@ -84,7 +84,7 @@ public class FileDownloadCommon {
             eventLogger.sendLogs(new ApiResponseEvent(MDC.get(ORGANIZATION), jobUuid, HttpStatus.OK, "File Download",
                     "File " + filename + " was downloaded", (String) request.getAttribute(REQUEST_ID)));
             jobClient.incrementDownload(downloadResource.getFile(), jobUuid);
-            return new ResponseEntity<>(null, null, HttpStatus.OK);
+            return new ResponseEntity<>(HttpStatus.OK);
         }
     }
 

--- a/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/common/StatusCommon.java
@@ -194,7 +194,6 @@ public class StatusCommon {
         eventLogger.sendLogs(new ApiResponseEvent(MDC.get(ORGANIZATION), jobUuid, HttpStatus.ACCEPTED,
                 "Job cancelled", null, (String) request.getAttribute(REQUEST_ID)));
 
-        return new ResponseEntity<>(null, null,
-                HttpStatus.ACCEPTED);
+        return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityAPIV1.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v1/CapabilityAPIV1.java
@@ -62,6 +62,6 @@ public class CapabilityAPIV1 {
 
         String server = common.getCurrentUrl(request).replace("/metadata", "");
         CapabilityStatement capabilityStatement = CapabilityStatementSTU3.populateCS(server);
-        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), null, HttpStatus.OK);
+        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), HttpStatus.OK);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityAPIV2.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v2/CapabilityAPIV2.java
@@ -61,6 +61,6 @@ public class CapabilityAPIV2 {
 
         String server = common.getCurrentUrl(request).replace("/metadata", "");
         CapabilityStatement capabilityStatement = CapabilityStatementR4.populateCS(server);
-        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), null, HttpStatus.OK);
+        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), HttpStatus.OK);
     }
 }

--- a/api/src/main/java/gov/cms/ab2d/api/controller/v3/CapabilityAPIV3.java
+++ b/api/src/main/java/gov/cms/ab2d/api/controller/v3/CapabilityAPIV3.java
@@ -52,6 +52,6 @@ public class CapabilityAPIV3 {
 
         String server = common.getCurrentUrl(request).replace("/metadata", "");
         CapabilityStatement capabilityStatement = CapabilityStatementR4V3.populateCS(server);
-        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), null, HttpStatus.OK);
+        return new ResponseEntity<>(parser.encodeResourceToString(capabilityStatement), HttpStatus.OK);
     }
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,7 +12,6 @@ spring.liquibase.liquibase-schema=public
 spring.liquibase.default-schema=ab2d
 
 
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.cloud.compatibility-verifier.enabled=false
 
 api.retry-after.delay=5

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIMaintenanceModeTests.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.api.controller;
 
 import com.jayway.jsonpath.JsonPath;
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -24,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -67,8 +69,11 @@ public class AdminAPIMaintenanceModeTests {
     @Autowired
     JobClientMock jobClientMock;
 
-    @Autowired
+    @MockitoBean
     SQSEventClient sqsEventClient;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Autowired
     private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.api.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.remote.JobClientMock;
@@ -27,6 +28,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -82,6 +84,8 @@ public class AdminAPIPdpClientTests {
     @Autowired
     private RoleService roleService;
 
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AdminAPIPdpClientTests.java
@@ -16,6 +16,7 @@ import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.contracts.model.Contract;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.job.dto.StartJobDTO;
 import java.util.List;
@@ -86,6 +87,9 @@ public class AdminAPIPdpClientTests {
 
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
@@ -20,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -60,8 +62,11 @@ public class AuthenticationTests {
     @Autowired
     SqsAsyncClient amazonSqs;
 
-    @Autowired
+    @MockitoBean
     SQSEventClient sqsEventClient;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Captor
     private ArgumentCaptor<LoggableEvent> captor;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/AuthenticationTests.java
@@ -14,9 +14,8 @@ import gov.cms.ab2d.eventclient.events.ApiResponseEvent;
 import gov.cms.ab2d.eventclient.events.LoggableEvent;
 import org.junit.jupiter.api.*;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
@@ -68,7 +67,6 @@ public class AuthenticationTests {
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
 
-    @Captor
     private ArgumentCaptor<LoggableEvent> captor;
 
     @Container
@@ -78,6 +76,7 @@ public class AuthenticationTests {
 
     @BeforeEach
     public void setup() throws JwtVerificationException {
+        captor = ArgumentCaptor.forClass(LoggableEvent.class);
         token = testUtil.setupToken(List.of(SPONSOR_ROLE));
     }
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIIntegrationTests.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.api.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.JsonPath;
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -37,6 +38,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -94,6 +98,11 @@ class BulkDataAccessAPIIntegrationTests {
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
+
     @Autowired
     private TestUtil testUtil;
 
@@ -105,6 +114,9 @@ class BulkDataAccessAPIIntegrationTests {
 
     @Autowired
     SQSEventClient sqsEventClient;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Autowired
     private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -28,6 +29,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -85,11 +89,19 @@ public class BulkDataAccessAPIUnusualDataTests {
     @Autowired
     SqsAsyncClient amazonSQS;
 
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
+
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
 
     @Autowired
     private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIUnusualDataTests.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
@@ -10,6 +10,7 @@ import gov.cms.ab2d.common.repository.PdpClientRepository;
 import gov.cms.ab2d.common.service.ContractServiceStub;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.job.dto.StartJobDTO;
 import java.util.List;
@@ -77,6 +78,9 @@ public class BulkDataAccessAPIV2IntegrationTests {
 
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV2IntegrationTests.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -7,7 +8,6 @@ import gov.cms.ab2d.api.remote.JobClientMock;
 import gov.cms.ab2d.common.properties.PropertyServiceStub;
 import gov.cms.ab2d.common.repository.PdpClientRepository;
 import gov.cms.ab2d.common.service.ContractServiceStub;
-import gov.cms.ab2d.common.util.AB2DLocalstackContainer;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
 import gov.cms.ab2d.contracts.model.Contract;
@@ -22,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -65,9 +66,6 @@ public class BulkDataAccessAPIV2IntegrationTests {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @Container
-    private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
-
     @Autowired
     private TestUtil testUtil;
 
@@ -76,6 +74,9 @@ public class BulkDataAccessAPIV2IntegrationTests {
 
     @Autowired
     private ApplicationContext context;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV3IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV3IntegrationTests.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -19,6 +20,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -66,6 +70,11 @@ public class BulkDataAccessAPIV3IntegrationTests {
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
+
     @Autowired
     private TestUtil testUtil;
 
@@ -74,6 +83,9 @@ public class BulkDataAccessAPIV3IntegrationTests {
 
     @Autowired
     private ApplicationContext context;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     private String token;
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV3IntegrationTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/BulkDataAccessAPIV3IntegrationTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.model.PdpClient;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -51,6 +53,9 @@ public class InvalidTokenTest {
 
     @Autowired
     ContractServiceStub contractServiceStub;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/InvalidTokenTest.java
@@ -9,6 +9,7 @@ import gov.cms.ab2d.common.service.ContractServiceStub;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,9 @@ public class InvalidTokenTest {
 
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.properties.PropertyServiceStub;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -40,6 +42,9 @@ public class MaintenanceModeAPITests {
 
     @Autowired
     private ApplicationContext context;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     private PropertyServiceStub propertiesService = new PropertyServiceStub();
 

--- a/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/MaintenanceModeAPITests.java
@@ -7,7 +7,7 @@ import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.okta.jwt.AccessTokenVerifier;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -47,6 +49,9 @@ public class RoleTests {
 
     @Autowired
     private DataSetup dataSetup;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/RoleTests.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -52,6 +53,9 @@ public class RoleTests {
 
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -6,6 +6,7 @@ import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -73,6 +74,9 @@ public class TLSTest {
 
     @MockitoBean
     AccessTokenVerifier mockAccessTokenVerifier;
+
+    @MockitoBean
+    SQSEventClient sqsEventClient;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TLSTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller;
 
+import com.okta.jwt.AccessTokenVerifier;
 import com.okta.jwt.JwtVerificationException;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
@@ -34,6 +35,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -68,6 +70,9 @@ public class TLSTest {
 
     @Autowired
     SqsAsyncClient amazonSqs;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Container
     private static final PostgreSQLContainer postgreSQLContainer = new AB2DPostgresqlContainer();

--- a/api/src/test/java/gov/cms/ab2d/api/controller/TestUtil.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/TestUtil.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -45,7 +44,7 @@ public class TestUtil {
     @Getter
     private PropertyServiceStub propertiesService = new PropertyServiceStub();
 
-    @MockBean
+    @Autowired
     AccessTokenVerifier mockAccessTokenVerifier;
 
     @Value("${api.okta-jwt-audience}")

--- a/api/src/test/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2Test.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2Test.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.v2;
 
+import com.okta.jwt.AccessTokenVerifier;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.TestUtil;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -17,6 +18,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -52,6 +56,11 @@ class StatusAPIV2Test {
   @Container
   private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
+  @DynamicPropertySource
+  static void sqsProps(DynamicPropertyRegistry registry) {
+    registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+  }
+
   @Autowired
   private TestUtil testUtil;
 
@@ -61,8 +70,11 @@ class StatusAPIV2Test {
   @Autowired
   SqsAsyncClient amazonSQS;
 
-  @Autowired
+  @MockitoBean
   SQSEventClient sqsEventClient;
+
+  @MockitoBean
+  AccessTokenVerifier mockAccessTokenVerifier;
 
   @Autowired
   private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2Test.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/v2/StatusAPIV2Test.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/v3/StatusAPIV3Test.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/v3/StatusAPIV3Test.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.api.controller.v3;
 
+import com.okta.jwt.AccessTokenVerifier;
 import gov.cms.ab2d.api.SpringBootApp;
 import gov.cms.ab2d.api.controller.TestUtil;
 import gov.cms.ab2d.api.controller.common.ApiCommon;
@@ -17,6 +18,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -53,6 +57,11 @@ class StatusAPIV3Test {
   @Container
   private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
+  @DynamicPropertySource
+  static void sqsProps(DynamicPropertyRegistry registry) {
+    registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+  }
+
   @Autowired
   private TestUtil testUtil;
 
@@ -62,8 +71,11 @@ class StatusAPIV3Test {
   @Autowired
   SqsAsyncClient amazonSQS;
 
-  @Autowired
+  @MockitoBean
   SQSEventClient sqsEventClient;
+
+  @MockitoBean
+  AccessTokenVerifier mockAccessTokenVerifier;
 
   @Autowired
   private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/controller/v3/StatusAPIV3Test.java
+++ b/api/src/test/java/gov/cms/ab2d/api/controller/v3/StatusAPIV3Test.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;

--- a/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
@@ -26,6 +26,9 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -83,8 +86,16 @@ class JwtAuthenticationFilterTest {
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
 
-    @Autowired
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
+
+    @MockitoBean
     SQSEventClient sqsEventClient;
+
+    @MockitoBean
+    AccessTokenVerifier mockAccessTokenVerifier;
 
     @Autowired
     private ApplicationContext context;

--- a/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
+++ b/api/src/test/java/gov/cms/ab2d/api/security/JwtAuthenticationFilterTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -9,6 +9,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.enabled=true
 spring.liquibase.contexts=test
+spring.liquibase.liquibase-schema=public
+spring.liquibase.default-schema=ab2d
 
 spring.cloud.compatibility-verifier.enabled=false
 

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -14,7 +14,6 @@ spring.cloud.compatibility-verifier.enabled=false
 
 spring.main.allow-bean-definition-overriding=true
 spring.profiles.active=mock-beans
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 api.retry-after.delay=30
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,6 +54,10 @@
             <version>${postgresql.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-liquibase</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.33.0</version>
         </dependency>
 
         <dependency>
@@ -133,13 +132,13 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>4.3.0</version>
+            <version>5.0.1</version>
         </dependency>
 
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.6.0</version> <!-- Override version 1.5 from spring-cloud-starter-openfeign@4.3.0-->
+            <version>1.6.0</version> <!-- Override version 1.5 from spring-cloud-starter-openfeign@5.0.1-->
         </dependency>
 
         <dependency>

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -199,3 +199,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_audit_logging.sql
   - include:
       file: db/changelog/v2026/add_v3_coverage_check_enabled.sql
+  - include:
+      file: db/changelog/v2026/add_int_lock_expired_after.sql

--- a/common/src/main/resources/db/changelog/v2026/add_int_lock_expired_after.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_int_lock_expired_after.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset system:add-int-lock-expired-after
+--preconditions onFail:MARK_RAN onError:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT count(*) FROM pg_tables WHERE tablename = 'int_lock' AND schemaname = current_schema()
+ALTER TABLE int_lock ADD COLUMN IF NOT EXISTS expired_after TIMESTAMP NOT NULL DEFAULT NOW();

--- a/common/src/test/java/gov/cms/ab2d/common/SpringBootAppTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/SpringBootAppTest.java
@@ -4,7 +4,7 @@ import gov.cms.ab2d.common.feign.ContractFeignClient;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;

--- a/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceFeignImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceFeignImplTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -32,7 +32,7 @@ class ContractServiceFeignImplTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @MockBean
+    @MockitoBean
     private ContractFeignClient contractFeignClient;
 
     @Autowired

--- a/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
+++ b/common/src/test/java/gov/cms/ab2d/common/service/ContractServiceImplTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -35,7 +35,7 @@ class ContractServiceImplTest {
     @Container
     private static final PostgreSQLContainer postgreSQLContainer= new AB2DPostgresqlContainer();
 
-    @MockBean
+    @MockitoBean
     private ContractFeignClient contractRepo;
 
     @Autowired

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DLocalstackContainer.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DLocalstackContainer.java
@@ -21,7 +21,9 @@ public class AB2DLocalstackContainer extends LocalStackContainer {
         System.setProperty("com.amazonaws.sdk.disableCertChecking", "");
         super.withServices(Service.SQS);
         super.start();
-        System.setProperty("AWS_SQS_URL",
-                "http://localhost:" + this.getMappedPort(EnabledService.named("SQS").getPort()));
+    }
+
+    public String getSqsEndpoint() {
+        return "http://localhost:" + this.getMappedPort(EnabledService.named("SQS").getPort());
     }
 }

--- a/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/AB2DSQSMockConfig.java
@@ -5,10 +5,10 @@ import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
@@ -21,10 +21,10 @@ public class AB2DSQSMockConfig {
     System.setProperty("feature.sqs.enabled", "false");
   }
 
-  @MockBean
+  @MockitoBean
   SqsAsyncClient amazonSQSAsync;
 
-  @MockBean
+  @MockitoBean
   SQSEventClient sQSEventClient;
 
    @Bean("mockAmazonSQS")

--- a/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/DataSetup.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Component
-@Import(ContractServiceTestConfig.class)
+@Import({ContractServiceTestConfig.class, LiquibaseTestConfig.class})
 public class DataSetup {
 
     @Autowired

--- a/common/src/test/java/gov/cms/ab2d/common/util/LiquibaseTestConfig.java
+++ b/common/src/test/java/gov/cms/ab2d/common/util/LiquibaseTestConfig.java
@@ -16,7 +16,9 @@ public class LiquibaseTestConfig {
     public SpringLiquibase testLiquibase(
             @Value("${spring.datasource.url}") String url,
             @Value("${spring.datasource.username}") String user,
-            @Value("${spring.datasource.password}") String pass
+            @Value("${spring.datasource.password}") String pass,
+            @Value("${spring.liquibase.default-schema:ab2d}") String defaultSchema,
+            @Value("${spring.liquibase.liquibase-schema:public}") String liquibaseSchema
     ) {
         HikariDataSource ds = new HikariDataSource();
         ds.setJdbcUrl(url);
@@ -26,6 +28,8 @@ public class LiquibaseTestConfig {
         SpringLiquibase lb = new SpringLiquibase();
         lb.setDataSource(ds);
         lb.setChangeLog("classpath:/db/changelog/db.changelog-master.yaml");
+        lb.setDefaultSchema(defaultSchema);
+        lb.setLiquibaseSchema(liquibaseSchema);
         lb.setShouldRun(true);
         return lb;
     }

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '4.0.6'
     id "org.sonarqube" version "7.3.0.8198"
     id 'maven-publish'
     id 'org.cyclonedx.bom' version '3.0.0' apply true
@@ -13,19 +13,19 @@ group = "gov.cms.ab2d"
 
 ext {
     lombokVersion = '1.18.38'
-    springCloudAwsVersion = '3.4.0'
-    springBootVersion='3.5.14'
+    springCloudAwsVersion = '4.0.0'
+    springBootVersion='4.0.6'
     testContainerVersion='1.21.4'
     liquibaseVersion = '5.0.0'
     eventClientVersion='3.3.14'
     contractClientVersion='2.2.0'
-    commonsLangVersion='3.18.0' // Spring Boot's commons-lang3 version is on 3.17.0; force version upgrade; Remove this property next time Spring Boot is updated
 }
 
 allprojects {
     apply plugin: "org.cyclonedx.bom"
     dependencies {
         implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+        testImplementation enforcedPlatform("org.testcontainers:testcontainers-bom:${testContainerVersion}")
         implementation "gov.cms.ab2d:ab2d-events-client:${eventClientVersion}"
         implementation "gov.cms.ab2d:ab2d-contracts-client:${contractClientVersion}"
         implementation "io.awspring.cloud:spring-cloud-aws:${springCloudAwsVersion}"
@@ -41,10 +41,10 @@ allprojects {
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-        implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
-        implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
         testImplementation 'org.mockito:mockito-core:5.16.1'
         testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+        testImplementation "org.springframework.boot:spring-boot-starter-webmvc-test:${springBootVersion}"
         testImplementation "org.testcontainers:localstack:${testContainerVersion}"
         testImplementation "org.testcontainers:postgresql:${testContainerVersion}"
         testImplementation "org.testcontainers:junit-jupiter:${testContainerVersion}"
@@ -53,19 +53,7 @@ allprojects {
         implementation(platform(annotationProcessor("org.projectlombok:lombok:${lombokVersion}")))
         annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
 
-        // remove these constraints on upgrade to Spring Boot >= 4.0.0
         constraints {
-            implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.55'
-            implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.55'
-            implementation 'io.netty:netty-codec:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http2:4.1.133.Final'
-            implementation 'io.netty:netty-codec-dns:4.1.133.Final'
-            implementation 'io.netty:netty-handler-proxy:4.1.133.Final'
-            implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.1.0'
-            implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.0'
-            implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0'
-            implementation 'org.jetbrains.kotlin:kotlin-stdlib-common:2.1.0'
             // commons-compress: test-only, pulled in by testcontainers 1.21.4.
             implementation 'org.apache.commons:commons-compress:1.28.0'
         }

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -35,6 +35,7 @@ allprojects {
         implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
         implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
         implementation 'org.postgresql:postgresql:42.7.11'
+        runtimeOnly "org.springframework.boot:spring-boot-properties-migrator:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-quartz:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-webflux:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -41,6 +41,8 @@ allprojects {
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
+        implementation "org.springframework.boot:spring-boot-persistence:${springBootVersion}"
+        implementation "org.springframework.boot:spring-boot-liquibase:${springBootVersion}"
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
         testImplementation 'org.mockito:mockito-core:5.16.1'
         testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"

--- a/contracts/src/main/java/gov/cms/ab2d/contracts/SpringBootApp.java
+++ b/contracts/src/main/java/gov/cms/ab2d/contracts/SpringBootApp.java
@@ -3,7 +3,7 @@ package gov.cms.ab2d.contracts;
 import gov.cms.ab2d.contracts.quartz.HPMSIngestQuartzSetup;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;

--- a/contracts/src/main/java/gov/cms/ab2d/contracts/config/OpenAPIConfig.java
+++ b/contracts/src/main/java/gov/cms/ab2d/contracts/config/OpenAPIConfig.java
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import lombok.extern.slf4j.Slf4j;
-import org.springdoc.core.GroupedOpenApi;
-import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,7 +17,7 @@ import static gov.cms.ab2d.contracts.config.SwaggerConstants.MAIN;
  *
  * {@link OpenAPI} - the base configuration for all versions of the API
  * {@link GroupedOpenApi} - one of these for each version of FHIR we support (V1 - STU3, V2 - R4)
- * {@link OpenApiCustomiser} - customize a {@link GroupedOpenApi} with default behavior
+ * {@link OpenApiCustomizer} - customize a {@link GroupedOpenApi} with default behavior
  */
 @Slf4j
 @Configuration

--- a/contracts/src/main/java/gov/cms/ab2d/contracts/controller/ErrorHandler.java
+++ b/contracts/src/main/java/gov/cms/ab2d/contracts/controller/ErrorHandler.java
@@ -68,6 +68,6 @@ public class ErrorHandler extends ResponseEntityExceptionHandler {
                 .message(ex.getMessage())
                 .path(request.getServletPath())
                 .timestamp(new java.util.Date())
-                .build(), null, status);
+                .build(), status);
     }
 }

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
@@ -9,7 +9,6 @@ import java.time.OffsetDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,9 +39,6 @@ class ContractControllerTest {
 
     @Autowired
     private ContractRepository contractRepository;
-
-    @MockitoBean
-    private SQSEventClient eventLogger;
 
     @Container
     private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new AB2DPostgresqlContainer();

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
@@ -4,6 +4,7 @@ import gov.cms.ab2d.contracts.SpringBootApp;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.contracts.repository.ContractRepository;
 import gov.cms.ab2d.contracts.util.AB2DPostgresqlContainer;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,9 @@ class ContractControllerTest {
 
     @Autowired
     private ContractRepository contractRepository;
+
+    @MockitoBean
+    private SQSEventClient eventLogger;
 
     @Container
     private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new AB2DPostgresqlContainer();

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/controller/ContractControllerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/controller/HealthcheckControllerTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/controller/HealthcheckControllerTest.java
@@ -5,7 +5,7 @@ import gov.cms.ab2d.contracts.util.AB2DPostgresqlContainer;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/service/ContractServiceTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/service/ContractServiceTest.java
@@ -17,9 +17,9 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Testcontainers

--- a/contracts/src/test/java/gov/cms/ab2d/contracts/service/HPMSMockedAuthTest.java
+++ b/contracts/src/test/java/gov/cms/ab2d/contracts/service/HPMSMockedAuthTest.java
@@ -22,7 +22,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.concurrent.CompletionException;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -97,7 +99,7 @@ class HPMSMockedAuthTest {
         // This is to test when HMPS is completely down so we don't get any response.
         try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
             client.authRequestTimeout(mockedWebClient, webClientStatic, nullBody);
-            assertThrows(RemoteTimeoutException.class, () -> authService.buildAuthHeaders(headers));
+            assertCausedBy(RemoteTimeoutException.class, () -> authService.buildAuthHeaders(headers));
         }
     }
 
@@ -105,8 +107,17 @@ class HPMSMockedAuthTest {
         HttpHeaders headers = new HttpHeaders();
         try (MockedStatic<WebClient> webClientStatic = Mockito.mockStatic(WebClient.class)) {
             client.authRequestError(mockedWebClient, webClientStatic, httpStatus, new HPMSAuthResponse());
-            assertThrows(WebClientResponseException.class, () -> authService.buildAuthHeaders(headers));
+            assertCausedBy(WebClientResponseException.class, () -> authService.buildAuthHeaders(headers));
         }
+    }
+
+    // spring wraps the original error in CompletionException.
+    private static void assertCausedBy(Class<? extends Throwable> expected, org.junit.jupiter.api.function.Executable executable) {
+        Throwable thrown = assertThrows(Throwable.class, executable);
+        if (thrown instanceof CompletionException && thrown.getCause() != null) {
+            thrown = thrown.getCause();
+        }
+        assertInstanceOf(expected, thrown);
     }
 
     @AfterEach

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/SpringBootCoverageTestApp.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/SpringBootCoverageTestApp.java
@@ -2,7 +2,7 @@ package gov.cms.ab2d.coverage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication(scanBasePackages = {

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/model/CoverageSearchTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/model/CoverageSearchTest.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/repository/CoverageServiceRepositoryTest.java
@@ -15,10 +15,14 @@ import gov.cms.ab2d.coverage.util.AB2DCoverageLocalstackContainer;
 import gov.cms.ab2d.coverage.util.AB2DCoveragePostgressqlContainer;
 import gov.cms.ab2d.coverage.util.CoverageDataSetup;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
@@ -47,6 +51,8 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 @SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @EntityScan(basePackages = {"gov.cms.ab2d.common.model", "gov.cms.ab2d.coverage.model"})
 @EnableJpaRepositories({"gov.cms.ab2d.common.repository", "gov.cms.ab2d.coverage.repository"})
 @Testcontainers

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/CoverageServiceExceptionTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/CoverageServiceExceptionTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/CoverageServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/CoverageServiceImplTest.java
@@ -44,7 +44,7 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.ApplicationContext;

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -30,6 +30,7 @@ allprojects {
     dependencies {
         implementation "com.squareup.okhttp3:okhttp:5.0.0"
         implementation "org.springframework.boot:spring-boot-starter:${springBootVersion}"
+        runtimeOnly "org.springframework.boot:spring-boot-properties-migrator:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-jdbc:${springBootVersion}"
         implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -42,6 +42,7 @@ allprojects {
 
         implementation "commons-codec:commons-codec:1.18.0"
         implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
+        implementation "org.springframework.boot:spring-boot-liquibase:${springBootVersion}"
         implementation "com.amazonaws:amazon-kinesis-client:1.15.3"
         implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:${jacksonVersion}"
         implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"

--- a/events/build.gradle
+++ b/events/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '4.0.6'
     id "org.sonarqube" version "7.3.0.8198"
     id 'maven-publish'
     id 'org.cyclonedx.bom' version '2.0.0' apply true
@@ -14,14 +14,14 @@ version="2.0.1"
 group = "gov.cms.ab2d"
 
 ext {
-    springBootVersion= '3.5.14'
-    springCloudAwsVersion = '3.4.0'
+    springBootVersion= '4.0.6'
+    springCloudAwsVersion = '4.0.0'
     liquibaseVersion='5.0.0'
     jacksonVersion='2.20.0'
     testContainerVersion='1.21.4'
     eventClientVersion='3.3.14'
     lombokVersion = '1.18.38'
-    commonsLangVersion='3.18.0' // // Spring Boot's commons-lang3 version is on 3.17.0; force version upgrade; Remove this property next time Spring Boot is updated
+    commonsLangVersion='3.18.0'
 }
 
 allprojects {
@@ -68,14 +68,6 @@ allprojects {
             implementation('org.apache.thrift:libthrift:0.23.0')
             implementation('org.bouncycastle:bcprov-jdk18on:1.84')
             implementation('org.bouncycastle:bcpkix-jdk18on:1.84')
-
-            // remove all below on upgrade to Spring Boot >= 4.0.0
-            implementation('org.apache.tomcat.embed:tomcat-embed-core:10.1.55')
-            implementation('org.apache.tomcat.embed:tomcat-embed-websocket:10.1.55')
-            implementation('io.netty:netty-codec:4.1.133.Final')
-            implementation('io.netty:netty-codec-http:4.1.133.Final')
-            implementation('io.netty:netty-codec-http2:4.1.133.Final')
-            implementation('io.netty:netty-codec-dns:4.1.133.Final')
             implementation('org.apache.commons:commons-compress:1.28.0')
         }
     }

--- a/events/src/test/java/gov/cms/ab2d/eventlogger/utils/AB2DLocalstackContainer.java
+++ b/events/src/test/java/gov/cms/ab2d/eventlogger/utils/AB2DLocalstackContainer.java
@@ -27,4 +27,10 @@ public class AB2DLocalstackContainer extends LocalStackContainer {
                         + this.getMappedPort(EnabledService.named("SQS").getPort())
                         + "/local-events-sqs");
     }
+
+    @Override
+    public void stop() {
+        // Survive across test classes so Spring 7's TestContext restart doesn't reconnect to a dead port.
+        // Ryuk reaps the container at JVM exit.
+    }
 }

--- a/events/src/test/java/gov/cms/ab2d/eventlogger/utils/SendAndReceiveSqsEventTest.java
+++ b/events/src/test/java/gov/cms/ab2d/eventlogger/utils/SendAndReceiveSqsEventTest.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -66,7 +66,7 @@ public class SendAndReceiveSqsEventTest {
     @Autowired
     private SqsAsyncClient amazonSQS;
 
-    @MockBean
+    @MockitoBean
     private LogManager logManager;
 
     @Autowired

--- a/idr-db-importer/build.gradle
+++ b/idr-db-importer/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
 	implementation 'org.bouncycastle:bcpkix-jdk18on:1.84'
 	implementation 'org.springframework.boot:spring-boot-starter'
+	runtimeOnly 'org.springframework.boot:spring-boot-properties-migrator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.retry:spring-retry'

--- a/idr-db-importer/build.gradle
+++ b/idr-db-importer/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	runtimeOnly 'org.springframework.boot:spring-boot-properties-migrator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-persistence'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.retry:spring-retry'
 	implementation 'org.postgresql:postgresql:42.7.11'

--- a/idr-db-importer/build.gradle
+++ b/idr-db-importer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.14'
+	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'org.sonarqube' version '7.3.0.8198'
 	id 'jacoco'
@@ -23,9 +23,6 @@ repositories {
 
 ext {
 	awssdkVersion = '2.41.5'
-	// Remove on upgrade to Spring Boot >= 4.0.0
-	set('tomcat.version', '10.1.55')
-	set('netty.version', '4.1.133.Final')
 }
 
 dependencies {

--- a/idr-db-importer/build.gradle
+++ b/idr-db-importer/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 	runtimeOnly 'org.springframework.boot:spring-boot-properties-migrator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-persistence'
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.retry:spring-retry'
 	implementation 'org.postgresql:postgresql:42.7.11'
 	compileOnly 'org.projectlombok:lombok'

--- a/idr-db-importer/src/main/java/gov/cms/ab2d/importer/SpringBootApp.java
+++ b/idr-db-importer/src/main/java/gov/cms/ab2d/importer/SpringBootApp.java
@@ -7,7 +7,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.retry.annotation.EnableRetry;
 

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-quartz</artifactId>
         </dependency>
         <dependency>

--- a/job/src/test/java/gov/cms/ab2d/job/JobTestSpringBootApp.java
+++ b/job/src/test/java/gov/cms/ab2d/job/JobTestSpringBootApp.java
@@ -4,7 +4,7 @@ import gov.cms.ab2d.common.feign.ContractFeignClient;
 import gov.cms.ab2d.common.util.AB2DSQSMockConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;

--- a/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/JobServiceTest.java
@@ -50,6 +50,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.TransactionSystemException;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -117,7 +118,7 @@ class JobServiceTest extends JobCleanup {
     @Autowired
     private ContractService contractService;
 
-    @Autowired
+    @MockitoBean
     private SQSEventClient sqsEventClient;
 
     @SuppressWarnings({"rawtypes", "unused"})

--- a/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
+++ b/job/src/test/java/gov/cms/ab2d/job/service/MaxJobsTest.java
@@ -5,6 +5,7 @@ import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.common.service.PdpClientService;
 import gov.cms.ab2d.common.util.AB2DPostgresqlContainer;
 import gov.cms.ab2d.common.util.DataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.job.JobTestSpringBootApp;
 import gov.cms.ab2d.job.dto.StartJobDTO;
 import gov.cms.ab2d.job.model.Job;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -53,6 +55,10 @@ class MaxJobsTest extends JobCleanup {
 
     @Autowired
     private DataSetup dataSetup;
+
+    @MockitoBean
+    @SuppressWarnings("unused")
+    private SQSEventClient sqsEventClient;
 
     private StartJobDTO startJobDTO;
 

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -72,15 +72,6 @@ subprojects {
 
     dependencies {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
-
-        // Remove on upgrade to Spring Boot >= 4.0.0
-        constraints {
-            implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.55'
-            implementation 'io.netty:netty-codec:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http2:4.1.133.Final'
-            implementation 'io.netty:netty-codec-dns:4.1.133.Final'
-        }
     }
     ext {
         //override this in subprojects using ext.set("zipName", '{new value}')

--- a/lambdas/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
+++ b/lambdas/optout/src/test/java/gov/cms/ab2d/optout/OptOutResultsTest.java
@@ -1,8 +1,8 @@
 package gov.cms.ab2d.optout;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OptOutResultsTest {
 

--- a/libs/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BFDSearchImplTest.java
+++ b/libs/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BFDSearchImplTest.java
@@ -16,8 +16,8 @@ import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SendSnsTest.java
+++ b/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SendSnsTest.java
@@ -13,8 +13,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.services.sns.SnsClient;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Testcontainers

--- a/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
+++ b/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
@@ -3,18 +3,9 @@ package gov.cms.ab2d.snsclient.config;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
-import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
-import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication(
-        scanBasePackages = {"gov.cms.ab2d.snsclient"},
-        exclude = {
-                DataSourceAutoConfiguration.class,
-                DataSourceTransactionManagerAutoConfiguration.class,
-                HibernateJpaAutoConfiguration.class}
-)
+@SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.snsclient"})
 public class SpringBootApp {
     public static void main(String[] args) {
         SpringApplication.run(SpringBootApp.class, args);

--- a/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
+++ b/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
@@ -5,7 +5,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication(scanBasePackages = {"gov.cms.ab2d.snsclient"})
+@SpringBootApplication(
+        scanBasePackages = {"gov.cms.ab2d.snsclient"},
+        excludeName = {
+                "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+                "org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration",
+                "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration"
+        }
+)
 public class SpringBootApp {
     public static void main(String[] args) {
         SpringApplication.run(SpringBootApp.class, args);

--- a/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
+++ b/libs/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SpringBootApp.java
@@ -3,9 +3,9 @@ package gov.cms.ab2d.snsclient.config;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication(

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -29,7 +29,7 @@ ext {
     eventClientVersion='3.3.14'
     propertiesClientVersion='2.1.1'
     contractClientVersion='2.2.0'
-    snsClientVersion='1.1.8'
+    snsClientVersion='1.1.9'
 
     sourcesRepo = 'ab2d-maven-repo'
     deployerRepo = 'ab2d-main'

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -37,8 +37,8 @@ ext {
 
     commonsLangVersion='3.18.0'
     lombokVersion = '1.18.38'
-    springBootVersion='3.5.14'
-    springCloudAwsVersion='3.4.0'
+    springBootVersion='4.0.6'
+    springCloudAwsVersion='4.0.0'
     hapiVersion = '8.4.0'
     ddTraceApiVersion='1.63.0'
     testContainerVersion='1.21.4'
@@ -156,16 +156,6 @@ subprojects {
         implementation(platform("org.testcontainers:junit-jupiter:$testContainerVersion"))
         implementation(platform("org.testcontainers:localstack:$testContainerVersion"))
         implementation(platform(annotationProcessor("org.projectlombok:lombok:$lombokVersion")))
-
-        // remove on upgrade to Spring Boot >= 4.0.0
-        constraints {
-            implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.55'
-            implementation 'org.apache.tomcat.embed:tomcat-embed-websocket:10.1.55'
-            implementation 'io.netty:netty-codec:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http:4.1.133.Final'
-            implementation 'io.netty:netty-codec-http2:4.1.133.Final'
-            implementation 'io.netty:netty-codec-dns:4.1.133.Final'
-        }
     }
 
     processResources {

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -39,7 +39,7 @@ ext {
     lombokVersion = '1.18.38'
     springBootVersion='4.0.6'
     springCloudAwsVersion='4.0.0'
-    hapiVersion = '8.4.0'
+    hapiVersion = '8.8.0'
     ddTraceApiVersion='1.63.0'
     testContainerVersion='1.21.4'
     mockServerVersion='5.15.0'

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <properties>
         <project.root>${basedir}</project.root>
         <java.version>25</java.version>
-        <hapi.version>8.4.0</hapi.version>
+        <hapi.version>8.8.0</hapi.version>
         <mockito.core.version>5.16.1</mockito.core.version>
         <okhttp3.version>5.0.0</okhttp3.version>
         <checkstyle.config>${project.root}/src/main/resources/checkstyle.xml</checkstyle.config>
         <logback-encoder.version>9.0</logback-encoder.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <newrelic.version>8.22.0</newrelic.version>
-        <spring-cloud-aws.version>3.4.0</spring-cloud-aws.version>
+        <spring-cloud-aws.version>4.0.0</spring-cloud-aws.version>
         <postgresql.version>42.7.11</postgresql.version>
         <kotlin.version>2.1.0</kotlin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>gov.cms.ab2d</groupId>
@@ -56,17 +56,17 @@
         <!-- Dependency versions -->
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-io.version>2.19.0</commons-io.version>
-
-        <!-- // Spring Boot's commons-lang3 version is on 3.17.0; force version upgrade; Remove this property next time Spring Boot is updated -->
-        <commons-lang3.version>3.18.0</commons-lang3.version>
-
-        <!-- remove these two overrides on upgrade to Spring Boot >= 4.0.0 -->
-        <tomcat.version>10.1.55</tomcat.version>
-        <netty.version>4.1.133.Final</netty.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.awspring.cloud</groupId>
+                <artifactId>spring-cloud-aws-dependencies</artifactId>
+                <version>${spring-cloud-aws.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- pin hapi-fhir-base -->
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-base</artifactId>
+                <version>${hapi.version}</version>
+            </dependency>
             <!-- patch for util
             todo: change when new HAPI release updates version natively
             -->

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-test</artifactId>
             <scope>test</scope>

--- a/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/SpringBootApp.java
@@ -6,7 +6,7 @@ import gov.cms.ab2d.worker.stuckjob.StuckJobQuartzSetup;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.annotation.Import;

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -89,7 +89,8 @@ logging.level.liquibase=WARN
 health.requiredSpareMemoryInMB=32
 health.urlsToCheck=http://www.google.com,http://www.facebook.com
 
-spring.autoconfigure.exclude[0]=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+spring.autoconfigure.exclude[0]=org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration
+spring.autoconfigure.exclude[1]=org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration
 
 ## ---------------------------------------------------------------------------- BFD Health Check
 bfd.health.check.schedule=*/15 * * * * ?

--- a/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
@@ -10,7 +10,11 @@ import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +33,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = SpringBootApp.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @Testcontainers
 @Import(AB2DSQSMockConfig.class)
 public class BFDHealthCheckTest {

--- a/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/bfdhealthcheck/BFDHealthCheckTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -47,7 +48,7 @@ public class BFDHealthCheckTest {
     @Mock
     private BFDClient bfdClient;
 
-    @Autowired
+    @MockitoBean
     private SQSEventClient logManager;
 
     @Autowired

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/AggregatorJobTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/AggregatorJobTest.java
@@ -32,8 +32,12 @@ import java.util.concurrent.TimeUnit;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -54,6 +58,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @Testcontainers
 @Import(AB2DSQSMockConfig.class)
 class AggregatorJobTest {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -33,6 +33,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -93,6 +95,11 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
 
     @BeforeEach
     void setUp() {

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobProcessorIntegrationTest.java
@@ -58,6 +58,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.integration.test.context.SpringIntegrationTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -175,6 +177,12 @@ class JobProcessorIntegrationTest extends JobCleanup {
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
+
     private static final ExplanationOfBenefit EOB = (ExplanationOfBenefit) EobTestDataUtil.createEOB();
 
     private Contract contract;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageCheckIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageCheckIntegrationTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -53,6 +55,11 @@ public class CoverageCheckIntegrationTest {
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
 
     @Autowired
     private ContractServiceStub contractServiceStub;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -7,6 +7,7 @@ import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.common.dto.PdpClientDTO;
 import gov.cms.ab2d.contracts.model.Contract;
 import gov.cms.ab2d.common.model.PdpClient;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.model.JobStatus;
@@ -49,6 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -120,6 +122,9 @@ class CoverageDriverTest extends JobCleanup {
 
     @Autowired
     private PdpClientService pdpClientService;
+
+    @MockitoBean
+    private SQSEventClient sqsEventClient;
 
     private PropertyServiceStub propertiesService = new PropertyServiceStub();
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageDriverTest.java
@@ -29,6 +29,7 @@ import gov.cms.ab2d.job.service.JobCleanup;
 import gov.cms.ab2d.common.properties.PropertyServiceStub;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import gov.cms.ab2d.worker.service.ContractWorkerClient;
+import java.sql.Timestamp;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -135,6 +137,9 @@ class CoverageDriverTest extends JobCleanup {
 
     @Autowired
     private CoverageSnapshotService snapshotService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private Contract contract;
     private Contract contract1;
@@ -768,12 +773,16 @@ class CoverageDriverTest extends JobCleanup {
         CoverageSearchEvent event = new CoverageSearchEvent();
         event.setCoveragePeriod(period);
         event.setNewStatus(status);
-        event.setCreated(created);
         event.setDescription("testing");
 
         event = coverageSearchEventRepo.saveAndFlush(event);
+
+        // Hibernate 7 treats @CreationTimestamp fields as immutable; bypass JPA via JDBC so
+        // tests can backdate the event for stuck-job / staleness scenarios.
+        jdbcTemplate.update(
+                "UPDATE event_bene_coverage_search_status_change SET created = ? WHERE id = ?",
+                Timestamp.from(created.toInstant()), event.getId());
         event.setCreated(created);
-        coverageSearchEventRepo.saveAndFlush(event);
 
         return event;
     }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorIntTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageProcessorIntTest.java
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -37,6 +39,11 @@ class CoverageProcessorIntTest {
 
     @Container
     private static final AB2DLocalstackContainer LOCALSTACK_CONTAINER = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", LOCALSTACK_CONTAINER::getSqsEndpoint);
+    }
 
     @Autowired
     private ContractServiceStub contractServiceStub;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -17,6 +17,7 @@ import gov.cms.ab2d.coverage.repository.CoverageSearchRepository;
 import gov.cms.ab2d.coverage.service.CoverageService;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.coverage.util.CoverageDataSetup;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import gov.cms.ab2d.worker.service.ContractWorkerClient;
@@ -43,6 +44,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -109,6 +111,9 @@ class CoverageUpdateAndProcessorTest {
 
     @Autowired
     private CoverageV3Service coverageV3Service;
+
+    @MockitoBean
+    private SQSEventClient sqsEventClient;
 
     private PropertyServiceStub propertiesService = new PropertyServiceStub();
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/CoverageUpdateAndProcessorTest.java
@@ -22,6 +22,7 @@ import gov.cms.ab2d.worker.config.ContractToContractCoverageMapping;
 import gov.cms.ab2d.worker.service.ContractWorkerClient;
 import gov.cms.ab2d.worker.service.coveragesnapshot.CoverageSnapshotService;
 import gov.cms.ab2d.worker.util.WorkerDataSetup;
+import java.sql.Timestamp;
 import java.time.DayOfWeek;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -40,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -124,6 +126,9 @@ class CoverageUpdateAndProcessorTest {
 
     @Autowired
     private CoverageSnapshotService snapshotService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private Contract contract;
     private CoveragePeriod january;
@@ -656,12 +661,16 @@ class CoverageUpdateAndProcessorTest {
         CoverageSearchEvent event = new CoverageSearchEvent();
         event.setCoveragePeriod(period);
         event.setNewStatus(status);
-        event.setCreated(created);
         event.setDescription("testing");
 
         event = coverageSearchEventRepo.saveAndFlush(event);
+
+        // Hibernate 7 treats @CreationTimestamp fields as immutable; bypass JPA via JDBC so
+        // tests can backdate the event for stuck-job / staleness scenarios.
+        jdbcTemplate.update(
+                "UPDATE event_bene_coverage_search_status_change SET created = ? WHERE id = ?",
+                Timestamp.from(created.toInstant()), event.getId());
         event.setCreated(created);
-        coverageSearchEventRepo.saveAndFlush(event);
 
         return event;
     }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/coverage/check/CoverageCheckPredicatesIntegrationTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -51,6 +53,11 @@ public class CoverageCheckPredicatesIntegrationTest {
 
     @Container
     private static final AB2DLocalstackContainer localstackContainer = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", localstackContainer::getSqsEndpoint);
+    }
 
     @Autowired
     private CoverageSearchRepository coverageSearchRepo;

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/coveragesnapshot/CoverageSnapshotTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/coveragesnapshot/CoverageSnapshotTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -68,7 +68,7 @@ class CoverageSnapshotTest {
     @Autowired
     CoverageSearchRepository coverageSearchRepo;
 
-    @SpyBean
+    @MockitoSpyBean
     CoverageServiceRepository coverageServiceRepo;
     @Autowired
     CoverageService coverageService;

--- a/worker/src/test/java/gov/cms/ab2d/worker/service/coveragesnapshot/CoverageSnapshotTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/service/coveragesnapshot/CoverageSnapshotTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.context.annotation.Import;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -54,6 +56,11 @@ class CoverageSnapshotTest {
 
     @Container
     private static final AB2DLocalstackContainer LOCALSTACK_CONTAINER = new AB2DLocalstackContainer();
+
+    @DynamicPropertySource
+    static void sqsProps(DynamicPropertyRegistry registry) {
+        registry.add("AWS_SQS_URL", LOCALSTACK_CONTAINER::getSqsEndpoint);
+    }
 
     @Autowired
     CoverageSnapshotService coverageSnapshotService;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7306

## 🛠 Changes

This PR mostly changes dependency/library versions, changes import paths to their new locations, and updates some test code to work with changes in Spring 4. 

Some of the more substantive changes:

- ResponseEntity now drops the "null" and uses a different constructor
- AWS_SQS_URL is now set dynamically for tests that need it
- Liquibase migration to add new required column to int_lock

## ℹ️ Context

The upgrade to spring boot 4 brings with it access to new features, increased performance, and increased security. 

## 🧪 Validation

successful job run and deployment workflows, local test success
