### PR TITLE
AB2D-7303 Added the three DD_* disable env vars to container_environment

### DIFF
--- a/ops/services/30-api/main.tf
+++ b/ops/services/30-api/main.tf
@@ -268,6 +268,9 @@ module "service" {
     { name = "AWS_SQS_FEATURE_FLAG", value = "true" },
     { name = "AWS_SQS_URL", value = data.aws_sqs_queue.events.url }, #FIXME: Is this even used?
     { name = "MICROSERVICES_URL", value = local.microservices_url },
+    { name = "DD_DYNAMIC_INSTRUMENTATION_ENABLED", value = "false" },
+    { name = "DD_EXCEPTION_REPLAY_ENABLED", value = "false" },
+    { name = "DD_CODE_ORIGIN_FOR_SPANS_ENABLED", value = "false" },
   ]
   container_secrets = [
     { name = "AB2D_DB_DATABASE", valueFrom = local.db_name_arn },

--- a/ops/services/30-worker/main.tf
+++ b/ops/services/30-worker/main.tf
@@ -154,7 +154,10 @@ module "service" {
     { name = "AWS_SQS_URL", value = data.aws_sqs_queue.events.url },
     { name = "AWS_SNS_TOPIC_PREFIX", value = "ab2d-${local.parent_env}" },
     { name = "IMAGE_VERSION", value = local.worker_image_tag },
-    { name = "MICROSERVICES_URL", value = local.contracts_url }
+    { name = "MICROSERVICES_URL", value = local.contracts_url },
+    { name = "DD_DYNAMIC_INSTRUMENTATION_ENABLED", value = "false" },
+    { name = "DD_EXCEPTION_REPLAY_ENABLED", value = "false" },
+    { name = "DD_CODE_ORIGIN_FOR_SPANS_ENABLED", value = "false" }
   ]
 
   container_secrets = [


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7303

## 🛠 Changes

added the three DD_* disable env vars to container_environment 

## ℹ️ Context

We would like to disable datadog debugging logs on the api and worker containers

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
