### PR TITLE
AB2D-7261 AB2D-7094 Update historic_mbis datatype and update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # AB2D
 
-[![Maintainability](https://qlty.sh/gh/CMSgov/projects/ab2d/maintainability.svg)](https://qlty.sh/gh/CMSgov/projects/ab2d)
-[![Test Coverage](https://qlty.sh/gh/CMSgov/projects/ab2d/coverage.svg)](https://qlty.sh/gh/CMSgov/projects/ab2d)
 [![CodeQL](https://github.com/CMSgov/ab2d/actions/workflows/codeql.yml/badge.svg)](https://github.com/CMSgov/ab2d/actions/workflows/codeql.yml)
-[![Automated Release Notes by gren](https://img.shields.io/badge/%F0%9F%A4%96-release%20notes-00B2EE.svg)](https://github-tools.github.io/github-release-notes/)
 
 ## Table of Contents
 

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -201,3 +201,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_v3_coverage_check_enabled.sql
   - include:
       file: db/changelog/v2026/add_int_lock_expired_after.sql
+  - include:
+      file: db/changelog/v2026/alter_historic_mbis_type.sql

--- a/common/src/main/resources/db/changelog/v2026/alter_historic_mbis_type.sql
+++ b/common/src/main/resources/db/changelog/v2026/alter_historic_mbis_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ab2d.coverage ALTER COLUMN historic_mbis TYPE varchar;


### PR DESCRIPTION
## 🎫 Ticket

- https://jira.cms.gov/browse/AB2D-7261 Liquibase updates for `historic_mbis` database type
- https://jira.cms.gov/browse/AB2D-7094 Remove `qlty.sh` and release notes badges 

## 🛠 Changes

- Add liquibase script for modifying `historic_mbis` column to varchar
- Remove `qlty.sh` links related to code coverage & maintanability and obsolete _release notes_ badge  

## ℹ️ Context

On 5/5/26, the worker failed to insert attribution data because a few contracts had beneficiaries whose value for `historic_mbis` field exceeded 256 characters. This caused the weekly coverage job to fail. The column type was changed manually to `varchar` in production. 

Team decided to remove qlty.sh and release notes badges here: https://cmsgov.slack.com/archives/CNHDC8HCZ/p1785517800141639?thread_ts=1775058352.052969&cid=CNHDC8HCZ

## 🧪 Validation


