### PR TITLE
AB2D-7383 Update Monitors Module Hash

### DIFF
--- a/ops/services/60-monitors/config/defaults.yml
+++ b/ops/services/60-monitors/config/defaults.yml
@@ -1,4 +1,4 @@
-shadow_mode: true
+shadow_mode: false
 notifications:
   slack: true
   victorops: false

--- a/ops/services/60-monitors/main.tf
+++ b/ops/services/60-monitors/main.tf
@@ -20,7 +20,7 @@ provider "datadog" {
 
 
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=941672f97adfd8a19ce6533313302c4c74bac7a8"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app          = local.app
@@ -113,7 +113,7 @@ locals {
 ###################
 
 module "common_datadog_monitors" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=945fbd644cc8d239bdf3f3a3a7241fb6066a0f55"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_monitors?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
 
   app             = "ab2d"
   env             = local.env

--- a/ops/services/65-dashboard/main.tf
+++ b/ops/services/65-dashboard/main.tf
@@ -19,7 +19,7 @@ provider "datadog" {
 }
 
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=941672f97adfd8a19ce6533313302c4c74bac7a8"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app          = local.app
@@ -45,7 +45,7 @@ locals {
 }
 
 module "datadog_dashboard" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_dashboard?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_dashboard?ref=945fbd644cc8d239bdf3f3a3a7241fb6066a0f55"
 
   app = local.app
 

--- a/ops/services/65-dashboard/main.tf
+++ b/ops/services/65-dashboard/main.tf
@@ -19,7 +19,7 @@ provider "datadog" {
 }
 
 module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=941672f97adfd8a19ce6533313302c4c74bac7a8"
+  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
   providers = { aws = aws, aws.secondary = aws.secondary }
 
   app          = local.app
@@ -45,7 +45,7 @@ locals {
 }
 
 module "datadog_dashboard" {
-  source = "github.com/CMSgov/cdap//terraform/modules/datadog_dashboard?ref=945fbd644cc8d239bdf3f3a3a7241fb6066a0f55"
+  source = "github.com/CMSgov/cdap//terraform/modules/datadog_dashboard?ref=f6fe4544d0d6ed72c50605261f0c3091487753e1"
 
   app = local.app
 


### PR DESCRIPTION
## 🎫 Ticket

AB2D-7383

## 🛠 Changes

Updates the reference hashes in `60-monitors` and `65-dashboard` to the most recent hash. Also disables shadow mode.

## ℹ️ Context
Without these changes, alerts will not reach Victorops Splunk

## 🧪 Validation

Applied in Dev cleanly. See workflows
