### PR TITLE
AB2D-7344 pause resume integration

### DIFF
--- a/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
+++ b/e2e-bfd-test/src/test/java/gov/cms/ab2d/testjobs/EndToEndBfdTests.java
@@ -192,7 +192,7 @@ public class EndToEndBfdTests {
 
         // Instantiate the job processors
         jobService = new JobServiceImpl(jobRepository, jobOutputService, logManager, path.getAbsolutePath());
-        jobPreProcessor = new JobPreProcessorImpl(contractWorkerClient, jobRepository, logManager, coverageDriver);
+        jobPreProcessor = new JobPreProcessorImpl(contractWorkerClient, jobRepository, logManager, coverageDriver, propertiesService);
 
         jobProcessor = new JobProcessorImpl(new FileServiceImpl(), jobChannelService, jobProgressService, jobProgressUpdateService,
                 jobRepository, jobOutputRepository, contractProcessor, logManager, coverageV3Service);

--- a/job/src/main/java/gov/cms/ab2d/job/repository/JobOutputRepository.java
+++ b/job/src/main/java/gov/cms/ab2d/job/repository/JobOutputRepository.java
@@ -14,6 +14,8 @@ public interface JobOutputRepository extends JpaRepository<JobOutput, Long> {
 
     Optional<JobOutput> findByFilePathAndJob(String filePath, Job job);
 
+    long countByJob(Job job);
+
     //HQL doesn't seem to have a way to modify dates. It was with a native query or adding a special  query to find the DB time
     @Query(nativeQuery = true, value = "select jobOutput.id as id, jobOutput.checksum as checksum, jobOutput.downloaded as downloaded, " +
             "                   jobOutput.error as error, jobOutput.fhir_resource_type as fhir_resource_type, " +

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/EobNdjsonSerializer.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/EobNdjsonSerializer.java
@@ -1,0 +1,45 @@
+package gov.cms.ab2d.worker.processor;
+
+import ca.uhn.fhir.parser.IParser;
+import gov.cms.ab2d.fhir.FhirVersion;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializes a beneficiary's EOBs to ndjson with error isolation. Resources that fail to encode
+ * get added as an OperationOutcome line in the error file instead of failing the whole bene
+ */
+@Slf4j
+public final class EobNdjsonSerializer {
+
+    private EobNdjsonSerializer() {
+    }
+
+    /**
+     * Encode each resource to a string and add it to the appropriate list, to be later flushed
+     * into a file.
+     */
+    public static SerializedEobs serialize(FhirVersion version, List<IBaseResource> eobs) {
+        if (eobs == null || eobs.isEmpty()) {
+            return new SerializedEobs(List.of(), List.of());
+        }
+        IParser parser = version.getJsonParser().setPrettyPrint(false);
+        List<String> dataLines = new ArrayList<>(eobs.size());
+        List<String> errorLines = new ArrayList<>();
+        for (IBaseResource resource : eobs) {
+            try {
+                dataLines.add(parser.encodeResourceToString(resource));
+            } catch (Exception ex) {
+                log.warn("Encountered exception while serializing job resources: {}", ex.getClass());
+                String errMsg = ExceptionUtils.getRootCauseMessage(ex);
+                IBaseResource operationOutcome = version.getErrorOutcome(errMsg);
+                errorLines.add(parser.encodeResourceToString(operationOutcome));
+            }
+        }
+        return new SerializedEobs(dataLines, errorLines);
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/JobPreProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/JobPreProcessorImpl.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.worker.processor;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.common.model.SinceSource;
+import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.fhir.FhirVersion;
 import gov.cms.ab2d.job.model.Job;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import static gov.cms.ab2d.common.util.PropertyConstants.PAUSE_RESUME_PROTOTYPE_ENABLED;
 import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_COVERAGE_ISSUE;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_STARTED;
@@ -43,13 +45,15 @@ public class JobPreProcessorImpl implements JobPreProcessor {
     private final JobRepository jobRepository;
     private final SQSEventClient eventLogger;
     private final CoverageDriver coverageDriver;
+    private final PropertiesService propertiesService;
 
     public JobPreProcessorImpl(ContractWorkerClient contractWorkerClient, JobRepository jobRepository, SQSEventClient logManager,
-                               CoverageDriver coverageDriver) {
+                               CoverageDriver coverageDriver, PropertiesService propertiesService) {
         this.contractWorkerClient = contractWorkerClient;
         this.jobRepository = jobRepository;
         this.eventLogger = logManager;
         this.coverageDriver = coverageDriver;
+        this.propertiesService = propertiesService;
     }
 
     @Override
@@ -60,6 +64,15 @@ public class JobPreProcessorImpl implements JobPreProcessor {
         if (job == null) {
             log.error("Job was not found");
             throw new IllegalArgumentException("Job " + jobUuid + " was not found");
+        }
+
+        // If we're being asked to preprocess a job that is in_progress, the preprocessor will
+        // reject it on the normal pathway, and send it for hard recovery on the prototype pathway.
+        if (IN_PROGRESS.equals(job.getStatus())
+                && propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false)) {
+            log.info("Job {} re-entered preprocess while IN_PROGRESS - prototype hard-recovery resume, "
+                    + "passing through", jobUuid);
+            return job;
         }
 
         // validate status is SUBMITTED
@@ -170,7 +183,7 @@ public class JobPreProcessorImpl implements JobPreProcessor {
 
     /**
      * Update the 'since' logic if the user has not supplied one. We pick the date the last job was successfully
-     * run by the PDP (ignoring AB2D run jobs). If no job has every been successfully run, we default to a null
+     * run by the PDP (ignoring AB2D run jobs). If no job has ever been successfully run, we default to a null
      * since date.
      *
      * @param job - The job object to update (although not save)

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/PatientClaimsProcessorImpl.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.processor;
 
-import ca.uhn.fhir.parser.IParser;
 import datadog.trace.api.Trace;
 import gov.cms.ab2d.aggregator.ClaimsStream;
 import gov.cms.ab2d.bfd.client.BFDClient;
@@ -20,7 +19,6 @@ import gov.cms.ab2d.worker.config.SearchConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Value;
@@ -128,8 +126,8 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
     }
 
     @Trace(operationName = "ab2d.eob.write_to_file")
-    private String writeOutResource(FhirVersion version, ProgressTrackerUpdate update, List<IBaseResource> eobs, ClaimsStream stream) {
-        IParser parser = version.getJsonParser().setPrettyPrint(false);
+    private String writeOutResource(FhirVersion version, ProgressTrackerUpdate update, List<IBaseResource> eobs, ClaimsStream stream)
+            throws IOException {
         if (eobs == null) {
             log.debug("ignoring empty results because pulling eobs failed");
             return null;
@@ -138,32 +136,20 @@ public class PatientClaimsProcessorImpl implements PatientClaimsProcessor {
             return null;
         }
 
-        int eobsWritten = 0;
-        int eobsError = 0;
-
         update.incPatientsWithEobsCount();
         update.addEobFetchedCount(eobs.size());
 
+        SerializedEobs serialized = EobNdjsonSerializer.serialize(version, eobs);
+
+        for (String dataLine : serialized.dataLines()) {
+            stream.write(dataLine + System.lineSeparator());
+        }
+        update.addEobProcessedCount(serialized.dataLines().size());
+
         StringBuilder errorPayload = new StringBuilder();
-        for (IBaseResource resource : eobs) {
-            try {
-                stream.write(parser.encodeResourceToString(resource) + System.lineSeparator());
-                eobsWritten++;
-            } catch (Exception ex) {
-                log.warn("Encountered exception while processing job resources: {}", ex.getClass());
-                String errMsg = ExceptionUtils.getRootCauseMessage(ex);
-                IBaseResource operationOutcome = version.getErrorOutcome(errMsg);
-                errorPayload.append(parser.encodeResourceToString(operationOutcome)).append(System.lineSeparator());
-                eobsError++;
-            }
+        for (String errorLine : serialized.errorLines()) {
+            errorPayload.append(errorLine).append(System.lineSeparator());
         }
-
-        update.addEobProcessedCount(eobsWritten);
-
-        if (eobsError != 0) {
-            return errorPayload.toString();
-        }
-
         return errorPayload.toString();
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/SerializedEobs.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/SerializedEobs.java
@@ -1,0 +1,19 @@
+package gov.cms.ab2d.worker.processor;
+
+import java.util.List;
+
+/**
+ * Serialized ndjson output of one beneficiary's EOBs. Contains both the successful and error lines, produced
+ * by {@link EobNdjsonSerializer} and shared between the prototype and main code.
+ */
+public record SerializedEobs(List<String> dataLines, List<String> errorLines) {
+
+    public SerializedEobs {
+        dataLines = dataLines == null ? List.of() : dataLines;
+        errorLines = errorLines == null ? List.of() : errorLines;
+    }
+
+    public boolean isEmpty() {
+        return dataLines.isEmpty() && errorLines.isEmpty();
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
@@ -2,11 +2,14 @@ package gov.cms.ab2d.worker.processor.prototype;
 
 import gov.cms.ab2d.contracts.model.ContractDTO;
 import gov.cms.ab2d.coverage.model.CoverageSummary;
+import gov.cms.ab2d.fhir.FhirVersion;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.repository.JobRepository;
 import gov.cms.ab2d.worker.config.SearchConfig;
+import gov.cms.ab2d.worker.processor.EobNdjsonSerializer;
 import gov.cms.ab2d.worker.processor.PatientClaimsProcessor;
 import gov.cms.ab2d.worker.processor.PatientClaimsRequest;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
 import gov.cms.ab2d.worker.service.ContractWorkerClient;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -20,13 +23,11 @@ import java.util.List;
 @Slf4j
 @Component
 @StepScope
-public class EobItemProcessor implements ItemProcessor<CoverageSummary, List<IBaseResource>> {
-    // set false to simulate a failure
-    private volatile boolean alreadyFailedOnce = true;
-    private int patientToFail = 950;
+public class EobItemProcessor implements ItemProcessor<CoverageSummary, SerializedEobs> {
 
     private final PatientClaimsProcessor patientClaimsProcessor;
     private final PatientClaimsRequest request;
+    private final FhirVersion version;
     private final long itemDelayMs;
 
     public EobItemProcessor(
@@ -39,6 +40,7 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, List<IBa
         this.patientClaimsProcessor = patientClaimsProcessor;
         this.itemDelayMs = itemDelayMs;
         Job job = jobRepository.findByJobUuid(jobUuid);
+        this.version = job.getFhirVersion();
         ContractDTO contract = contractWorkerClient.getContractByContractNumber(job.getContractNumber());
 
         this.request = new PatientClaimsRequest(
@@ -57,16 +59,19 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, List<IBa
     }
 
     @Override
-    public List<IBaseResource> process(CoverageSummary patient) throws InterruptedException {
+    public SerializedEobs process(CoverageSummary patient) throws InterruptedException {
         // optional artificial slowdown so a running job stays alive long enough to interrupt in tests
         if (itemDelayMs > 0) {
             Thread.sleep(itemDelayMs);
         }
-        if (patient.getIdentifiers().getPatientIdV3() == patientToFail && !alreadyFailedOnce) {
-            alreadyFailedOnce = true;
-            throw new RuntimeException("Simulated an expected failure on patient");
-        }
         List<IBaseResource> eobs = patientClaimsProcessor.getEobBundleResources(request, patient);
-        return (eobs == null || eobs.isEmpty()) ? null : eobs;
+        if (eobs == null || eobs.isEmpty()) {
+            return null;
+        }
+
+        // The serializer will create both the resource and error lines, and is used by both this and the main
+        // pathway.
+        SerializedEobs serialized = EobNdjsonSerializer.serialize(version, eobs);
+        return serialized.isEmpty() ? null : serialized;
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Component
@@ -29,6 +30,8 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
     private final PatientClaimsRequest request;
     private final FhirVersion version;
     private final long itemDelayMs;
+    // remove this later
+    private final double crashProbability;
 
     public EobItemProcessor(
             PatientClaimsProcessor patientClaimsProcessor,
@@ -36,9 +39,11 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
             ContractWorkerClient contractWorkerClient,
             SearchConfig searchConfig,
             @Value("#{jobParameters['jobUuid']}") String jobUuid,
-            @Value("${pause-resume.prototype.item-delay-ms:0}") long itemDelayMs) {
+            @Value("${pause-resume.prototype.item-delay-ms:0}") long itemDelayMs,
+            @Value("${pause-resume.prototype.crash-probability:0}") double crashProbability) {
         this.patientClaimsProcessor = patientClaimsProcessor;
         this.itemDelayMs = itemDelayMs;
+        this.crashProbability = crashProbability;
         Job job = jobRepository.findByJobUuid(jobUuid);
         this.version = job.getFhirVersion();
         ContractDTO contract = contractWorkerClient.getContractByContractNumber(job.getContractNumber());
@@ -60,6 +65,13 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
 
     @Override
     public SerializedEobs process(CoverageSummary patient) throws InterruptedException {
+        // dev test code - simulates a hard crash by just throwing the process in the trash
+        // remove this later
+        if (crashProbability > 0 && ThreadLocalRandom.current().nextDouble() < crashProbability) {
+            log.error("Simulating hard crash. Goodbye.");
+            Runtime.getRuntime().halt(137);
+        }
+
         // optional artificial slowdown so a running job stays alive long enough to interrupt in tests
         if (itemDelayMs > 0) {
             Thread.sleep(itemDelayMs);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/JobCancellationChunkListener.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/JobCancellationChunkListener.java
@@ -1,17 +1,23 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
+import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.job.repository.JobRepository;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.batch.core.listener.ChunkListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.Chunk;
 
 /**
  * Polls the AB2D job status once per chunk and, if the job has been cancelled, terminate
  * the worker step at the next chunk boundary
  */
 @Slf4j
-public class JobCancellationChunkListener implements ChunkListener {
+public class JobCancellationChunkListener implements ChunkListener<CoverageSummary, SerializedEobs> {
 
     private final JobRepository jobRepository;
     private final String jobUuid;
@@ -22,10 +28,21 @@ public class JobCancellationChunkListener implements ChunkListener {
     }
 
     @Override
-    public void beforeChunk(ChunkContext context) {
-        if (jobRepository.getJobStatusOfJob(jobUuid) == JobStatus.CANCELLED) {
-            log.warn("job {} was cancelled - terminating worker step at chunk boundary", jobUuid);
-            context.getStepContext().getStepExecution().setTerminateOnly();
+    public void beforeChunk(@NonNull Chunk<CoverageSummary> chunk) {
+        if (jobRepository.getJobStatusOfJob(jobUuid) != JobStatus.CANCELLED) {
+            return;
         }
+        StepExecution stepExecution = currentStepExecution();
+        if (stepExecution == null) {
+            log.warn("job {} was cancelled, but this chunk is unavailable. Will retry terminating the job next chunk.", jobUuid);
+            return;
+        }
+        log.warn("job {} was cancelled, the worker step will be terminated when this chunk finishes", jobUuid);
+        stepExecution.setTerminateOnly();
+    }
+
+    private static StepExecution currentStepExecution() {
+        StepContext context = StepSynchronizationManager.getContext();
+        return context == null ? null : context.getStepExecution();
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
@@ -1,0 +1,60 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.worker.processor.SerializedEobs;
+import org.jspecify.annotations.NonNull;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.batch.infrastructure.item.ItemStreamWriter;
+import org.springframework.batch.infrastructure.item.file.FlatFileItemWriter;
+
+import java.util.List;
+
+/**
+ * Creates two FlatFile writers that handle their own output files. The dataWriter writes the EOBs to ndjson, and
+ * the errorWriter writes error lines to the _error file. Each writer can ONLY handle 1 file. Since we need two
+ * output files, we need two writers. The composite writer keeps both synced.
+ */
+public class NdjsonCompositeWriter implements ItemStreamWriter<SerializedEobs> {
+
+    private final FlatFileItemWriter<String> dataWriter;
+    private final FlatFileItemWriter<String> errorWriter;
+
+    public NdjsonCompositeWriter(FlatFileItemWriter<String> dataWriter, FlatFileItemWriter<String> errorWriter) {
+        this.dataWriter = dataWriter;
+        this.errorWriter = errorWriter;
+    }
+
+    @Override
+    public void open(@NonNull ExecutionContext executionContext) throws ItemStreamException {
+        dataWriter.open(executionContext);
+        errorWriter.open(executionContext);
+    }
+
+    @Override
+    public void update(@NonNull ExecutionContext executionContext) throws ItemStreamException {
+        dataWriter.update(executionContext);
+        errorWriter.update(executionContext);
+    }
+
+    @Override
+    public void close() throws ItemStreamException {
+        try {
+            dataWriter.close();
+        } finally {
+            errorWriter.close();
+        }
+    }
+
+    @Override
+    public void write(@NonNull Chunk<? extends SerializedEobs> chunk) throws Exception {
+        List<String> dataLines = chunk.getItems().stream().flatMap(item -> item.dataLines().stream()).toList();
+        List<String> errorLines = chunk.getItems().stream().flatMap(item -> item.errorLines().stream()).toList();
+        if (!dataLines.isEmpty()) {
+            dataWriter.write(new Chunk<>(dataLines));
+        }
+        if (!errorLines.isEmpty()) {
+            errorWriter.write(new Chunk<>(errorLines));
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
@@ -1,12 +1,9 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
-import ca.uhn.fhir.parser.IParser;
-import gov.cms.ab2d.fhir.FhirVersion;
-import gov.cms.ab2d.job.model.Job;
-import gov.cms.ab2d.job.repository.JobRepository;
 import gov.cms.ab2d.worker.config.SearchConfig;
-import org.hl7.fhir.instance.model.api.IBaseResource;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemStreamWriter;
 import org.springframework.batch.infrastructure.item.file.FlatFileItemWriter;
 import org.springframework.batch.infrastructure.item.file.builder.FlatFileItemWriterBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,46 +14,48 @@ import org.springframework.core.io.FileSystemResource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
- * Defines the output writer using Spring Batch's FlatFileWriter
+ * Defines the writer for a worker step. Consists of a {@link NdjsonCompositeWriter} with two
+ * flat file writers. Lines are already serialized, so this just passes them along.
  */
 @Configuration
 public class NdjsonWriterConfig {
 
     @Bean
     @StepScope
-    public FlatFileItemWriter<List<IBaseResource>> ndjsonItemWriter(
-            JobRepository jobRepository,
+    public ItemStreamWriter<SerializedEobs> ndjsonItemWriter(
             SearchConfig searchConfig,
             @Value("#{jobParameters['jobUuid']}") String jobUuid,
             @Value("#{jobParameters['fenceToken']}") long fenceToken,
             @Value("#{stepExecutionContext['contractNumber']}") String contract,
             @Value("#{stepExecutionContext['partitionIndex']}") int partitionIndex) throws IOException {
 
-        Job job = jobRepository.findByJobUuid(jobUuid);
-        FhirVersion version = job.getFhirVersion();
-        IParser parser = version.getJsonParser().setPrettyPrint(false);
 
-        // files are named with the fenceToken so that each time it bumps, there must be a new file
-        // no stale worker can modify another worker's file.
-        Path outputFile = Path.of(searchConfig.getEfsMount(), jobUuid, searchConfig.getStreamingDir())
-                .resolve(contract + "_partition" + partitionIndex + "_t" + fenceToken + ".ndjson");
+        Path streamingDir = Path.of(searchConfig.getEfsMount(), jobUuid, searchConfig.getStreamingDir());
         // FlatFileItemWriter does not create parent directories
-        Files.createDirectories(outputFile.getParent());
+        Files.createDirectories(streamingDir);
 
-        // the writer and reader are kept in line along the same fence token.
-        // forceSync happens on every chunk flush and on close so we can actually guarantee safety
-        // when soft-resuming. The file will always match what the cursor says.
-        return new FlatFileItemWriterBuilder<List<IBaseResource>>()
-                .name("ndjsonItemWriter.t" + fenceToken)
+        // files are named with the fenceToken so that each time it bumps there must be a new file. This keeps
+        // restart safe. Stale/zombie workers cannot interact with the new file.
+        String base = contract + "_partition" + partitionIndex + "_t" + fenceToken;
+        FlatFileItemWriter<String> dataWriter = lineWriter(
+                streamingDir.resolve(base + ".ndjson"), "ndjsonDataWriter.p" + partitionIndex + ".t" + fenceToken);
+        FlatFileItemWriter<String> errorWriter = lineWriter(
+                streamingDir.resolve(base + "_error.ndjson"), "ndjsonErrorWriter.p" + partitionIndex + ".t" + fenceToken);
+        return new NdjsonCompositeWriter(dataWriter, errorWriter);
+    }
+
+    /**
+     * Simple line writer. forceSync true ensures that the file matches the saved offset, which
+     * allows for soft-resume.
+     */
+    private static FlatFileItemWriter<String> lineWriter(Path outputFile, String name) {
+        return new FlatFileItemWriterBuilder<String>()
+                .name(name)
                 .resource(new FileSystemResource(outputFile))
                 .forceSync(true)
-                .lineAggregator(eobs -> eobs.stream()
-                        .map(parser::encodeResourceToString)
-                        .collect(Collectors.joining("\n")))
-                .build(); // fresh run overwrites, restart truncates to position
+                .lineAggregator(line -> line)
+                .build();
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
@@ -15,6 +15,7 @@ import java.util.Map;
  * failedExecutionCount - how many times the job's execution has failed
  * healIndeterminateExecutions - force a job's indeterminate executions/steps to a restartable FAILED state
  *      This is mainly to handle UNKNOWN statuses resulting from zombie workers.
+ * completedProcessedCount - how many benes have we processed already? Used to track progress
  */
 @Slf4j
 @Component
@@ -59,6 +60,25 @@ public class PrototypeBatchMetadataRepository {
                  ORDER BY se.step_name, ft.parameter_value::bigint DESC
             ) winners
             ORDER BY partition_index
+            """;
+
+    // Gathers the winners from the set of completed partitions to estimate the progress of a job. Used on
+    // restart/recovery to seed the value so a restarting job reports approximately accurate progress.
+    private static final String COMPLETED_PROCESSED_COUNT_SQL = """
+            SELECT COALESCE(SUM(read_count), 0) FROM (
+                SELECT DISTINCT ON (se.step_name)
+                       se.read_count AS read_count
+                  FROM batch_step_execution se
+                  JOIN batch_job_execution je ON je.job_execution_id = se.job_execution_id
+                  JOIN batch_job_execution_params pj ON pj.job_execution_id = je.job_execution_id
+                       AND pj.parameter_name = 'jobUuid'
+                  JOIN batch_job_execution_params ft ON ft.job_execution_id = je.job_execution_id
+                       AND ft.parameter_name = 'fenceToken'
+                 WHERE pj.parameter_value = :uuid
+                   AND se.step_name LIKE :stepPrefix
+                   AND se.status = 'COMPLETED'
+                 ORDER BY se.step_name, ft.parameter_value::bigint DESC
+            ) winners
             """;
 
     // When hard-recovering a job, we set its old job execution to FAILED since we're
@@ -108,6 +128,15 @@ public class PrototypeBatchMetadataRepository {
                 """;
         Integer count = jdbc.queryForObject(sql, Map.of("uuid", jobUuid), Integer.class);
         return count == null ? 0 : count;
+    }
+
+    /**
+     * Total beneficiaries already processed by partitions completed in prior runs
+     */
+    public long completedProcessedCount(String jobUuid, String workerStepName) {
+        Long count = jdbc.queryForObject(COMPLETED_PROCESSED_COUNT_SQL,
+                Map.of("uuid", jobUuid, "stepPrefix", workerStepName + ":partition%"), Long.class);
+        return count == null ? 0L : count;
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -284,6 +284,8 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             leaseRenewer.untrack(jobUuid);
         }
 
+        preserveLiveProgress(job, jobUuid);
+
         Job result = jobRepository.save(job);
         // EFS cleanup. We do not handle in_progress or submitted status here, because both of those
         // are resumable and somebody else will handle the files/directories
@@ -321,6 +323,20 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         job.setStatus(FAILED);
         job.setStatusMessage("Failed: too many patient records in the job had failures");
         coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+    }
+
+    /**
+     * Refreshes the jobs progress before the job saves so we don't overwrite the progress count
+     * with stale info
+     */
+    private void preserveLiveProgress(Job job, String jobUuid) {
+        if (job.getStatus() == SUCCESSFUL) {
+            return;
+        }
+        Job persisted = jobRepository.findByJobUuid(jobUuid);
+        if (persisted != null) {
+            job.setProgress(persisted.getProgress());
+        }
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -2,14 +2,20 @@ package gov.cms.ab2d.worker.processor.prototype;
 
 import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.fhir.FhirVersion;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.repository.JobRepository;
+import gov.cms.ab2d.worker.processor.JobMeasure;
+import gov.cms.ab2d.worker.processor.JobProgressService;
+import gov.cms.ab2d.worker.processor.JobProgressUpdateService;
+import gov.cms.ab2d.worker.processor.ProgressTracker;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
 import gov.cms.ab2d.worker.processor.prototype.lease.JobLeaseRepository;
 import gov.cms.ab2d.worker.processor.prototype.lease.PrototypeFenceGuard;
 import gov.cms.ab2d.worker.processor.prototype.lease.PrototypeJobLeaseRenewer;
+import gov.cms.ab2d.worker.service.JobChannelService;
 import lombok.extern.slf4j.Slf4j;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -30,9 +36,12 @@ import org.springframework.web.client.ResourceAccessException;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PROD_LIST;
+import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_COMPLETED;
 import static gov.cms.ab2d.job.model.JobStatus.CANCELLED;
 import static gov.cms.ab2d.job.model.JobStatus.FAILED;
 import static gov.cms.ab2d.job.model.JobStatus.IN_PROGRESS;
@@ -71,19 +80,21 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private final PrototypeOutputAssembler outputAssembler;
     private final PrototypeJobLeaseRenewer leaseRenewer;
     private final JobLeaseRepository jobLease;
+    // progress and failure reporting, reused from the main processor
+    private final JobChannelService jobChannelService;
+    private final JobProgressService jobProgressService;
+    private final JobProgressUpdateService jobProgressUpdateService;
+    private final SQSEventClient eventLogger;
     // per-JVM diagnostic identity recorded on the lease so logs/monitoring can attribute ownership
     private final String owner = "worker-" + java.util.UUID.randomUUID();
-    private final int partitionSize;
-    private final int chunkSize;
-    private final int concurrency;
-    private final int maxFailureAttempts;
-    private final int maxStartAttempts;
-    private final int itemRetryLimit;
-    private final long shutdownAwaitMs;
+    private final PrototypeProperties props;
+
+    private final int failureThreshold;
+    private final int auditFilesTtlHours;
 
     private final BeneficiaryItemReader beneficiaryItemReader;
     private final EobItemProcessor eobItemProcessor;
-    private final ItemStreamWriter<List<IBaseResource>> ndjsonItemWriter;
+    private final ItemStreamWriter<SerializedEobs> ndjsonItemWriter;
 
     public PrototypeJobProcessorImpl(
             JobRepository jobRepository,
@@ -95,16 +106,16 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             PrototypeOutputAssembler outputAssembler,
             PrototypeJobLeaseRenewer leaseRenewer,
             JobLeaseRepository jobLease,
+            JobChannelService jobChannelService,
+            JobProgressService jobProgressService,
+            JobProgressUpdateService jobProgressUpdateService,
+            SQSEventClient eventLogger,
             BeneficiaryItemReader beneficiaryItemReader,
             EobItemProcessor eobItemProcessor,
-            ItemStreamWriter<List<IBaseResource>> ndjsonItemWriter,
-            @Value("${pause-resume.prototype.partition-size:1000}") int partitionSize,
-            @Value("${pause-resume.prototype.chunk-size:100}") int chunkSize,
-            @Value("${pause-resume.prototype.concurrency:4}") int concurrency,
-            @Value("${pause-resume.prototype.max-failure-attempts:3}") int maxFailureAttempts,
-            @Value("${pause-resume.prototype.max-start-attempts:50}") int maxStartAttempts,
-            @Value("${pause-resume.prototype.item-retry-limit:3}") int itemRetryLimit,
-            @Value("${pause-resume.prototype.shutdown-await-ms:30000}") long shutdownAwaitMs) {
+            ItemStreamWriter<SerializedEobs> ndjsonItemWriter,
+            PrototypeProperties props,
+            @Value("${failure.threshold}") int failureThreshold,
+            @Value("${audit.files.ttl.hours}") int auditFilesTtlHours) {
         this.jobRepository = jobRepository;
         this.jobOperator = jobOperator;
         this.batchJobRepository = batchJobRepository;
@@ -114,16 +125,16 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         this.outputAssembler = outputAssembler;
         this.leaseRenewer = leaseRenewer;
         this.jobLease = jobLease;
-        this.partitionSize = partitionSize;
+        this.jobChannelService = jobChannelService;
+        this.jobProgressService = jobProgressService;
+        this.jobProgressUpdateService = jobProgressUpdateService;
+        this.eventLogger = eventLogger;
         this.beneficiaryItemReader = beneficiaryItemReader;
         this.eobItemProcessor = eobItemProcessor;
         this.ndjsonItemWriter = ndjsonItemWriter;
-        this.chunkSize = chunkSize;
-        this.concurrency = concurrency;
-        this.maxFailureAttempts = maxFailureAttempts;
-        this.maxStartAttempts = maxStartAttempts;
-        this.itemRetryLimit = itemRetryLimit;
-        this.shutdownAwaitMs = shutdownAwaitMs;
+        this.props = props;
+        this.failureThreshold = failureThreshold;
+        this.auditFilesTtlHours = auditFilesTtlHours;
     }
 
     @Override
@@ -192,6 +203,17 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                         last.getId(), jobUuid, softResume ? "soft resume" : "hard recovery", fenceToken);
             }
 
+            // job progress is initialized on startup since we could be restarting
+            // a job that was already in progress
+            jobProgressUpdateService.initJob(jobUuid);
+            jobChannelService.sendUpdate(jobUuid, JobMeasure.FAILURE_THRESHHOLD, failureThreshold);
+            jobChannelService.sendUpdate(jobUuid, JobMeasure.PATIENTS_EXPECTED,
+                    coverageV3Service.getMaxRowNumber(contractNumber));
+            long alreadyProcessed = batchMeta.completedProcessedCount(jobUuid, WORKER_STEP_NAME);
+            if (alreadyProcessed > 0) {
+                jobChannelService.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_PROCESSED, alreadyProcessed);
+            }
+
             org.springframework.batch.core.job.Job batchJob = buildPartitionedJob(contractNumber, jobUuid, fenceToken);
 
             JobExecution execution = launchOrResume(batchJob, parameters, last);
@@ -212,16 +234,21 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             if (current != null && current.getStatus() == CANCELLED) {
                 log.warn("prototype job {} was cancelled during processing; leaving CANCELLED and cleaning up", jobUuid);
                 coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+                outputAssembler.deleteJobDirectory(jobUuid);
                 return current;
             }
 
             if (execution.getStatus() == BatchStatus.COMPLETED) {
-                // Failure during assembly is terminal and fails the job. We can recover from a crash during
-                // assembly, but we can't recover from an exception e.g. missing files in a "completed" job.
-                outputAssembler.assemble(job, jobUuid, contractNumber);
-                job.setStatus(SUCCESSFUL);
-                job.setStatusMessage("Completed via prototype");
-                coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+                if (thresholdExceeded(jobUuid)) {
+                    // The batch finished but too many beneficiaries errored, this is a terminal failure
+                    applyThresholdFailure(job, contractNumber, jobUuid);
+                } else {
+                    // Failure during assembly is terminal and fails the job. We can recover from a crash
+                    // during assembly, but not from an exception e.g. missing files in a "completed" job.
+                    outputAssembler.assemble(job, jobUuid, contractNumber);
+                    completeJobSuccessfully(job, jobUuid);
+                    coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+                }
             } else if (execution.getStatus() == BatchStatus.STOPPED || wasInterrupted(execution)) {
                 // Graceful shutdown ensures that the batch job is fully stopped and every file has been closed
                 // and fsynced its file to the saved offset.
@@ -230,8 +257,11 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 jobLease.markCleanSuspend(jobUuid, fenceToken);
                 job.setStatus(SUBMITTED);
                 job.setStatusMessage("Paused via prototype");
+            } else if (hasThresholdException(execution) || thresholdExceeded(jobUuid)) {
+                // Too many beneficiaries errored, terminal failure
+                applyThresholdFailure(job, contractNumber, jobUuid);
             } else {
-                // A run that failed is resumable, up to some tolerance for retrying
+                // A run that failed for other reasons is resumable, up to some tolerance for retrying
                 applyFailureOutcome(job, contractNumber, jobUuid,
                         "Prototype failed with status " + execution.getStatus());
             }
@@ -254,7 +284,15 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             leaseRenewer.untrack(jobUuid);
         }
 
-        return jobRepository.save(job);
+        Job result = jobRepository.save(job);
+        // EFS cleanup. We do not handle in_progress or submitted status here, because both of those
+        // are resumable and somebody else will handle the files/directories
+        if (result.getStatus() == SUCCESSFUL) {
+            outputAssembler.deleteIntermediateDirectories(jobUuid);
+        } else if (result.getStatus() == FAILED) {
+            outputAssembler.deleteJobDirectory(jobUuid);
+        }
+        return result;
     }
 
     /**
@@ -262,6 +300,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      */
     private void applyFailureOutcome(Job job, String contractNumber, String jobUuid, String message) {
         int failures = batchMeta.failedExecutionCount(jobUuid);
+        int maxFailureAttempts = props.getMaxFailureAttempts();
         if (failures < maxFailureAttempts) {
             job.setStatus(SUBMITTED);
             job.setStatusMessage(message + " (attempt " + failures + " of " + maxFailureAttempts + "; will resume)");
@@ -272,6 +311,45 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             log.error("prototype job {} exhausted {} failure attempts - marking FAILED", jobUuid, maxFailureAttempts);
             coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
         }
+    }
+
+    /**
+     * Terminal failure because too many beneficiaries errored
+     */
+    private void applyThresholdFailure(Job job, String contractNumber, String jobUuid) {
+        log.error("prototype job {} failed: too many patient records in the job had failures", jobUuid);
+        job.setStatus(FAILED);
+        job.setStatusMessage("Failed: too many patient records in the job had failures");
+        coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+    }
+
+    /**
+     * Record terminal success state, great job.
+     */
+    private void completeJobSuccessfully(Job job, String jobUuid) {
+        ProgressTracker tracker = jobProgressService.getStatus(jobUuid);
+        int processed = tracker == null ? 0 : tracker.getPatientRequestProcessedCount();
+        String message = String.format("%s via prototype: processed %d patients into %d file(s)",
+                EOB_JOB_COMPLETED, processed, job.getJobOutputs().size());
+        eventLogger.logAndAlert(job.buildJobStatusChangeEvent(SUCCESSFUL, message), PROD_LIST);
+
+        job.setStatus(SUCCESSFUL);
+        job.setStatusMessage("100%");
+        job.setProgress(100);
+        job.setExpiresAt(OffsetDateTime.now().plusHours(auditFilesTtlHours));
+        job.setCompletedAt(OffsetDateTime.now());
+    }
+
+    /** True if the progress tracker shows the failed-bene ratio at or above the threshold. */
+    private boolean thresholdExceeded(String jobUuid) {
+        ProgressTracker tracker = jobProgressService.getStatus(jobUuid);
+        return tracker != null && tracker.getTotalCount() > 0 && tracker.isErrorThresholdExceeded();
+    }
+
+    /** True if the batch failed because a chunk tripped the failure threshold mid-run. */
+    private boolean hasThresholdException(JobExecution execution) {
+        return execution.getAllFailureExceptions().stream()
+                .anyMatch(ThresholdExceededException.class::isInstance);
     }
 
     /**
@@ -297,6 +375,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
 
         // Wait for the partition threads to actually finish before changing status
         // might need a TODO for a more robust system than a sleep
+        long shutdownAwaitMs = props.getShutdownAwaitMs();
         long deadline = System.currentTimeMillis() + shutdownAwaitMs;
         while (System.currentTimeMillis() < deadline) {
             if (batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).isEmpty()) {
@@ -374,16 +453,21 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private org.springframework.batch.core.job.Job buildPartitionedJob(String contractNumber, String jobUuid,
             long fenceToken) {
         var workerStepBuilder = new StepBuilder(WORKER_STEP_NAME, batchJobRepository)
-                .<CoverageSummary, List<IBaseResource>>chunk(chunkSize)
+                .<CoverageSummary, SerializedEobs>chunk(props.getChunkSize())
                 .reader(beneficiaryItemReader)
                 .processor(eobItemProcessor)
                 .writer(ndjsonItemWriter)
                 // each chunk commit comes with a fence token which prevents
                 // us from committing work if we've lost the job
                 .listener(new PrototypeFenceGuard(jobLease, jobUuid, fenceToken))
-                // retry transient item level failures before failing the chunk
+                // per-chunk progress and failure reporting
+                .listener(new PrototypeProgressListener(jobChannelService, jobProgressService, jobUuid))
                 .faultTolerant()
-                .retryLimit(itemRetryLimit);
+                // retry items that fail, skip benes that fail too much
+                .retryLimit(props.getItemRetryLimit())
+                .skipPolicy(new PrototypeSkipPolicy())
+                // count each skipped beneficiary as one error against the error threshold
+                .skipListener(new PrototypeSkipCounter(jobChannelService, jobUuid));
         TRANSIENT_EXCEPTIONS.forEach(workerStepBuilder::retry);
 
         Step workerStep = workerStepBuilder
@@ -391,11 +475,12 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 .listener(new JobCancellationChunkListener(jobRepository, jobUuid))
                 .allowStartIfComplete(false)
                 // should basically never trip
-                .startLimit(maxStartAttempts)
+                .startLimit(props.getMaxStartAttempts())
                 .transactionManager(transactionManager)
                 .build();
 
-        BeneficiaryPartitioner partitioner = new BeneficiaryPartitioner(coverageV3Service, contractNumber, partitionSize);
+        BeneficiaryPartitioner partitioner =
+                new BeneficiaryPartitioner(coverageV3Service, contractNumber, props.getPartitionSize());
 
         // the manager partitions the work, and each partition gets its own
         // workerStep, which brings along its own reader/processor/writer
@@ -404,7 +489,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 .partitioner(WORKER_STEP_NAME, partitioner)
                 .step(workerStep)
                 .taskExecutor(partitionTaskExecutor())
-                .gridSize(concurrency)
+                .gridSize(props.getConcurrency())
                 .build();
 
         return new JobBuilder(PROTOTYPE_JOB_NAME, batchJobRepository)
@@ -418,7 +503,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      */
     private TaskExecutor partitionTaskExecutor() {
         SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("proto-partition-");
-        executor.setConcurrencyLimit(Math.max(1, concurrency));
+        executor.setConcurrencyLimit(Math.max(1, props.getConcurrency()));
         return executor;
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
+import gov.cms.ab2d.aggregator.FileOutputType;
 import gov.cms.ab2d.fhir.BundleUtils;
 import gov.cms.ab2d.job.model.Job;
 import gov.cms.ab2d.job.model.JobOutput;
@@ -8,6 +9,7 @@ import gov.cms.ab2d.worker.config.SearchConfig;
 import gov.cms.ab2d.worker.processor.StreamOutput;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.FileSystemUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -23,16 +25,14 @@ import java.util.List;
  * picks files from multiple potential candidates, tolerates unfinished prior assembly, and does so
  * idempotently.
  *
- * TODO: Prototype simplifications that will need to be fixed on integration:
- *      Streaming/finished directories need to be deleted
- *      Output needs to be compressed
- *      No error ndjson produced
  */
 @Slf4j
 @Component
 public class PrototypeOutputAssembler {
 
     private static final int BYTES_PER_MB = 1024 * 1024;
+    private static final String DATA_SUFFIX = "";
+    private static final String ERROR_SUFFIX = "_error";
 
     private final SearchConfig searchConfig;
     private final JobOutputRepository jobOutputRepository;
@@ -52,6 +52,14 @@ public class PrototypeOutputAssembler {
      * @throws IOException If a winning file is missing, the job is a failure and cannot be completed.
      */
     public void assemble(Job job, String jobUuid, String contractNumber) throws IOException {
+        // existence of JobOutput rows indicates we've already done the assembly, so we skip
+        long existingOutputs = jobOutputRepository.countByJob(job);
+        if (existingOutputs > 0) {
+            log.info("assembly for job {}: output already delivered ({} JobOutput row(s)) - skipping",
+                    jobUuid, existingOutputs);
+            return;
+        }
+
         List<PrototypeBatchMetadataRepository.CompletedPartition> partitions =
                 batchMeta.completedPartitionFiles(jobUuid, PrototypeJobProcessorImpl.WORKER_STEP_NAME);
 
@@ -65,74 +73,111 @@ public class PrototypeOutputAssembler {
         Path jobRoot = Path.of(searchConfig.getEfsMount(), jobUuid);
         long rolloverBytes = (long) searchConfig.getNdjsonRollOver() * BYTES_PER_MB;
 
-        // Promote the winning component files streaming/ -> finished/, so finished/ ends up holding exactly the one
-        // file per partition
         Files.createDirectories(finishedDir);
-        List<Path> winners = promoteWinners(partitions, contractNumber, streamingDir, finishedDir, jobUuid);
-
         Files.createDirectories(jobRoot);
-        List<Path> rolloverFiles = concatenate(winners, contractNumber, jobRoot, rolloverBytes);
 
-        List<JobOutput> outputs = new ArrayList<>(rolloverFiles.size());
-        for (Path file : rolloverFiles) {
-            String fileName = file.getFileName().toString();
-            // a worker that crashed between the batch being completed and the job being recorded successful
-            // re-runs assembly on recovery. We skip files with existing JobOutput to avoid duplicates.
-            if (jobOutputRepository.findByFilePathAndJob(fileName, job).isPresent()) {
-                log.info("assembly for job {}: JobOutput for {} already registered - skipping (idempotent re-assembly)",
-                        jobUuid, fileName);
-                continue;
-            }
-            JobOutput output = new JobOutput();
-            output.setFilePath(fileName);
-            output.setFhirResourceType(BundleUtils.EOB);
-            output.setError(false);
-            output.setChecksum(StreamOutput.generateChecksum(file.toFile()));
-            output.setFileLength(Files.size(file));
-            job.addJobOutput(output);
-            outputs.add(output);
-        }
+        // Data stream is required: a missing data winner means the delivered output would be incomplete.
+        List<Path> dataWinners = promoteWinners(partitions, contractNumber, DATA_SUFFIX, streamingDir, finishedDir,
+                jobUuid, true);
+        List<Path> dataRollover = concatenate(dataWinners, contractNumber, jobRoot, rolloverBytes, DATA_SUFFIX);
+
+        // Error stream is optional: a partition with no serialization failures has an empty error file.
+        List<Path> errorWinners = promoteWinners(partitions, contractNumber, ERROR_SUFFIX, streamingDir, finishedDir,
+                jobUuid, false);
+        List<Path> errorRollover = concatenate(errorWinners, contractNumber, jobRoot, rolloverBytes, ERROR_SUFFIX);
+
+        List<JobOutput> outputs = new ArrayList<>(dataRollover.size() + errorRollover.size());
+        registerOutputs(dataRollover, job, outputs);
+        registerOutputs(errorRollover, job, outputs);
         if (!outputs.isEmpty()) {
             jobOutputRepository.saveAll(outputs);
         }
-        log.info("assembly for job {}: promoted {} winning partition file(s) to finished/ and registered {} new "
-                + "rollover manifest row(s) of {} rollover file(s)",
-                jobUuid, winners.size(), outputs.size(), rolloverFiles.size());
+        log.info("assembly for job {}: {} data + {} error rollover file(s) from {} winning partition(s), "
+                + "{} new JobOutput row(s)",
+                jobUuid, dataRollover.size(), errorRollover.size(), dataWinners.size(), outputs.size());
     }
 
     /**
-     * Promotes files from streaming to finished, and tolerates a winner already in finished from prior
-     * crashed workers. File selection is deterministic, it's always the file with the highest value token.
+     * Compress each rollover file and register a JobOutput row for it. Idempotency is handled by parent.
+     */
+    private void registerOutputs(List<Path> rolloverFiles, Job job, List<JobOutput> outputs)
+            throws IOException {
+        for (Path file : rolloverFiles) {
+            StreamOutput streamOutput = new StreamOutput(file.toFile());
+            JobOutput output = new JobOutput();
+            output.setFilePath(streamOutput.getFilePath());
+            output.setFhirResourceType(BundleUtils.EOB);
+            output.setError(streamOutput.getType() == FileOutputType.ERROR
+                    || streamOutput.getType() == FileOutputType.ERROR_COMPRESSED);
+            output.setChecksum(streamOutput.getChecksum());
+            output.setFileLength(streamOutput.getFileLength());
+            job.addJobOutput(output);
+            outputs.add(output);
+        }
+    }
+
+    /**
+     * Remove the streaming/ and finished/ directories if the job is successful
+     */
+    public void deleteIntermediateDirectories(String jobUuid) {
+        boolean streaming = FileSystemUtils.deleteRecursively(searchConfig.getStreamingDir(jobUuid));
+        boolean finished = FileSystemUtils.deleteRecursively(searchConfig.getFinishedDir(jobUuid));
+        log.info("cleanup for job {}: removed intermediate directories (streaming={}, finished={})",
+                jobUuid, streaming, finished);
+    }
+
+    /**
+     * Remove the entire job output directory. Called on a terminal failure or cancellation so we do not
+     * leave partial output lying around on EFS.
+     */
+    public void deleteJobDirectory(String jobUuid) {
+        boolean removed = FileSystemUtils.deleteRecursively(Path.of(searchConfig.getEfsMount(), jobUuid).toFile());
+        log.info("cleanup for job {}: removed job output directory (existed={})", jobUuid, removed);
+    }
+
+    /**
+     * Takes as an argument a list of the winning partition files (already determined earlier) and
+     * promotes them, checking the finished directory to see if there is already a winner there from
+     * a prior assembly that got interrupted.
+     *
+     * @param required if true a missing winner is fatal. Missing winners for data files is fatal
+     *                      missing winners for error files is fine, there might not be one
      */
     private List<Path> promoteWinners(List<PrototypeBatchMetadataRepository.CompletedPartition> partitions,
-                                      String contractNumber, Path streamingDir, Path finishedDir, String jobUuid)
-            throws IOException {
+                                      String contractNumber, String suffix, Path streamingDir, Path finishedDir,
+                                      String jobUuid, boolean required) throws IOException {
         List<Path> promoted = new ArrayList<>(partitions.size());
         for (PrototypeBatchMetadataRepository.CompletedPartition partition : partitions) {
             String name = contractNumber + "_partition" + partition.partitionIndex()
-                    + "_t" + partition.token() + ".ndjson";
+                    + "_t" + partition.token() + suffix + ".ndjson";
             Path source = streamingDir.resolve(name);
             Path dest = finishedDir.resolve(name);
-            if (!Files.isRegularFile(source)) {
-                if (Files.isRegularFile(dest)) {
-                    promoted.add(dest);   // already promoted by an earlier, interrupted assembly
+            if (Files.isRegularFile(source)) {
+                if (!required && Files.size(source) == 0) {
+                    continue;   // empty file for this partition, but it isn't required
+                }
+                Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING);
+                promoted.add(dest);
+            } else if (Files.isRegularFile(dest)) {
+                if (!required && Files.size(dest) == 0) {
                     continue;
                 }
+                promoted.add(dest);   // already promoted by an earlier, interrupted assembly
+            } else if (required) {
                 throw new IOException("assembly for job " + jobUuid + ": winning file missing for partition "
                         + partition.partitionIndex() + " (token " + partition.token() + "): " + source
-                        + " - refusing to deliver incomplete output");
+                        + " - the output is incomplete, so the assembly is terminated");
             }
-            Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING);
-            promoted.add(dest);
         }
         return promoted;
     }
 
     /**
-     * Concatenates the winning files into ndjson of the desired size.
+     * Concatenates the winning files into ndjson of the desired size. Returns an empty list when there are
+     * no winners (like in the case of an error stream with no errors).
      */
-    private List<Path> concatenate(List<Path> winners, String contractNumber, Path jobRoot, long rolloverBytes)
-            throws IOException {
+    private List<Path> concatenate(List<Path> winners, String contractNumber, Path jobRoot, long rolloverBytes,
+                                   String suffix) throws IOException {
         List<Path> rolloverFiles = new ArrayList<>();
         int sequence = 0;
         OutputStream current = null;
@@ -145,7 +190,7 @@ public class PrototypeOutputAssembler {
                     current = null;
                 }
                 if (current == null) {
-                    Path currentPath = jobRoot.resolve(rolloverFileName(contractNumber, ++sequence));
+                    Path currentPath = jobRoot.resolve(rolloverFileName(contractNumber, ++sequence, suffix));
                     current = Files.newOutputStream(currentPath);
                     currentSize = 0;
                     rolloverFiles.add(currentPath);
@@ -161,7 +206,7 @@ public class PrototypeOutputAssembler {
         return rolloverFiles;
     }
 
-    private static String rolloverFileName(String contractNumber, int sequence) {
-        return contractNumber + "_" + String.format("%04d", sequence) + ".ndjson";
+    private static String rolloverFileName(String contractNumber, int sequence, String suffix) {
+        return contractNumber + "_" + String.format("%04d", sequence) + suffix + ".ndjson";
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
@@ -1,25 +1,31 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
+import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.worker.processor.JobMeasure;
 import gov.cms.ab2d.worker.processor.JobProgressService;
 import gov.cms.ab2d.worker.processor.ProgressTracker;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
 import gov.cms.ab2d.worker.service.JobChannelService;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.batch.core.listener.ChunkListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.core.scope.context.StepSynchronizationManager;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.Chunk;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Reports the progress of a job to {@link ProgressTracker} and checks to see if we've passed the
- * failure threshold.
+ * Reports per-chunk progress to {@link ProgressTracker} and aborts the step when the failure
+ * threshold is exceeded. A single instance is shared by all partition worker threads.
  *
- * A single instance is shared by all partition worker threads.
+ * The read/write counts come from the {@link StepExecution}, which this callback is not passed,
+ * so it is read from the step context.
  */
 @Slf4j
-public class PrototypeProgressListener implements ChunkListener {
+public class PrototypeProgressListener implements ChunkListener<CoverageSummary, SerializedEobs> {
 
     private final JobChannelService channel;
     private final JobProgressService progress;
@@ -34,8 +40,13 @@ public class PrototypeProgressListener implements ChunkListener {
     }
 
     @Override
-    public synchronized void afterChunk(@NonNull ChunkContext context) {
-        var stepExecution = context.getStepContext().getStepExecution();
+    public synchronized void afterChunk(@NonNull Chunk<SerializedEobs> chunk) {
+        StepExecution stepExecution = currentStepExecution();
+        if (stepExecution == null) {
+            log.warn("job {} afterChunk with no bound step context; skipping progress update", jobUuid);
+            return;
+        }
+
         long read = stepExecution.getReadCount();
         long write = stepExecution.getWriteCount();
 
@@ -62,5 +73,10 @@ public class PrototypeProgressListener implements ChunkListener {
             throw new ThresholdExceededException(jobUuid, tracker.getPatientFailureCount(),
                     tracker.getTotalCount(), tracker.getFailureThreshold());
         }
+    }
+
+    private static StepExecution currentStepExecution() {
+        StepContext context = StepSynchronizationManager.getContext();
+        return context == null ? null : context.getStepExecution();
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
@@ -1,0 +1,66 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.worker.processor.JobMeasure;
+import gov.cms.ab2d.worker.processor.JobProgressService;
+import gov.cms.ab2d.worker.processor.ProgressTracker;
+import gov.cms.ab2d.worker.service.JobChannelService;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.batch.core.listener.ChunkListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reports the progress of a job to {@link ProgressTracker} and checks to see if we've passed the
+ * failure threshold.
+ *
+ * A single instance is shared by all partition worker threads.
+ */
+@Slf4j
+public class PrototypeProgressListener implements ChunkListener {
+
+    private final JobChannelService channel;
+    private final JobProgressService progress;
+    private final String jobUuid;
+    // stepExecutionId -> last reported [read, write] for the current run
+    private final Map<Long, long[]> reported = new HashMap<>();
+
+    public PrototypeProgressListener(JobChannelService channel, JobProgressService progress, String jobUuid) {
+        this.channel = channel;
+        this.progress = progress;
+        this.jobUuid = jobUuid;
+    }
+
+    @Override
+    public synchronized void afterChunk(@NonNull ChunkContext context) {
+        var stepExecution = context.getStepContext().getStepExecution();
+        long read = stepExecution.getReadCount();
+        long write = stepExecution.getWriteCount();
+
+        long[] last = reported.getOrDefault(stepExecution.getId(), new long[2]);
+        long readDelta = read - last[0];
+        long writeDelta = write - last[1];
+        reported.put(stepExecution.getId(), new long[]{read, write});
+
+        // read count includes benes that were skipped, the subset that were skipped is counted
+        // separately by the SkipCounter
+        if (readDelta > 0) {
+            channel.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_PROCESSED, readDelta);
+        }
+        if (writeDelta > 0) {
+            channel.sendUpdate(jobUuid, JobMeasure.PATIENTS_WITH_EOBS, writeDelta);
+        }
+
+        // Optimistic abort by checking failures against the failure threshold.
+        // Checked again by the processor when the job finishes.
+        ProgressTracker tracker = progress.getStatus(jobUuid);
+        if (tracker != null && tracker.getTotalCount() > 0 && tracker.isErrorThresholdExceeded()) {
+            log.warn("job {} tripped failure threshold mid-run ({} of {} benes failed) - aborting",
+                    jobUuid, tracker.getPatientFailureCount(), tracker.getTotalCount());
+            throw new ThresholdExceededException(jobUuid, tracker.getPatientFailureCount(),
+                    tracker.getTotalCount(), tracker.getFailureThreshold());
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -1,0 +1,39 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Props of the prototype job processor, provided here as a component so that the
+ * job processor's already behemoth constructor doesn't need an individual line for
+ * each of the configs
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "pause-resume.prototype")
+public class PrototypeProperties {
+
+    /** Beneficiaries per partition. */
+    private int partitionSize = 1000;
+
+    /** Beneficiaries per chunk commit. */
+    private int chunkSize = 100;
+
+    /** Number of partitions processed concurrently. */
+    private int concurrency = 4;
+
+    /** How many times a job's batch execution can fail before it is marked terminally failed. */
+    private int maxFailureAttempts = 8;
+
+    /** How many times a job can be restarted, this is for safety and should basically never reach max. */
+    private int maxStartAttempts = 50;
+
+    /** Item-level retries before marking an item as failed. */
+    private int itemRetryLimit = 3;
+
+    /** How long shutdown waits for the batch execution to finish cleaning up before shutting down. */
+    private long shutdownAwaitMs = 32000;
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
@@ -1,0 +1,44 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.coverage.model.CoverageSummary;
+import gov.cms.ab2d.worker.processor.JobMeasure;
+import gov.cms.ab2d.worker.processor.SerializedEobs;
+import gov.cms.ab2d.worker.service.JobChannelService;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.batch.core.listener.SkipListener;
+
+/**
+ * Counts beneficiares skipped for any reason as an error in the progress tracker.
+ */
+@Slf4j
+public class PrototypeSkipCounter implements SkipListener<CoverageSummary, SerializedEobs> {
+
+    private final JobChannelService channel;
+    private final String jobUuid;
+
+    public PrototypeSkipCounter(JobChannelService channel, String jobUuid) {
+        this.channel = channel;
+        this.jobUuid = jobUuid;
+    }
+
+    @Override
+    public void onSkipInProcess(@NonNull CoverageSummary item, @NonNull Throwable t) {
+        recordSkip(t);
+    }
+
+    @Override
+    public void onSkipInRead(@NonNull Throwable t) {
+        recordSkip(t);
+    }
+
+    @Override
+    public void onSkipInWrite(@NonNull SerializedEobs item, @NonNull Throwable t) {
+        recordSkip(t);
+    }
+
+    private void recordSkip(Throwable t) {
+        log.warn("job {}: skipping a beneficiary after a persistent failure: {}", jobUuid, t.toString());
+        channel.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_ERRORED, 1);
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.batch.core.listener.SkipListener;
 
 /**
- * Counts beneficiares skipped for any reason as an error in the progress tracker.
+ * Counts beneficiaries skipped for any reason as an error in the progress tracker.
  */
 @Slf4j
 public class PrototypeSkipCounter implements SkipListener<CoverageSummary, SerializedEobs> {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipPolicy.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipPolicy.java
@@ -1,0 +1,29 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.worker.processor.prototype.lease.FenceLostException;
+import org.springframework.batch.core.step.skip.SkipPolicy;
+
+/**
+ * Our policy is to skip a failing beneficiary unless it is failing for one of the following reasons, in
+ * which case the job will be failed.
+ *   - {@link FenceLostException}: this worker lost its lease
+ *   - {@link InterruptedException}: a pause/shutdown in progress
+ *   - {@link ThresholdExceededException}: too many skips
+ */
+public class PrototypeSkipPolicy implements SkipPolicy {
+
+    /**
+     * the skipCount argument is intentionally unused. We cap skips not by absolute count but
+     * by percentage of total benes. This is handled with the threshold exception.
+     */
+    @Override
+    public boolean shouldSkip(Throwable t, long skipCount) {
+        return !isControlFlow(t) && !isControlFlow(t.getCause());
+    }
+
+    private static boolean isControlFlow(Throwable t) {
+        return t instanceof FenceLostException
+                || t instanceof InterruptedException
+                || t instanceof ThresholdExceededException;
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ThresholdExceededException.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ThresholdExceededException.java
@@ -1,0 +1,13 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+/**
+ * Thrown when the number of skipped benes exceeds the defined threshold, which is expressed
+ * as a percentage of the total benes.
+ */
+public class ThresholdExceededException extends RuntimeException {
+
+    public ThresholdExceededException(String jobUuid, int failures, int expected, int thresholdPercent) {
+        super("job " + jobUuid + " exceeded failure threshold: " + failures + " of " + expected
+                + " beneficiaries failed (over " + thresholdPercent + "%)");
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/service/WorkerServiceImpl.java
@@ -45,22 +45,22 @@ public class WorkerServiceImpl implements WorkerService {
 
         activeJobs.add(jobUuid);
         try {
-            // when prototype pause/resume feature is enabled, reroute the entire job to the prototype
-            if (propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false)) {
-                log.info("{} routed to pause/resume prototype processor", jobUuid);
-                return prototypeJobProcessor.process(jobUuid);
-            }
-
             Job job = jobPreprocessor.preprocess(jobUuid);
 
             if (job.getStatus() == JobStatus.IN_PROGRESS) {
                 log.info("{} has been started", jobUuid);
 
-                if (job.getFhirVersion() == FhirVersion.R4V3) {
-                    coverageV3Service.createAggregatedAttributionTable(job.getContractNumber());
+                // The pause/resume prototype handles v3 jobs when the feature flag is on
+                if (propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false)
+                        && job.getFhirVersion() == FhirVersion.R4V3) {
+                    log.info("{} routed to pause/resume prototype processor", jobUuid);
+                    job = prototypeJobProcessor.process(jobUuid);
+                } else {
+                    if (job.getFhirVersion() == FhirVersion.R4V3) {
+                        coverageV3Service.createAggregatedAttributionTable(job.getContractNumber());
+                    }
+                    job = jobProcessor.process(jobUuid);
                 }
-
-                job = jobProcessor.process(jobUuid);
                 log.info("Job was processed");
             } else if (job.getStatus() == JobStatus.SUBMITTED) {
                 log.info("{} job is waiting for enrollment information", jobUuid);

--- a/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorImpl.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.stuckjob;
 
+import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.fhir.FhirVersion;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import static gov.cms.ab2d.common.util.PropertyConstants.PAUSE_RESUME_PROTOTYPE_ENABLED;
 import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_CANCELLED;
 import static gov.cms.ab2d.job.model.JobStatus.CANCELLED;
@@ -29,18 +31,21 @@ public class CancelStuckJobsProcessorImpl implements CancelStuckJobsProcessor {
     private final int cancelThreshold;
     private final CoverageV3Service coverageV3Service;
     private final PrototypeBatchMetadataRepository batchMeta;
+    private final PropertiesService propertiesService;
 
     public CancelStuckJobsProcessorImpl(
             JobRepository jobRepository,
             SQSEventClient eventLogger,
             @Value("${stuck.job.cancel.threshold}") int cancelThreshold,
             CoverageV3Service coverageV3Service,
-            PrototypeBatchMetadataRepository batchMeta) {
+            PrototypeBatchMetadataRepository batchMeta,
+            PropertiesService propertiesService) {
         this.jobRepository = jobRepository;
         this.eventLogger = eventLogger;
         this.cancelThreshold = cancelThreshold;
         this.coverageV3Service = coverageV3Service;
         this.batchMeta = batchMeta;
+        this.propertiesService = propertiesService;
     }
 
     @Override
@@ -52,13 +57,15 @@ public class CancelStuckJobsProcessorImpl implements CancelStuckJobsProcessor {
         final List<Job> stuckJobs = jobRepository.findStuckJobs(cutOffTime);
         log.info("Found {} jobs that appears to be stuck", stuckJobs.size());
 
+        final boolean prototypeEnabled = propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false);
+
         for (Job stuckJob : stuckJobs) {
             // For pause/resume jobs, the runtime of the job must not include time spent paused
-            if (stuckJob.getFhirVersion() == FhirVersion.R4V3) {
+            if (prototypeEnabled && stuckJob.getFhirVersion() == FhirVersion.R4V3) {
                 final long activeSeconds = batchMeta.activeRuntimeSeconds(stuckJob.getJobUuid());
                 final long thresholdSeconds = (long) cancelThreshold * 3600L;
                 if (activeSeconds < thresholdSeconds) {
-                    log.info("Skipping stuck-cancel for v3 job {} (likely paused)",
+                    log.info("Skipping stuck-cancel for v3 pause/resume job {} (likely paused)",
                             stuckJob.getJobUuid());
                     continue;
                 }

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -20,7 +20,7 @@ spring.integration.jdbc.initialize-schema=always
 pause-resume.prototype.item-delay-ms=0
 # DEV CRASH TESTING - sets the probability that the worker just crashes
 # for testing purposes only
-pause-resume.prototype.crash-probability=0.001
+pause-resume.prototype.crash-probability=0
 # granularity for pause/resume checkpointing
 pause-resume.prototype.chunk-size=100
 # number of partitions processed concurrently

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -18,6 +18,9 @@ spring.integration.jdbc.initialize-schema=always
 
 # artificial wait to simulate longer jobs
 pause-resume.prototype.item-delay-ms=0
+# DEV CRASH TESTING - sets the probability that the worker just crashes
+# for testing purposes only
+pause-resume.prototype.crash-probability=0.001
 # granularity for pause/resume checkpointing
 pause-resume.prototype.chunk-size=100
 # number of partitions processed concurrently

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/EobNdjsonSerializerTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/EobNdjsonSerializerTest.java
@@ -1,0 +1,61 @@
+package gov.cms.ab2d.worker.processor;
+
+import gov.cms.ab2d.fhir.FhirVersion;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the eob serializer.
+ */
+class EobNdjsonSerializerTest {
+
+    private final FhirVersion version = FhirVersion.R4V3;
+
+    @Test
+    @DisplayName("every resource that encodes cleanly becomes a data line, with no error lines")
+    void allResourcesSerializeToDataLines() {
+        SerializedEobs result = EobNdjsonSerializer.serialize(version, List.of(eob(1), eob(2)));
+
+        assertEquals(2, result.dataLines().size());
+        assertTrue(result.errorLines().isEmpty(), "no resource failed, so there should be no error lines");
+        assertTrue(result.dataLines().get(0).contains("Patient/1"));
+        assertTrue(result.dataLines().get(1).contains("Patient/2"));
+    }
+
+    @Test
+    @DisplayName("a resource that fails to encode becomes an OperationOutcome error line, others still succeed")
+    void aFailingResourceBecomesAnOperationOutcome() {
+        // mock of the resource will force an encoding error
+        IBaseResource unencodable = mock(IBaseResource.class);
+
+        SerializedEobs result = EobNdjsonSerializer.serialize(version, List.of(eob(1), unencodable));
+
+        assertEquals(1, result.dataLines().size(), "the encodable resource is still written");
+        assertTrue(result.dataLines().get(0).contains("Patient/1"));
+        assertEquals(1, result.errorLines().size(), "the unencodable resource becomes an error line");
+        assertTrue(result.errorLines().get(0).contains("OperationOutcome"),
+                "the error line should be an OperationOutcome: " + result.errorLines().get(0));
+    }
+
+    @Test
+    @DisplayName("null or empty input yields an empty result")
+    void nullOrEmptyYieldsEmpty() {
+        assertTrue(EobNdjsonSerializer.serialize(version, null).isEmpty());
+        assertTrue(EobNdjsonSerializer.serialize(version, List.of()).isEmpty());
+    }
+
+    private IBaseResource eob(long id) {
+        ExplanationOfBenefit eob = new ExplanationOfBenefit();
+        eob.setId("eob-" + id);
+        eob.getPatient().setReference("Patient/" + id);
+        return eob;
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorIntegrationTest.java
@@ -83,6 +83,9 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
     @Mock
     private CoverageDriver coverageDriver;
 
+    @Mock
+    private gov.cms.ab2d.common.properties.PropertiesService propertiesService;
+
     @Captor
     private ArgumentCaptor<LoggableEvent> captor;
 
@@ -105,7 +108,7 @@ class JobPreProcessorIntegrationTest extends JobCleanup {
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        cut = new JobPreProcessorImpl(contractWorkerClient, jobRepository, sqsEventClient, coverageDriver);
+        cut = new JobPreProcessorImpl(contractWorkerClient, jobRepository, sqsEventClient, coverageDriver, propertiesService);
 
         contract = new Contract();
         contract.setContractNumber(UUID.randomUUID().toString());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorUnitTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/JobPreProcessorUnitTest.java
@@ -61,6 +61,8 @@ class JobPreProcessorUnitTest {
     private SQSEventClient eventLogger;
     @Mock
     private CoverageDriver coverageDriver;
+    @Mock
+    private gov.cms.ab2d.common.properties.PropertiesService propertiesService;
 
     private Job job;
     private ContractDTO contract;
@@ -68,7 +70,7 @@ class JobPreProcessorUnitTest {
     @BeforeEach
     void setUp() {
         contract = new ContractDTO(null, "JPP5678", "JPP5678", OffsetDateTime.now(), Contract.ContractType.NORMAL, 0, 0);
-        cut = new JobPreProcessorImpl(contractWorkerClient, jobRepository, eventLogger, coverageDriver);
+        cut = new JobPreProcessorImpl(contractWorkerClient, jobRepository, eventLogger, coverageDriver, propertiesService);
         job = createJob();
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
@@ -148,6 +148,9 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
     @MockitoBean
     protected PatientClaimsProcessor patientClaimsProcessor;
 
+    @MockitoBean
+    protected gov.cms.ab2d.eventclient.clients.SQSEventClient eventLogger;
+
     // every getEobBundleResources call appends the patient id here
     // duplicates are kept on purpose so a test can prove a resume did not redo already-committed work
     protected final List<Long> processedLog = Collections.synchronizedList(new ArrayList<>());
@@ -396,9 +399,26 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
         return ndjsonFilesIn(searchConfig.getStreamingDir(uuid));
     }
 
-    /** The assembled, downloadable finished files in the job root */
-    protected List<Path> rootOutputFiles(String uuid) {
-        return ndjsonFilesIn(searchConfig.getFinishedDir(uuid).getParentFile());
+    /**
+     * The assembled, downloadable data files.
+     */
+    protected List<Path> deliveredOutputFiles(String uuid) {
+        return jobRootFiles(uuid, name -> name.endsWith(".ndjson.gz") && !name.endsWith("_error.ndjson.gz"));
+    }
+
+    /** The assembled, downloadable error files */
+    protected List<Path> deliveredErrorFiles(String uuid) {
+        return jobRootFiles(uuid, name -> name.endsWith("_error.ndjson.gz"));
+    }
+
+    /** Grabs all the output files */
+    private List<Path> jobRootFiles(String uuid, java.util.function.Predicate<String> nameMatch) {
+        File[] files = searchConfig.getFinishedDir(uuid).getParentFile()
+                .listFiles((d, name) -> nameMatch.test(name));
+        if (files == null) {
+            return List.of();
+        }
+        return List.of(files).stream().map(File::toPath).sorted().collect(Collectors.toList());
     }
 
     private List<Path> ndjsonFilesIn(File dir) {
@@ -409,11 +429,23 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
         return List.of(files).stream().map(File::toPath).sorted().collect(Collectors.toList());
     }
 
-    /** Every beneficiary id referenced across the given ndjson files. */
+    /** Read the lines of an ndjson file, unzipping it if it's compressed */
+    protected List<String> linesOf(Path file) throws IOException {
+        if (file.getFileName().toString().endsWith(".gz")) {
+            try (var in = new java.util.zip.GZIPInputStream(Files.newInputStream(file));
+                 var reader = new java.io.BufferedReader(
+                         new java.io.InputStreamReader(in, java.nio.charset.StandardCharsets.UTF_8))) {
+                return reader.lines().collect(Collectors.toList());
+            }
+        }
+        return Files.readAllLines(file);
+    }
+
+    /** Every beneficiary id referenced across the given ndjson files (compressed or not). */
     protected List<Long> benesIn(List<Path> files) throws IOException {
         List<Long> ids = new ArrayList<>();
         for (Path file : files) {
-            for (String line : Files.readAllLines(file)) {
+            for (String line : linesOf(file)) {
                 Matcher m = PATIENT_REF.matcher(line);
                 if (m.find()) {
                     ids.add(Long.parseLong(m.group(1)));
@@ -446,7 +478,7 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
      * Assert that the output contains every bene exactly once, no duplicates, nobody missing.
      */
     protected void assertEveryBeneExactlyOnceInOutput(String uuid) throws IOException {
-        List<Long> delivered = benesIn(finishedFiles(uuid));
+        List<Long> delivered = benesIn(deliveredOutputFiles(uuid));
         assertEquals(ALL_BENES.size(), delivered.size(),
                 "expected exactly " + ALL_BENES.size() + " beneficiaries in the output, saw " + delivered.size()
                         + " (duplicate=" + duplicates(delivered) + ")");

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
@@ -65,7 +65,7 @@ class PrototypeCrashPointIntegrationTest extends AbstractPrototypeRecoveryIntegr
     }
 
     @Test
-    @DisplayName("Crash during processing: fail while processing a beneficiary")
+    @DisplayName("Item steps should be retried after failing and every bene is still delivered once")
     void crashDuringProcessingRecovers() throws Exception {
         Job job = createSubmittedV3Job("crash-processing");
         String uuid = job.getJobUuid();
@@ -77,15 +77,16 @@ class PrototypeCrashPointIntegrationTest extends AbstractPrototypeRecoveryIntegr
         doAnswer(inv -> {
             CoverageSummary patient = inv.getArgument(1);
             if (patientId(patient) == failBene && thrown.compareAndSet(false, true)) {
-                log.info("=== injecting processing failure for bene {} on job {} ===", failBene, uuid);
-                throw new IllegalStateException("injected failure for bene " + failBene);
+                log.info("=== injecting transient processing failure for bene {} on job {} ===", failBene, uuid);
+                throw new org.springframework.web.client.ResourceAccessException(
+                        "injected transient failure for bene " + failBene);
             }
             return oneEobFor(patient);
         }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
 
         Job result = processUntilSuccessful(uuid, 3);
 
-        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a processing crash should recover on resume");
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a transient processing blip should recover");
         assertTrue(thrown.get(), "the processing failure should actually have been injected");
         // The rolled-back chunk must not have committed output, so despite the failed attempt the delivered
         // output is still exactly-once.
@@ -109,9 +110,9 @@ class PrototypeCrashPointIntegrationTest extends AbstractPrototypeRecoveryIntegr
         Job recovered = prototypeJobProcessor.process(uuid);
 
         assertEquals(JobStatus.SUCCESSFUL, recovered.getStatus(), "a mid-write crash should hard-recover to SUCCESSFUL");
-        for (Path file : finishedFiles(uuid)) {
+        for (Path file : deliveredOutputFiles(uuid)) {
             List<Long> inFile = new ArrayList<>();
-            for (String line : Files.readAllLines(file)) {
+            for (String line : linesOf(file)) {
                 Matcher m = PATIENT_REF.matcher(line);
                 assertTrue(m.find(), "output file " + file.getFileName() + " has a line with no Patient reference "
                         + "(torn write?): " + line);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeErrorAndSkipIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeErrorAndSkipIntegrationTest.java
@@ -1,0 +1,116 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.coverage.model.CoverageSummary;
+import gov.cms.ab2d.job.model.Job;
+import gov.cms.ab2d.job.model.JobStatus;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Covers the error/skip behavior of the prototype, making sure that the job fails when it hits its failure
+ * threshold, that failing benes are skipped, and that failures are written to the error file.
+ */
+class PrototypeErrorAndSkipIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
+
+    @Test
+    @DisplayName("A resource that fails to serialize is written to the _error output but the job still succeeds")
+    void serializationFailureIsWrittenToErrorOutput() throws Exception {
+        Job job = createSubmittedV3Job("err-output");
+        String uuid = job.getJobUuid();
+        long badBene = 6L;
+
+        // Return an un-encodable resource for one bene only
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            long id = patientId(patient);
+            processedLog.add(id);
+            return id == badBene ? List.of(mock(IBaseResource.class)) : List.of(eobFor(id));
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a serialization error should not fail the job");
+
+        // an error output file exists, is a valid OperationOutcome, and is registered as an error JobOutput
+        List<Path> errorFiles = deliveredErrorFiles(uuid);
+        assertFalse(errorFiles.isEmpty(), "expected an _error.ndjson.gz output for the serialization failure");
+        assertTrue(linesOf(errorFiles.get(0)).stream().anyMatch(line -> line.contains("OperationOutcome")),
+                "the error output should contain an OperationOutcome");
+        assertTrue(jobOutputFilePaths(uuid).stream().anyMatch(p -> p.endsWith("_error.ndjson.gz")),
+                "an error JobOutput row should be registered: " + jobOutputFilePaths(uuid));
+
+        // the good benes are still delivered in the output and the un-encodable one doesn't appear
+        Set<Long> data = new HashSet<>(benesIn(deliveredOutputFiles(uuid)));
+        assertFalse(data.contains(badBene), "the un-encodable bene should not appear in the data output");
+        assertEquals(TOTAL_BENES - 1, data.size(), "every other beneficiary should be in the data output");
+    }
+
+    @Test
+    @DisplayName("A persistently-failing beneficiary is skipped and the job still succeeds under the threshold")
+    void aPersistentlyFailingBeneIsSkipped() throws Exception {
+        Job job = createSubmittedV3Job("skip-under");
+        String uuid = job.getJobUuid();
+        long failBene = 6L;
+
+        // A persistent, non-transient failure is skipped (not retried) and counted as one error
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            long id = patientId(patient);
+            if (id == failBene) {
+                throw new IllegalStateException("persistent failure for bene " + failBene);
+            }
+            processedLog.add(id);
+            return List.of(eobFor(id));
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "one skipped bene is under the failure threshold");
+
+        Set<Long> data = new HashSet<>(benesIn(deliveredOutputFiles(uuid)));
+        assertFalse(data.contains(failBene), "the skipped bene must not be in the output");
+        assertEquals(TOTAL_BENES - 1, data.size(), "every other beneficiary should be delivered exactly once");
+    }
+
+    @Test
+    @DisplayName("Too many failing beneficiaries trips the failure threshold and fails the job")
+    void tooManyFailingBenesFailsTheJob() throws Exception {
+        Job job = createSubmittedV3Job("skip-over");
+        String uuid = job.getJobUuid();
+        Set<Long> failBenes = Set.of(6L, 14L);
+
+        // Two failures out of 20 reaches the 10% threshold, so the job fails terminally.
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            long id = patientId(patient);
+            if (failBenes.contains(id)) {
+                throw new IllegalStateException("persistent failure for bene " + id);
+            }
+            processedLog.add(id);
+            return List.of(eobFor(id));
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+        assertEquals(JobStatus.FAILED, result.getStatus(),
+                "reaching the failure threshold should fail the job terminally");
+    }
+
+    /** A minimal eob referencing the given id. */
+    private IBaseResource eobFor(long id) {
+        org.hl7.fhir.r4.model.ExplanationOfBenefit eob = new org.hl7.fhir.r4.model.ExplanationOfBenefit();
+        eob.setId("eob-" + id);
+        eob.getPatient().setReference("Patient/" + id);
+        return eob;
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobPauseResumeIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobPauseResumeIntegrationTest.java
@@ -89,8 +89,12 @@ class PrototypeJobPauseResumeIntegrationTest extends AbstractPrototypeRecoveryIn
                 "resume reprocessed too much work (" + processedLog.size() + " calls for " + TOTAL_BENES
                         + " benes) - it looks like it restarted instead of resuming");
 
-        // Step 5e output files were produced for each partition
-        List<Path> outputs = finishedFiles(uuid);
-        assertFalse(outputs.isEmpty(), "expected ndjson output files under the finished dir for job " + uuid);
+        // Step 5e output files are available, and has JobOutput rows
+        List<Path> outputs = deliveredOutputFiles(uuid);
+        assertFalse(outputs.isEmpty(), "expected .ndjson.gz output files in the job root for job " + uuid);
+        assertTrue(jobOutputFilePaths(uuid).stream().allMatch(p -> p.endsWith(".ndjson.gz")),
+                "every JobOutput should reference a compressed .ndjson.gz file: " + jobOutputFilePaths(uuid));
+        assertTrue(finishedFiles(uuid).isEmpty() && streamingFiles(uuid).isEmpty(),
+                "streaming/ and finished/ working directories should be cleaned up after success");
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/stuckjob/CancelStuckJobsProcessorTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.stuckjob;
 
+import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.coverage.service.v3.CoverageV3Service;
 import gov.cms.ab2d.eventclient.clients.SQSEventClient;
 import gov.cms.ab2d.job.model.Job;
@@ -43,6 +44,9 @@ class CancelStuckJobsProcessorTest {
     @Mock
     PrototypeBatchMetadataRepository batchMeta;
 
+    @Mock
+    PropertiesService propertiesService;
+
     @Captor
     private ArgumentCaptor<Job> captor;
 
@@ -50,7 +54,7 @@ class CancelStuckJobsProcessorTest {
 
     @BeforeEach
     void setUp() {
-        cut = new CancelStuckJobsProcessorImpl(mockJobRepo, eventLogger, 36, coverageV3Service, batchMeta);
+        cut = new CancelStuckJobsProcessorImpl(mockJobRepo, eventLogger, 36, coverageV3Service, batchMeta, propertiesService);
         ReflectionTestUtils.setField(cut, "cancelThreshold", 6);
 
         jobs.add(createStuckJob(7));


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7344

## 🛠 Changes

This PRs main changes are focused on making sure the output of the prototype is the same as the output of the current V3 processor. 

This includes:

- Serialization of the ndjson, which affects both pathways (it was pulled out to a common class)
- Error output file, which was not being produced before
- Compression of the output file and checksum
- Leftover directory cleanup
- Progress tracking, the prototype now reports its % complete based on completed partitions
- Skip policy handles benes which are failing but can be skipped up to some threshold
- Prototype jobs go through preprocessing
- Config file consolidation
- Bunch of tests

## ℹ️ Context

These changes bring the prototype processor closer to matching the current V3 processor in terms of features and output. 

## 🧪 Validation

Local testing as well as a deployed dev worker with the prototype on being tested. It can complete jobs, produces downloadable files through swagger, and can be crashed/resumed and successfully completes job in a deployed environment.