### PR TITLE
AB2D-7326 add kms access to idr importer

### DIFF
--- a/ops/services/10-core/iam.tf
+++ b/ops/services/10-core/iam.tf
@@ -238,6 +238,12 @@ resource "aws_iam_role_policy_attachment" "idr_db_importer_task_execution" {
   policy_arn = aws_iam_policy.idr_db_importer_task_execution.arn
 }
 
+
+resource "aws_iam_role_policy_attachment" "idr_kms" {
+  role       = aws_iam_role.idr_db_importer_task_execution.name
+  policy_arn = aws_iam_policy.kms_key_access.arn
+}
+
 resource "aws_iam_role" "idr_db_importer_task" {
   permissions_boundary = data.aws_iam_policy.developer_boundary_policy.arn
   name                 = "${local.service_prefix}-idr-db-importer-task"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7326

## 🛠 Changes

Adds KMS:Decrypt permissions to IDR DB importer task execution role. 

## ℹ️ Context

This change was manually made and never replicated in the terraform code, meaning when `10-core` was applied, it was wiped out.

## 🧪 Validation

Applied in TEST
