### PR TITLE
AB2D-7299  Release ab2d-bfd library without newrelic-api

### DIFF
--- a/libs/ab2d-bfd/build.gradle
+++ b/libs/ab2d-bfd/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:${hapiVersion}"
     implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-r4:${hapiVersion}"
     implementation "org.springframework.retry:spring-retry:2.0.8"
-    implementation "com.newrelic.agent.java:newrelic-api:${newRelicVersion}"
+    implementation "com.datadoghq:dd-trace-api:${ddTraceApiVersion}"
     testImplementation "org.testcontainers:testcontainers:${testContainerVersion}"
     testImplementation "org.testcontainers:postgresql:${testContainerVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testContainerVersion}"

--- a/libs/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/libs/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -3,9 +3,7 @@ package gov.cms.ab2d.bfd.client;
 import ca.uhn.fhir.rest.gclient.TokenClientParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import com.newrelic.api.agent.NewRelic;
-import com.newrelic.api.agent.Segment;
-import com.newrelic.api.agent.Trace;
+import datadog.trace.api.Trace;
 import gov.cms.ab2d.fhir.FhirVersion;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -72,7 +70,7 @@ public class BFDClientImpl implements BFDClient {
      * objects
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
-    @Trace
+    @Trace(operationName = "ab2d.bfd.client.request_eob_from_server")
     @Override
     @Retryable(
             maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",
@@ -97,7 +95,7 @@ public class BFDClientImpl implements BFDClient {
      * objects
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
-    @Trace
+    @Trace(operationName = "ab2d.bfd.client.request_eob_from_server")
     @SneakyThrows
     @Override
     @Retryable(
@@ -106,18 +104,25 @@ public class BFDClientImpl implements BFDClient {
             exclude = { ResourceNotFoundException.class }
     )
     public IBaseBundle requestEOBFromServer(FhirVersion version, long patientID, OffsetDateTime sinceTime, OffsetDateTime untilTime, List<String> serviceDates, String contractNum) {
-            final Segment bfdSegment = NewRelic.getAgent().getTransaction().startSegment("BFD Call for patient with patient ID " + patientID +
-                    " using since " + sinceTime + " and until " + untilTime + " and serviceDates " + serviceDates);
-        bfdSegment.setMetricName("RequestEOB");
-
         BFDSearchDTO bfdSearchDTO = new BFDSearchDTO(patientID, version, contractNum, getJobId(), pageSize, sinceTime, untilTime, serviceDates);
-        IBaseBundle result = bfdSearch.searchEOB(bfdSearchDTO);
-        bfdSegment.end();
-
-        return result;
+        return callBFD(bfdSearchDTO);
     }
 
-    @Trace
+    /**
+     * Performs the timed call to BFD for a patient's Explanation of Benefit data.
+     * <p>
+     * Extracted into its own method so that the Datadog tracer surfaces it as a
+     * dedicated {@code ab2d.bfd.call} span (the former New Relic {@code RequestEOB}
+     * segment). The tracer handles span nesting automatically, so no manual
+     * start/end bookkeeping is required.
+     */
+    @Trace(operationName = "ab2d.bfd.call")
+    @SneakyThrows
+    private IBaseBundle callBFD(BFDSearchDTO bfdSearchDTO) {
+        return bfdSearch.searchEOB(bfdSearchDTO);
+    }
+
+    @Trace(operationName = "ab2d.bfd.client.request_eob_from_server_raw")
     @SneakyThrows
     @Retryable(
             maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",
@@ -136,7 +141,7 @@ public class BFDClientImpl implements BFDClient {
         return bfdSearch.parseBundle(version, bfdResponse);
     }
 
-    @Trace
+    @Trace(operationName = "ab2d.bfd.client.request_next_bundle_from_server")
     @Override
     @Retryable(
             maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",
@@ -163,7 +168,7 @@ public class BFDClientImpl implements BFDClient {
         return jobId;
     }
 
-    @Trace
+    @Trace(operationName = "ab2d.bfd.client.request_part_d_enrollees_from_server")
     @Override
     @Retryable(
             maxAttemptsExpression = "${bfd.retry.maxAttempts:3}",

--- a/libs/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDSearchImpl.java
+++ b/libs/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDSearchImpl.java
@@ -1,7 +1,7 @@
 package gov.cms.ab2d.bfd.client;
 
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import com.newrelic.api.agent.Trace;
+import datadog.trace.api.Trace;
 import gov.cms.ab2d.fhir.FhirVersion;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHeaders;
@@ -46,7 +46,7 @@ public class BFDSearchImpl implements BFDSearch {
      * @return a bundle of eobs for the patient.
      * @throws IOException on failure to retrieve claims from BFD
      */
-    @Trace
+    @Trace(operationName = "ab2d.bfd.search")
     @Override
     public IBaseBundle searchEOB(BFDSearchDTO searchDTO) throws IOException {
         return parseBundle(
@@ -112,9 +112,9 @@ public class BFDSearchImpl implements BFDSearch {
 
 
     /**
-     * Method exists to track connection to BFD for New Relic
+     * Method exists to track connection to BFD for Datadog
      */
-    @Trace
+    @Trace(operationName = "ab2d.bfd.call")
     private byte[] getEOBSFromBFD(long patientId, HttpGet request) throws IOException {
         byte[] responseBytes;
         try (CloseableHttpResponse response = (CloseableHttpResponse) httpClient.execute(request)) {
@@ -136,7 +136,7 @@ public class BFDSearchImpl implements BFDSearch {
         return responseBytes;
     }
 
-    @Trace
+    @Trace(operationName = "ab2d.bfd.parse_bundle")
     @Override
     public IBaseBundle parseBundle(FhirVersion version, byte[] responseBytes) {
         return version.getJsonParser().parseResource(version.getBundleClass(), new ByteArrayInputStream(responseBytes));

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -23,7 +23,7 @@ ext {
 
     // AB2D libraries
     fhirVersion='2.5.6'
-    bfdVersion='4.7.0'
+    bfdVersion='4.8.0'
     aggregatorVersion='2.1.5'
     filtersVersion='3.1.2'
     eventClientVersion='3.3.14'
@@ -40,7 +40,7 @@ ext {
     springBootVersion='3.5.14'
     springCloudAwsVersion='3.4.0'
     hapiVersion = '8.4.0'
-    newRelicVersion='8.4.0'
+    ddTraceApiVersion='1.63.0'
     testContainerVersion='1.21.4'
     mockServerVersion='5.15.0'
     liquibaseVersion="5.0.0"
@@ -151,7 +151,6 @@ subprojects {
 
     dependencies {
         implementation(platform("org.liquibase:liquibase-core:$liquibaseVersion"))
-        implementation(platform("com.newrelic.agent.java:newrelic-api:$newRelicVersion"))
         implementation(platform("org.testcontainers:testcontainers:$testContainerVersion"))
         implementation(platform("org.testcontainers:postgresql:$testContainerVersion"))
         implementation(platform("org.testcontainers:junit-jupiter:$testContainerVersion"))


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7299

## 🛠 Changes

- Replaced @Trace in BFDClientImpl (lines 75, 100, 120, 147) and BFDSearchImpl (lines 49, 109, 129) with @datadog.trace.api.Trace(operationName = "ab2d.bfd.<verb>").
- Converted the Segment block by extracting it into a method annotated @Trace(operationName = "ab2d.bfd.call").
- Dropped newrelic-api from libs/build.gradle and libs/ab2d-bfd/build.gradle.

## ℹ️ Context

The ab2d-bfd library should be traced with Datadog annotations instead of New Relic so that downstream services can consume a BFD library that no longer depends on newrelic-api.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
