### PR TITLE
AB2D-7303  AB2D/AB2D-Libs/Infra: Decommission NewRelic

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -97,20 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-java</artifactId>
-            <version>${newrelic.version}</version>
-            <scope>provided</scope>
-            <type>zip</type>
-        </dependency>
-
-        <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-api</artifactId>
-            <version>${newrelic.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>dd-trace-api</artifactId>
             <version>${dd-trace-api.version}</version>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -49,12 +49,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-api</artifactId>
-            <version>${newrelic.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,6 @@ services:
       - AB2D_DB_PASSWORD=ab2d
       # Location to store file within container
       - AB2D_EFS_MOUNT=/opt/ab2d
-      - NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}"
-      - NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME}"
       # LOCAL always to shut off Kinesis logging
       - AB2D_EXECUTION_ENV=${AB2D_EXECUTION_ENV:-local}
       - AB2D_V2_ENABLED=${AB2D_V2_ENABLED}
@@ -107,8 +105,6 @@ services:
       - AB2D_BFD_URL=https://prod-sbx.bfd.cms.gov
       - AB2D_BFD_KEYSTORE_PASSWORD=${AB2D_BFD_KEYSTORE_PASSWORD}
       - AB2D_BFD_KEYSTORE_LOCATION=${AB2D_BFD_KEYSTORE_LOCATION}
-      - NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}"
-      - NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME}"
       # Cert used to prove that keystore app has rights to bfd sandbox
       - AB2D_KEYSTORE_LOCATION=${AB2D_KEYSTORE_LOCATION}
       - AB2D_KEYSTORE_PASSWORD=${AB2D_KEYSTORE_PASSWORD}

--- a/local-dev/up.sh
+++ b/local-dev/up.sh
@@ -12,9 +12,6 @@ API_URL="https://localhost:${API_PORT:-8443}"
 MOCK_URL="http://localhost:9999"
 
 export API_PORT="${API_PORT:-8443}"
-# will be empty for local
-export NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY:-}"
-export NEW_RELIC_APP_NAME="${NEW_RELIC_APP_NAME:-local}"
 export AB2D_KEYSTORE_LOCATION="${AB2D_KEYSTORE_LOCATION:-}"
 export AB2D_KEYSTORE_PASSWORD="${AB2D_KEYSTORE_PASSWORD:-}"
 export AB2D_KEY_ALIAS="${AB2D_KEY_ALIAS:-}"

--- a/ops/services/10-config/values/ephemeral.yaml
+++ b/ops/services/10-config/values/ephemeral.yaml
@@ -1,5 +1,4 @@
 copy:
-  - /ab2d/${env}/common/sensitive/new_relic_license_key
   - /ab2d/${env}/common/sensitive/slack_alert_webhooks
   - /ab2d/${env}/common/sensitive/slack_trace_webhooks
   - /ab2d/${env}/core/nonsensitive/database_name
@@ -20,5 +19,4 @@ copy:
   - /ab2d/${env}/worker/nonsensitive/bfd_v3_truststore_cert
   - /ab2d/${env}/api/sensitive/tls_private_key
   - /ab2d/${env}/api/nonsensitive/tls_public_cert
-values:
-  /ab2d/${env}/common/nonsensitive/new_relic_app_name: "AB2D_${env}"
+values: {}

--- a/ops/services/20-contracts/main.tf
+++ b/ops/services/20-contracts/main.tf
@@ -292,11 +292,6 @@ module "contracts_service" {
       "readOnly"      = false
     },
     {
-      "containerPath" = "/newrelic/logs",
-      "sourceVolume"  = "newrelic_logs",
-      "readOnly"      = false
-    },
-    {
       "containerPath" = "/var/log",
       "sourceVolume"  = "var_log",
       "readOnly"      = false
@@ -316,10 +311,6 @@ module "contracts_service" {
     {
       configure_at_launch = false
       name                = "tmp"
-    },
-    {
-      configure_at_launch = false
-      name                = "newrelic_logs"
     },
     {
       configure_at_launch = false

--- a/ops/services/20-events/main.tf
+++ b/ops/services/20-events/main.tf
@@ -217,11 +217,6 @@ module "events_service" {
       "readOnly"      = false
     },
     {
-      "containerPath" = "/newrelic/logs",
-      "sourceVolume"  = "newrelic_logs",
-      "readOnly"      = false
-    },
-    {
       "containerPath" = "/var/log",
       "sourceVolume"  = "var_log",
       "readOnly"      = false
@@ -241,10 +236,6 @@ module "events_service" {
     {
       configure_at_launch = false
       name                = "tmp"
-    },
-    {
-      configure_at_launch = false
-      name                = "newrelic_logs"
     },
     {
       configure_at_launch = false

--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -70,8 +70,6 @@ locals {
   kms_master_key_id            = nonsensitive(module.platform.kms_alias_primary.target_key_arn)
   microservices_url            = lookup(module.platform.ssm.microservices, "url", { value : "none" }).value
   network_access_logs_bucket   = module.platform.splunk_logging_bucket.bucket
-  new_relic_app_name           = module.platform.ssm.common.new_relic_app_name.value
-  new_relic_license_key_arn    = nonsensitive(module.platform.ssm.common.new_relic_license_key.arn)
   private_subnet_ids           = keys(module.platform.private_subnets)
   public_subnet_ids            = keys(module.platform.public_subnets)
   slack_alert_webhooks_arn     = nonsensitive(module.platform.ssm.common.slack_alert_webhooks.arn)
@@ -269,7 +267,6 @@ module "service" {
     { name = "AB2D_V3_ENABLED", value = "true" },
     { name = "AWS_SQS_FEATURE_FLAG", value = "true" },
     { name = "AWS_SQS_URL", value = data.aws_sqs_queue.events.url }, #FIXME: Is this even used?
-    { name = "NEW_RELIC_APP_NAME", value = local.new_relic_app_name },
     { name = "MICROSERVICES_URL", value = local.microservices_url },
   ]
   container_secrets = [
@@ -284,7 +281,6 @@ module "service" {
     { name = "AB2D_SLACK_TRACE_WEBHOOKS", valueFrom = local.slack_trace_webhooks_arn }, #FIXME: Is this even used?
     { name = "HPMS_AUTH_KEY_ID", valueFrom = local.hpms_auth_key_id_arn },              #FIXME: Is this even used?
     { name = "HPMS_AUTH_KEY_SECRET", valueFrom = local.hpms_auth_key_secret_arn },      #FIXME: Is this even used?
-    { name = "NEW_RELIC_LICENSE_KEY", valueFrom = local.new_relic_license_key_arn },    #FIXME: Is this even used?
   ]
   mount_points = [
     {
@@ -294,10 +290,6 @@ module "service" {
     {
       "containerPath" = "/tmp",
       "sourceVolume"  = "tmp",
-    },
-    {
-      "containerPath" = "/newrelic/logs",
-      "sourceVolume"  = "newrelic_logs",
     },
     {
       "containerPath" = "/var/log",
@@ -318,9 +310,6 @@ module "service" {
     },
     {
       name = "tmp"
-    },
-    {
-      name = "newrelic_logs"
     },
     {
       name = "var_log"

--- a/ops/services/30-worker/main.tf
+++ b/ops/services/30-worker/main.tf
@@ -70,15 +70,13 @@ locals {
   max_concurrent_eob_jobs    = "2"
   worker_desired_instances   = 1
 
-  ab2d_db_host              = data.aws_rds_cluster.this.endpoint
-  db_name_arn               = nonsensitive(module.platform.ssm.core.database_name.arn)
-  db_password_arn           = nonsensitive(module.platform.ssm.core.database_password.arn)
-  db_username_arn           = nonsensitive(module.platform.ssm.core.database_user.arn)
-  contracts_url             = module.platform.ssm.contracts.url.value
-  new_relic_app_name        = module.platform.ssm.common.new_relic_app_name.value
-  new_relic_license_key_arn = nonsensitive(module.platform.ssm.common.new_relic_license_key.arn)
-  slack_alert_webhooks_arn  = nonsensitive(module.platform.ssm.common.slack_alert_webhooks.arn)
-  slack_trace_webhooks_arn  = nonsensitive(module.platform.ssm.common.slack_trace_webhooks.arn)
+  ab2d_db_host             = data.aws_rds_cluster.this.endpoint
+  db_name_arn              = nonsensitive(module.platform.ssm.core.database_name.arn)
+  db_password_arn          = nonsensitive(module.platform.ssm.core.database_password.arn)
+  db_username_arn          = nonsensitive(module.platform.ssm.core.database_user.arn)
+  contracts_url            = module.platform.ssm.contracts.url.value
+  slack_alert_webhooks_arn = nonsensitive(module.platform.ssm.common.slack_alert_webhooks.arn)
+  slack_trace_webhooks_arn = nonsensitive(module.platform.ssm.common.slack_trace_webhooks.arn)
 
   # Use the provided image tag or get the first, human-readable image tag, favoring a tag with 'latest' in its name if it should exist.
   worker_image_repo = split("@", data.aws_ecr_image.worker.image_uri)[0]
@@ -156,7 +154,6 @@ module "service" {
     { name = "AWS_SQS_URL", value = data.aws_sqs_queue.events.url },
     { name = "AWS_SNS_TOPIC_PREFIX", value = "ab2d-${local.parent_env}" },
     { name = "IMAGE_VERSION", value = local.worker_image_tag },
-    { name = "NEW_RELIC_APP_NAME", value = local.new_relic_app_name },
     { name = "MICROSERVICES_URL", value = local.contracts_url }
   ]
 
@@ -169,8 +166,7 @@ module "service" {
     { name = "AB2D_DB_PASSWORD", valueFrom = local.db_password_arn },
     { name = "AB2D_DB_USER", valueFrom = local.db_username_arn },
     { name = "AB2D_SLACK_ALERT_WEBHOOKS", valueFrom = local.slack_alert_webhooks_arn }, #FIXME: Is this even used?
-    { name = "AB2D_SLACK_TRACE_WEBHOOKS", valueFrom = local.slack_trace_webhooks_arn }, #FIXME: Is this even used?
-    { name = "NEW_RELIC_LICENSE_KEY", valueFrom = local.new_relic_license_key_arn }     #FIXME: Is this even used?
+    { name = "AB2D_SLACK_TRACE_WEBHOOKS", valueFrom = local.slack_trace_webhooks_arn }  #FIXME: Is this even used?
   ]
 
   mount_points = [
@@ -181,11 +177,6 @@ module "service" {
     {
       "containerPath" = "/tmp",
       "sourceVolume"  = "tmp",
-      "readOnly"      = false
-    },
-    {
-      "containerPath" = "/newrelic/logs",
-      "sourceVolume"  = "newrelic_logs",
       "readOnly"      = false
     },
     {
@@ -209,9 +200,6 @@ module "service" {
     },
     {
       name = "tmp"
-    },
-    {
-      name = "newrelic_logs"
     },
     {
       name = "var_logs"

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <checkstyle.config>${project.root}/src/main/resources/checkstyle.xml</checkstyle.config>
         <logback-encoder.version>9.0</logback-encoder.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <newrelic.version>8.22.0</newrelic.version>
         <dd.java.agent.version>1.63.0</dd.java.agent.version>
         <dd-trace-api.version>1.63.0</dd-trace-api.version>
         <dogstatsd-client.version>4.4.5</dogstatsd-client.version>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -126,16 +126,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Kept at compile scope until the source migration (separate ticket) removes the
-             runtime com.newrelic.api.agent.* calls (e.g. Insights.recordCustomEvent, Transaction
-             tokens). Dropping it from the fat jar now would cause NoClassDefFoundError at runtime
-             once the New Relic agent is no longer attached. -->
-        <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-api</artifactId>
-            <version>${newrelic.version}</version>
-        </dependency>
-
         <!-- DogStatsD client for emitting Datadog custom metrics. -->
         <dependency>
             <groupId>com.datadoghq</groupId>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7303

## 🛠 Changes

- Removed NewRelic dependencies and updated terraform to decommission NewRelic 

## ℹ️ Context

All remaining New Relic configuration, dependencies, and secrets should be removed so that New Relic is fully retired and no longer incurs cost or risk after the Datadog migration.

## 🧪 Validation

Unit, integration and e2e passed in test environment
