### PR TITLE
AB2D-7348 Add Datadog Tracing to V3 Coverage and IDR Importer

### DIFF
--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3ServiceImpl.java
@@ -1,24 +1,22 @@
 package gov.cms.ab2d.coverage.service.v3;
 
+import datadog.trace.api.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.*;
-import gov.cms.ab2d.coverage.model.v3.CoverageV3Count;
 import gov.cms.ab2d.coverage.model.v3.CoverageV3Periods;
 import gov.cms.ab2d.coverage.query.*;
 import gov.cms.ab2d.coverage.repository.CoverageServiceRepository;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -49,8 +47,11 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
     }
 
     @Override
+    @Trace(operationName = "ab2d.coverage.page_v3")
     public CoveragePagingResult pageCoverage(final CoveragePagingRequest page) {
         final ContractForCoverageDTO contract = page.getContract();
+        DatadogSpans.setTag("contract", contract.getContractNumber());
+        DatadogSpans.setTag("component", "coverage");
 
         // For v3, perform coverage periods check only once (expected vs actual coverage periods) instead for every batch
         // on subsequent batches, page.getCursor() will be populated -- only on first batch will it be absent
@@ -78,6 +79,7 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
 
         val beneficiarySummaries = queryAggregatedCoverageMembership(page, page.getPageSize());
         val beneficiaryRecordsFetched = beneficiarySummaries.size();
+        DatadogSpans.setMetric("coverage.v3.beneficiary_records_fetched", beneficiaryRecordsFetched);
         log.info("[V3] beneficiary summary records fetched = {}", beneficiaryRecordsFetched);
 
         if (LOG_ROWS_FETCHED) {
@@ -103,7 +105,10 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
 
 
     @Override
+    @Trace(operationName = "ab2d.coverage.get_coverage_periods_v3")
     public Map<String, List<YearMonthRecord>> getCoveragePeriods(List<ContractDTO> contracts) {
+        DatadogSpans.setTag("component", "coverage");
+        DatadogSpans.setMetric("coverage.v3.contract_count", contracts.size());
         val result = new HashMap<String, List<YearMonthRecord>>();
         val template = new NamedParameterJdbcTemplate(dataSource);
         val query =
@@ -137,7 +142,10 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
     }
 
     @Override
+    @Trace(operationName = "ab2d.coverage.create_aggregated_table_v3")
     public void createAggregatedAttributionTable(String contract) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
         new GetAggregatedCoverageMembership(dataSource).createAggregatedAttributionTable(contract);
     }
 
@@ -228,18 +236,27 @@ public class CoverageV3ServiceImpl implements CoverageV3Service {
 
     @Override
     @Transactional
+    @Trace(operationName = "ab2d.coverage.move_from_staging_v3")
     public CoverageV3SyncResult moveFromStagingToRecentCoverage(String contract, CoverageV3SyncSource source) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
         return coverageV3SyncService.copyFromStagingTablesToRecent(contract, source);
     }
 
     @Override
     @Transactional
+    @Trace(operationName = "ab2d.coverage.move_to_historical_v3")
     public CoverageV3SyncResult moveOldCoverageToHistoricalCoverage(String contract, CoverageV3SyncSource source) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
 	    return coverageV3SyncService.moveToHistorical(contract, source);
     }
 
     @Override
+    @Trace(operationName = "ab2d.coverage.count_beneficiaries_v3")
     public int countBeneficiariesByCoveragePeriod(final CoverageV3Periods periods, final String contract) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
         return executeTimedQuery(
             format("countBeneficiariesByCoveragePeriod historicalCoverage=%s; recentCoverage=%s; contract=%s",
                     periods.getHistoricalCoverage(),

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -1,6 +1,8 @@
 package gov.cms.ab2d.coverage.service.v3;
 
+import datadog.trace.api.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -188,7 +189,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
     """;
 
     @Transactional
+    @Trace(operationName = "ab2d.coverage.sync_from_staging_v3")
     public CoverageV3SyncResult copyFromStagingTablesToRecent(String contract, CoverageV3SyncSource source) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
+        DatadogSpans.setTag("sync.source", source.name());
         val action = COPY_FROM_STAGING;
         CoverageV3SyncResult result = null;
 
@@ -213,6 +218,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             format("[V3] getCoveragePeriodCountForCoverageV3Staging contract=%s", contract),
             () -> getCoveragePeriodCountForCoverageV3Staging(contract)
         );
+        DatadogSpans.setMetric("coverage.v3.rows_in_staging", rowsInStaging);
         log.info("[V3] Found {} rows in staging table for contract {}", rowsInStaging, contract);
 
         if (rowsInStaging == 0) {
@@ -313,7 +319,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
     // Set query timeout of 1 hour, otherwise large contracts may cause org.springframework.dao.QueryTimeoutException
     @Transactional(timeout=3600)
+    @Trace(operationName = "ab2d.coverage.sync_to_historical_v3")
     public CoverageV3SyncResult moveToHistorical(String contract, CoverageV3SyncSource source) {
+        DatadogSpans.setTag("contract", contract);
+        DatadogSpans.setTag("component", "coverage");
+        DatadogSpans.setTag("sync.source", source.name());
         val action = COPY_TO_HISTORICAL;
         CoverageV3SyncResult result = null;
 
@@ -331,6 +341,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         try {
             if (locked) {
                 int rowsMoved = moveToHistoricalInternal(contract);
+                DatadogSpans.setMetric("coverage.v3.rows_moved", rowsMoved);
                 log.info("[V3] Moved {} rows to historical coverage table for contract {}", rowsMoved, contract);
                 if (rowsMoved == 0) {
                     // skip audit logging to prevent noise - this operation would only copy records > 0 once a month
@@ -356,6 +367,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
                 }
                 int rowsDeleted = deleteMonthsOldCoverage(contract);
+                DatadogSpans.setMetric("coverage.v3.rows_deleted", rowsDeleted);
                 log.info("[V3] Deleted {} rows from recent coverage table for contract {}", rowsDeleted, contract);
 
                 if (rowsDeleted != rowsMoved) {
@@ -469,7 +481,9 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
     @Override
     @Transactional
+    @Trace(operationName = "ab2d.coverage.delete_inactive_contracts_v3")
     public int deleteInactiveContractsFromHistorySummary() {
+        DatadogSpans.setTag("component", "coverage");
         val cutoff = CUT_OFF_DATE_FOR_INACTIVE_CONTRACT.get();
         val parameters = new MapSqlParameterSource().addValue("cutoff", cutoff);
         val template = new NamedParameterJdbcTemplate(this.dataSource);
@@ -479,6 +493,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
 
         List<String> deletedContracts = template.queryForList(DELETE_INACTIVE_CONTRACTS_FROM_HISTORY_SUMMARY, parameters, String.class);
         log.info("[V3] Deleted {} rows from coverage_v3_history_summary for unattested contracts or contracts ended > 2 years ago", deletedContracts.size());
+        DatadogSpans.setMetric("coverage.v3.inactive_contracts_deleted", deletedContracts.size());
         audit.log(CoverageV3AuditAction.DELETE_INACTIVE_CONTACTS, null, null, null, Map.of("deletedContracts", deletedContracts));
         return deletedContracts.size();
     }

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -129,22 +129,6 @@ class CoverageV3SyncServiceImplTest {
 
 	}
 
-	@Test
-	void moveToHistorical_Z1234_tagsSpanAndRecordsMetrics() {
-		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
-		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
-		when(lock.tryLock()).thenReturn(true);
-
-		try (MockedStatic<DatadogSpans> spans = mockStatic(DatadogSpans.class)) {
-			service.moveToHistorical("Z1234", CoverageV3SyncSource.CRON_JOB);
-
-			spans.verify(() -> DatadogSpans.setTag("contract", "Z1234"));
-			spans.verify(() -> DatadogSpans.setTag("component", "coverage"));
-			spans.verify(() -> DatadogSpans.setTag("sync.source", "CRON_JOB"));
-			spans.verify(() -> DatadogSpans.setMetric("coverage.v3.rows_moved", 3L));
-		}
-	}
-
 	void assertAuditLogEquals(Map<String, Object> result, String string) {
 		// remove id and timestamp to simplify comparisons
 		result.remove("timestamp");

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLogImpl;
@@ -9,9 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.context.ApplicationContext;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -23,6 +24,7 @@ import java.util.concurrent.locks.Lock;
 import static gov.cms.ab2d.common.util.PropertyConstants.V3_AUDIT_LOGGING_ENABLED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @Testcontainers
@@ -125,6 +127,22 @@ class CoverageV3SyncServiceImplTest {
 		{action=COPY_FROM_STAGING, result=SYNC_SUCCESSFUL_FOR_CONTRACT, contract=Z9999, log=, data={"rowsInStagingDeleted": 4, "rowsInCoverageAfterCopy": 4}}
 		""");
 
+	}
+
+	@Test
+	void moveToHistorical_Z1234_tagsSpanAndRecordsMetrics() {
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
+		when(lock.tryLock()).thenReturn(true);
+
+		try (MockedStatic<DatadogSpans> spans = mockStatic(DatadogSpans.class)) {
+			service.moveToHistorical("Z1234", CoverageV3SyncSource.CRON_JOB);
+
+			spans.verify(() -> DatadogSpans.setTag("contract", "Z1234"));
+			spans.verify(() -> DatadogSpans.setTag("component", "coverage"));
+			spans.verify(() -> DatadogSpans.setTag("sync.source", "CRON_JOB"));
+			spans.verify(() -> DatadogSpans.setMetric("coverage.v3.rows_moved", 3L));
+		}
 	}
 
 	void assertAuditLogEquals(Map<String, Object> result, String string) {

--- a/idr-db-importer/src/main/java/gov/cms/ab2d/importer/CoverageV3ImportService.java
+++ b/idr-db-importer/src/main/java/gov/cms/ab2d/importer/CoverageV3ImportService.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.importer;
 
+import datadog.trace.api.Trace;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
@@ -44,8 +46,13 @@ public class CoverageV3ImportService {
             retryFor = Exception.class,
             backoff = @Backoff(delay = 1000, multiplier = 2.0)
     )
+    @Trace(operationName = "ab2d.idr.import")
     public void importWithRetry(String fqtn, String bucket, String key, String region) throws SQLException {
         String stagingFqtn = fqtn + "_staging";
+        DatadogSpans.setTag("component", "idr");
+        DatadogSpans.setTag("target_table", stagingFqtn);
+        DatadogSpans.setTag("s3.bucket", bucket);
+        DatadogSpans.setTag("s3.key", key);
 
         try (Connection connection = DriverManager.getConnection(jdbcUrl, dbUser, dbPassword)) {
             connection.setAutoCommit(false);
@@ -55,6 +62,7 @@ public class CoverageV3ImportService {
                 verifyFileExists(bucket, key);
 
                 int stagedRows = executeImport(connection, stagingFqtn, bucket, key, region);
+                DatadogSpans.setMetric("idr.staged_rows", stagedRows);
 
                 connection.commit();
 
@@ -70,6 +78,7 @@ public class CoverageV3ImportService {
                 );
             } catch (Exception e) {
                 rollback(connection);
+                DatadogSpans.markError(e);
                 log.error(
                         "CoverageV3 import failed: source=s3://{}/{}, target={}",
                         bucket, key, stagingFqtn, e

--- a/idr-db-importer/src/main/java/gov/cms/ab2d/importer/CoverageV3S3Importer.java
+++ b/idr-db-importer/src/main/java/gov/cms/ab2d/importer/CoverageV3S3Importer.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.importer;
 
+import datadog.trace.api.Trace;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,9 +38,13 @@ public class CoverageV3S3Importer {
         this.importService = importService;
     }
 
+    @Trace(operationName = "ab2d.idr.run_once")
     public void runOnce() throws Exception {
         String date = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
         String finalKey = "coverage_v3_" + date + ".csv";
+        DatadogSpans.setTag("component", "idr");
+        DatadogSpans.setTag("s3.bucket", bucket);
+        DatadogSpans.setTag("s3.key", finalKey);
 
         if (coverageQueryService != null) {
             try (Connection conn = coverageQueryService.open();

--- a/idr-db-importer/src/main/java/gov/cms/ab2d/importer/S3CsvWriter.java
+++ b/idr-db-importer/src/main/java/gov/cms/ab2d/importer/S3CsvWriter.java
@@ -1,5 +1,7 @@
 package gov.cms.ab2d.importer;
 
+import datadog.trace.api.Trace;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,7 +26,11 @@ public class S3CsvWriter {
 
     private static final int PART_BYTES = 8 * 1024 * 1024;
 
+    @Trace(operationName = "ab2d.idr.export_to_s3")
     public void writeSnowflakeToS3(String bucket, String finalKey, ResultSet rs) throws Exception {
+        DatadogSpans.setTag("component", "idr");
+        DatadogSpans.setTag("s3.bucket", bucket);
+        DatadogSpans.setTag("s3.key", finalKey);
         String tmpKey = finalKey + ".tmp";
         String uploadId = s3.createMultipartUpload(
                 r -> r.bucket(bucket).key(tmpKey).contentType("text/csv")
@@ -63,6 +69,7 @@ public class S3CsvWriter {
             s3.deleteObject(r -> r.bucket(bucket).key(tmpKey));
 
         } catch (Exception e) {
+            DatadogSpans.markError(e);
             log.warn("Aborting multipart upload uploadId={} for s3://{}/{}", uploadId, bucket, tmpKey, e);
 
             try {

--- a/idr-db-importer/src/main/java/gov/cms/ab2d/importer/SpringBootApp.java
+++ b/idr-db-importer/src/main/java/gov/cms/ab2d/importer/SpringBootApp.java
@@ -1,6 +1,8 @@
 package gov.cms.ab2d.importer;
 
+import datadog.trace.api.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.common.util.DatadogSpans;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -33,7 +35,9 @@ public class SpringBootApp implements ApplicationRunner {
 
 
     @Override
+    @Trace(operationName = "ab2d.idr.import_task")
     public void run(ApplicationArguments args) {
+        DatadogSpans.setTag("component", "idr");
         log.info("IDR S3 import ECS task started");
         updateStatus(STATUS_IN_PROGRESS);
         int exitCode = 1;
@@ -42,6 +46,7 @@ public class SpringBootApp implements ApplicationRunner {
             exitCode = 0;
             log.info("IDR import ECS task completed successfully");
         } catch (Exception e) {
+            DatadogSpans.markError(e);
             log.error("IDR import ECS task failed", e);
         } finally {
             updateStatus(STATUS_NOT_IN_PROGRESS);

--- a/idr-db-importer/src/test/java/gov/cms/ab2d/importer/CoverageV3ImportServiceTest.java
+++ b/idr-db-importer/src/test/java/gov/cms/ab2d/importer/CoverageV3ImportServiceTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.importer;
 
+import gov.cms.ab2d.common.util.DatadogSpans;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -92,6 +93,50 @@ class CoverageV3ImportServiceTest {
         }
 
         verify(connection).rollback();
+    }
+
+    @Test
+    void tagsSpanAndRecordsStagedRowsOnSuccess() throws Exception {
+        stubNonFirstDayStatements();
+
+        try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class);
+             MockedStatic<DatadogSpans> spans = mockStatic(DatadogSpans.class)) {
+            driverManager.when(() -> DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASSWORD))
+                    .thenReturn(connection);
+
+            service.importWithRetry(FQTN, BUCKET, KEY, REGION);
+
+            spans.verify(() -> DatadogSpans.setTag("component", "idr"));
+            spans.verify(() -> DatadogSpans.setTag("target_table", FQTN + "_staging"));
+            spans.verify(() -> DatadogSpans.setMetric("idr.staged_rows", 10L));
+        }
+    }
+
+    @Test
+    void marksSpanErroredWhenImportFails() throws Exception {
+        when(connection.prepareStatement(anyString())).thenAnswer(invocation -> {
+            String sql = invocation.getArgument(0, String.class);
+            if (sql.startsWith("SELECT aws_s3.table_import_from_s3")) {
+                return importPs;
+            }
+            if (sql.startsWith("TRUNCATE TABLE")) {
+                return truncatePs;
+            }
+            throw new IllegalArgumentException("Unexpected SQL: " + sql);
+        });
+
+        when(importPs.executeQuery()).thenThrow(new RuntimeException("boom"));
+
+        try (MockedStatic<DriverManager> driverManager = mockStatic(DriverManager.class);
+             MockedStatic<DatadogSpans> spans = mockStatic(DatadogSpans.class)) {
+            driverManager.when(() -> DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASSWORD))
+                    .thenReturn(connection);
+
+            assertThrows(RuntimeException.class,
+                    () -> service.importWithRetry(FQTN, BUCKET, KEY, REGION));
+
+            spans.verify(() -> DatadogSpans.markError(any(RuntimeException.class)));
+        }
     }
 
     private void stubNonFirstDayStatements() throws Exception {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7348

## 🛠 Changes

Added Datadog tracing to idr-db-importer  and CoverageService for v3

## ℹ️ Context

@Trace / Datadog spans are already used throughout the worker, BFD client, and V1/V2 coverage repositories. However, CoverageV3ServiceImpl, CoverageV3SyncServiceImpl, and the idr-db-importer currently only use plain SLF4J logging.

We should add Datadog tracing to these V3 and IDR importer components so we have better visibility into execution flow, performance, failures, and troubleshooting across the full AB2D V3 coverage pipeline.


## 🧪 Validation

Deployed in test, ran e2e and idr-importer task
<img width="1025" height="196" alt="Screenshot 2026-07-15 at 10 47 31 AM" src="https://github.com/user-attachments/assets/e2cda8d7-797b-45df-93f8-52b352dbacbc" />

