### PR TITLE
AB2D-7377 Copy forward

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
@@ -23,8 +23,6 @@ import java.util.Optional;
 @Component
 @StepScope
 public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> {
-    // the checkpoint key is named with the token so the reader/writer both reset together
-    static final String CURSOR_KEY_PREFIX = "beneficiary.reader.cursor.t";
 
     private final CoverageV3Service coverageV3Service;
     private final String contract;
@@ -50,7 +48,7 @@ public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> 
         this.startPatientId = startPatientId;
         this.endPatientId = endPatientId;
         this.pageSize = pageSize;
-        this.cursorKey = CURSOR_KEY_PREFIX + fenceToken;
+        this.cursorKey = PrototypePartitionNaming.readerCursorKey(fenceToken);
     }
 
     @Override

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryPartitioner.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryPartitioner.java
@@ -59,7 +59,7 @@ public class BeneficiaryPartitioner implements Partitioner {
             ec.putLong(KEY_START_PATIENT, lower);
             ec.putLong(KEY_END_PATIENT, upper);
 
-            partitions.put(partitionName(i), ec);
+            partitions.put(PrototypePartitionNaming.partitionName(i), ec);
             lower = upper;
         }
 
@@ -79,9 +79,5 @@ public class BeneficiaryPartitioner implements Partitioner {
         }
         int size = partitionSize <= 0 ? (int) Math.min(maxRow, Integer.MAX_VALUE) : partitionSize;
         return coverageV3Service.getPartitionBoundaryPatientIds(contractNumber, size);
-    }
-
-    private static String partitionName(int index) {
-        return "partition" + index;
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
@@ -38,11 +38,14 @@ public class NdjsonWriterConfig {
 
         // files are named with the fenceToken so that each time it bumps there must be a new file. This keeps
         // restart safe. Stale/zombie workers cannot interact with the new file.
-        String base = contract + "_partition" + partitionIndex + "_t" + fenceToken;
         FlatFileItemWriter<String> dataWriter = lineWriter(
-                streamingDir.resolve(base + ".ndjson"), "ndjsonDataWriter.p" + partitionIndex + ".t" + fenceToken);
+                streamingDir.resolve(PrototypePartitionNaming.fileName(contract, partitionIndex, fenceToken,
+                        PrototypePartitionNaming.DATA_STREAM)),
+                PrototypePartitionNaming.dataWriterName(partitionIndex, fenceToken));
         FlatFileItemWriter<String> errorWriter = lineWriter(
-                streamingDir.resolve(base + "_error.ndjson"), "ndjsonErrorWriter.p" + partitionIndex + ".t" + fenceToken);
+                streamingDir.resolve(PrototypePartitionNaming.fileName(contract, partitionIndex, fenceToken,
+                        PrototypePartitionNaming.ERROR_STREAM)),
+                PrototypePartitionNaming.errorWriterName(partitionIndex, fenceToken));
         return new NdjsonCompositeWriter(dataWriter, errorWriter);
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
@@ -16,6 +16,7 @@ import java.util.Map;
  * healIndeterminateExecutions - force a job's indeterminate executions/steps to a restartable FAILED state
  *      This is mainly to handle UNKNOWN statuses resulting from zombie workers.
  * completedProcessedCount - how many benes have we processed already? Used to track progress
+ * partitionStepNames - every partition the job has run, so recovery can inspect each one
  */
 @Slf4j
 @Component
@@ -79,6 +80,19 @@ public class PrototypeBatchMetadataRepository {
                    AND se.status = 'COMPLETED'
                  ORDER BY se.step_name, ft.parameter_value::bigint DESC
             ) winners
+            """;
+
+    // Every partition this job has ever run, whatever generation or status it ended in.
+    // Hard recovery uses this to determine which steps to carry forward.
+    private static final String PARTITION_STEP_NAMES_SQL = """
+            SELECT DISTINCT se.step_name
+              FROM batch_step_execution se
+              JOIN batch_job_execution je ON je.job_execution_id = se.job_execution_id
+              JOIN batch_job_execution_params pj ON pj.job_execution_id = je.job_execution_id
+                   AND pj.parameter_name = 'jobUuid'
+             WHERE pj.parameter_value = :uuid
+               AND se.step_name LIKE :stepPrefix
+             ORDER BY se.step_name
             """;
 
     // When hard-recovering a job, we set its old job execution to FAILED since we're
@@ -153,9 +167,17 @@ public class PrototypeBatchMetadataRepository {
     }
 
     /**
-     * On hard recovery, force indeterminate batch execution/step to FAILED so a resume can happen
-     * We redo failed partitions on hard recovery, so we don't care about the current partition's status.
-     * Potential for copy-forward on steps that are not UNKNOWN status, so we don't have to redo the entire partition
+     * The step name of every partition this job has run
+     */
+    public List<String> partitionStepNames(String jobUuid, String workerStepName) {
+        return jdbc.queryForList(PARTITION_STEP_NAMES_SQL,
+                Map.of("uuid", jobUuid, "stepPrefix", workerStepName + ":partition%"), String.class);
+    }
+
+    /**
+     * On hard recovery, force indeterminate (STARTING, STARTED, STOPPING or UNKNOWN) batch execution/step
+     * to FAILED so a resume can happen.
+     * Runs after the copy-forward, which allows chunk-level resume so long as there isn't any UNKNOWNs.
      */
     public int healIndeterminateExecutions(String jobUuid) {
         int steps = jdbc.update(HEAL_STEPS_SQL, Map.of("uuid", jobUuid));

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchMetadataRepository.java
@@ -47,7 +47,7 @@ public class PrototypeBatchMetadataRepository {
     private static final String COMPLETED_PARTITION_FILES_SQL = """
             SELECT partition_index, fence_token FROM (
                 SELECT DISTINCT ON (se.step_name)
-                       split_part(se.step_name, 'partition', 2)::int AS partition_index,
+                       split_part(se.step_name, '%s', 2)::int AS partition_index,
                        ft.parameter_value::bigint AS fence_token
                   FROM batch_step_execution se
                   JOIN batch_job_execution je ON je.job_execution_id = se.job_execution_id
@@ -61,7 +61,7 @@ public class PrototypeBatchMetadataRepository {
                  ORDER BY se.step_name, ft.parameter_value::bigint DESC
             ) winners
             ORDER BY partition_index
-            """;
+            """.formatted(PrototypePartitionNaming.PARTITION_TOKEN);
 
     // Gathers the winners from the set of completed partitions to estimate the progress of a job. Used on
     // restart/recovery to seed the value so a restarting job reports approximately accurate progress.
@@ -149,7 +149,8 @@ public class PrototypeBatchMetadataRepository {
      */
     public long completedProcessedCount(String jobUuid, String workerStepName) {
         Long count = jdbc.queryForObject(COMPLETED_PROCESSED_COUNT_SQL,
-                Map.of("uuid", jobUuid, "stepPrefix", workerStepName + ":partition%"), Long.class);
+                Map.of("uuid", jobUuid, "stepPrefix",
+                        PrototypePartitionNaming.partitionStepNamePattern(workerStepName)), Long.class);
         return count == null ? 0L : count;
     }
 
@@ -158,7 +159,8 @@ public class PrototypeBatchMetadataRepository {
      */
     public List<CompletedPartition> completedPartitionFiles(String jobUuid, String workerStepName) {
         return jdbc.query(COMPLETED_PARTITION_FILES_SQL,
-                Map.of("uuid", jobUuid, "stepPrefix", workerStepName + ":partition%"),
+                Map.of("uuid", jobUuid, "stepPrefix",
+                        PrototypePartitionNaming.partitionStepNamePattern(workerStepName)),
                 (rs, rowNum) -> new CompletedPartition(rs.getInt("partition_index"), rs.getLong("fence_token")));
     }
 
@@ -171,7 +173,8 @@ public class PrototypeBatchMetadataRepository {
      */
     public List<String> partitionStepNames(String jobUuid, String workerStepName) {
         return jdbc.queryForList(PARTITION_STEP_NAMES_SQL,
-                Map.of("uuid", jobUuid, "stepPrefix", workerStepName + ":partition%"), String.class);
+                Map.of("uuid", jobUuid, "stepPrefix",
+                        PrototypePartitionNaming.partitionStepNamePattern(workerStepName)), String.class);
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -78,6 +78,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private final CoverageV3Service coverageV3Service;
     private final PrototypeBatchMetadataRepository batchMeta;
     private final PrototypeOutputAssembler outputAssembler;
+    private final PrototypeJobRecovery recovery;
     private final PrototypeJobLeaseRenewer leaseRenewer;
     private final JobLeaseRepository jobLease;
     // progress and failure reporting, reused from the main processor
@@ -104,6 +105,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             CoverageV3Service coverageV3Service,
             PrototypeBatchMetadataRepository batchMeta,
             PrototypeOutputAssembler outputAssembler,
+            PrototypeJobRecovery recovery,
             PrototypeJobLeaseRenewer leaseRenewer,
             JobLeaseRepository jobLease,
             JobChannelService jobChannelService,
@@ -123,6 +125,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         this.coverageV3Service = coverageV3Service;
         this.batchMeta = batchMeta;
         this.outputAssembler = outputAssembler;
+        this.recovery = recovery;
         this.leaseRenewer = leaseRenewer;
         this.jobLease = jobLease;
         this.jobChannelService = jobChannelService;
@@ -159,23 +162,11 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
 
         String contractNumber = job.getContractNumber();
 
-        // we either adopt the current token (restarting from a graceful pause) or we get a new one
-        // Getting a new token "fences" out potentially still-living workers that think they still own this job
-        Optional<Long> adopted = jobLease.tryAdoptCleanSuspend(jobUuid, owner);
-        long fenceToken = adopted.orElseGet(() -> jobLease.bump(jobUuid, owner));
-        boolean softResume = adopted.isPresent();
-
-        // after we bump the token, we heal the state of the job by failing the in-progress steps
-        // note that this includes UNKNOWN status, which Spring Batch refuses to restart generally.
-        // TODO: Special-case the UNKNOWN steps so we can recover from hard-crash with copy-forward
-        //      this means separating the recover cases from hard-crash and hung/frozen worker
-        //      This also might be moot when doing remote partitioning
-        // Since the reader/writer are scoped to the current fence token, after we bump the token, we will
-        // be redoing the partition anyway, so we don't care if the status of the old step is UNKNOWN.
-        // Just fail the step, the zombie is fenced out now anyway.
-        if (!softResume) {
-            batchMeta.healIndeterminateExecutions(jobUuid);
-        }
+        // Either resume gracefully, by taking over the current execution, or hard restart, by
+        // bumping the fence token and healing the execution.
+        PrototypeJobRecovery.Ownership ownership = recovery.acquire(jobUuid, owner);
+        long fenceToken = ownership.fenceToken();
+        boolean softResume = ownership.softResume();
 
         // Start renewing the heartbeat
         leaseRenewer.track(jobUuid, fenceToken);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -1,0 +1,291 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.worker.config.SearchConfig;
+import gov.cms.ab2d.worker.processor.prototype.lease.JobLeaseRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import static gov.cms.ab2d.worker.processor.prototype.PrototypeJobProcessorImpl.JOB_UUID_PARAM;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypeJobProcessorImpl.PROTOTYPE_JOB_NAME;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypeJobProcessorImpl.WORKER_STEP_NAME;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypePartitionNaming.CURRENT_COUNT_SUFFIX;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypePartitionNaming.DATA_STREAM;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypePartitionNaming.ERROR_STREAM;
+import static gov.cms.ab2d.worker.processor.prototype.PrototypePartitionNaming.WRITTEN_SUFFIX;
+
+/**
+ * Everything a worker does to take over a job before it can run it.
+ * <p>
+ * Handles both the soft resume, which just adopts the current token and picks up the work where it left
+ * off, and hard recovery, which bumps the token, updates the checkpoints, and can copy old work into the new
+ * file.
+ * </p>
+ */
+@Slf4j
+@Component
+public class PrototypeJobRecovery {
+
+    private final JobLeaseRepository jobLease;
+    private final JobRepository batchJobRepository;
+    private final PrototypeBatchMetadataRepository batchMeta;
+    private final SearchConfig searchConfig;
+    private final PrototypeProperties props;
+
+    public PrototypeJobRecovery(JobLeaseRepository jobLease, JobRepository batchJobRepository,
+                                PrototypeBatchMetadataRepository batchMeta, SearchConfig searchConfig,
+                                PrototypeProperties props) {
+        this.jobLease = jobLease;
+        this.batchJobRepository = batchJobRepository;
+        this.batchMeta = batchMeta;
+        this.searchConfig = searchConfig;
+        this.props = props;
+    }
+
+    /** Record of whether this worker soft or hard restarted this job, and its token  */
+    public record Ownership(long fenceToken, boolean softResume) {
+    }
+
+    /**
+     * Claim a job and leave its Spring Batch state in a shape that can be restarted.
+     */
+    public Ownership acquire(String jobUuid, String owner) {
+        Optional<Long> adopted = jobLease.tryAdoptCleanSuspend(jobUuid, owner);
+        if (adopted.isPresent()) {
+            // The token did not move, so the files and checkpoint keys already line up. Nothing to repair.
+            return new Ownership(adopted.get(), true);
+        }
+
+        long fenceToken = jobLease.bump(jobUuid, owner);
+        // Copy-forward runs first, to see if there are any UNKNOWN statuses
+        // If no, it copies the old partition work to the new file
+        // If yes, it doesn't copy anything forward, the partition will be restarted
+        copyForward(jobUuid, fenceToken);
+        batchMeta.healIndeterminateExecutions(jobUuid);
+        return new Ownership(fenceToken, false);
+    }
+
+    /**
+     * If the partition is not in status UNKNOWN, and hasn't been completed, copy its work
+     * over to the new file
+     */
+    private int copyForward(String jobUuid, long newToken) {
+        if (!props.isCopyForwardEnabled()) {
+            log.info("copy-forward is disabled for job {}", jobUuid);
+            return 0;
+        }
+
+        JobInstance instance = batchJobRepository.getJobInstance(PROTOTYPE_JOB_NAME,
+                new JobParametersBuilder().addString(JOB_UUID_PARAM, jobUuid).toJobParameters());
+        if (instance == null) {
+            return 0;
+        }
+
+        int copied = 0;
+        for (String stepName : batchMeta.partitionStepNames(jobUuid, WORKER_STEP_NAME)) {
+            if (copyForwardPartition(jobUuid, instance, stepName, newToken)) {
+                copied++;
+            }
+        }
+        if (copied > 0) {
+            log.info("copy-forward for job {}: seeded {} partition(s) into token {}", jobUuid, copied, newToken);
+        }
+        return copied;
+    }
+
+    /**
+     * Copy forward a single partition. If the partition cannot successfully be
+     * copied forward, i.e. it has an unknown step execution status or is already
+     * completed, the executionContext is left untouched and the partition will
+     * behave "normally". Normal in this case means restarting the partition from scratch.
+     *
+     * @return true if the partition's checkpoint was updated
+     */
+    private boolean copyForwardPartition(String jobUuid, JobInstance instance, String stepName, long newToken) {
+        StepExecution last = batchJobRepository.getLastStepExecution(instance, stepName);
+        if (last == null || last.getStatus() == BatchStatus.COMPLETED) {
+            return false;
+        }
+        if (last.getStatus() == BatchStatus.UNKNOWN) {
+            log.info("copy-forward for job {}: {} ended UNKNOWN, so its partition " +
+                    "will be restarted", jobUuid, stepName);
+            return false;
+        }
+
+        ExecutionContext context = last.getExecutionContext();
+        String contractNumber = context.getString(BeneficiaryPartitioner.KEY_CONTRACT, null);
+        int partitionIndex = context.getInt(BeneficiaryPartitioner.KEY_PARTITION_INDEX, -1);
+        if (contractNumber == null || partitionIndex < 0) {
+            log.warn("copy-forward for job {}: {} is missing the contract number or partition index the " +
+                            "partitioner writes, so the partition must be restarted",
+                    jobUuid, stepName);
+            return false;
+        }
+
+        Checkpoint checkpoint = readCheckpoint(context, partitionIndex);
+        if (checkpoint == null) {
+            log.info("copy-forward for job {}: {} has no committed chunks, so it " +
+                    "will be restarted", jobUuid, stepName);
+            return false;
+        }
+
+        Path streamingDir = searchConfig.getStreamingDir(jobUuid).toPath();
+        List<Path> seeded = new ArrayList<>(2);
+        try {
+            Files.createDirectories(streamingDir);
+            seeded.add(seedFile(streamingDir, contractNumber, checkpoint, newToken, DATA_STREAM,
+                    checkpoint.dataBytes()));
+            seeded.add(seedFile(streamingDir, contractNumber, checkpoint, newToken, ERROR_STREAM,
+                    checkpoint.errorBytes()));
+        } catch (IOException e) {
+            deleteQuietly(seeded);
+            log.warn("copy-forward for job {}: could not seed {} from token {}, so the partition must restart",
+                    jobUuid, stepName, checkpoint.token(), e);
+            return false;
+        }
+
+        retarget(context, checkpoint, newToken);
+        batchJobRepository.updateExecutionContext(last);
+        log.info("copy-forward for job {}: {} resumes at patient {} with {} data byte(s) and {} error byte(s) "
+                        + "carried from token {} into token {}",
+                jobUuid, stepName, checkpoint.readerCursor(), checkpoint.dataBytes(), checkpoint.errorBytes(),
+                checkpoint.token(), newToken);
+        return true;
+    }
+
+    /**
+     * Gets a partition's cursor as of its last completed chunk.
+     * We need both the reader and writer cursor from the prior execution, so we can
+     * copy forward the correct data, and avoid rereading the part of the partition
+     * we've already processed.
+     */
+    private Checkpoint readCheckpoint(ExecutionContext context, int partitionIndex) {
+        long token = -1;
+        for (String key : keysOf(context)) {
+            Matcher matcher = PrototypePartitionNaming.DATA_WRITER_OFFSET_KEY.matcher(key);
+            if (matcher.matches()) {
+                token = Math.max(token, Long.parseLong(matcher.group(1)));
+            }
+        }
+        if (token < 0) {
+            return null;
+        }
+
+        String data = PrototypePartitionNaming.dataWriterName(partitionIndex, token);
+        String error = PrototypePartitionNaming.errorWriterName(partitionIndex, token);
+        String cursor = PrototypePartitionNaming.readerCursorKey(token);
+        if (!context.containsKey(data + WRITTEN_SUFFIX)
+                || !context.containsKey(error + CURRENT_COUNT_SUFFIX)
+                || !context.containsKey(error + WRITTEN_SUFFIX)
+                || !context.containsKey(cursor)) {
+            return null;
+        }
+        return new Checkpoint(partitionIndex, token,
+                context.getLong(data + CURRENT_COUNT_SUFFIX), context.getLong(data + WRITTEN_SUFFIX),
+                context.getLong(error + CURRENT_COUNT_SUFFIX), context.getLong(error + WRITTEN_SUFFIX),
+                context.getLong(cursor));
+    }
+
+    /**
+     * Take the bytes that have been committed from the prior worker's work, and copy
+     * them over to the file that the new worker will open.
+     *
+     * @return the file that was written, so a later failure can clean it up
+     */
+    private Path seedFile(Path streamingDir, String contractNumber, Checkpoint checkpoint, long newToken,
+                          String streamSuffix, long bytes) throws IOException {
+        Path source = streamingDir.resolve(PrototypePartitionNaming.fileName(
+                contractNumber, checkpoint.partitionIndex(), checkpoint.token(), streamSuffix));
+        Path destination = streamingDir.resolve(PrototypePartitionNaming.fileName(
+                contractNumber, checkpoint.partitionIndex(), newToken, streamSuffix));
+
+        if (bytes > 0) {
+            if (!Files.isRegularFile(source)) {
+                throw new IOException("missing source file " + source + " for " + bytes + " committed byte(s)");
+            }
+            long available = Files.size(source);
+            if (available < bytes) {
+                throw new IOException("source file " + source + " holds " + available + " byte(s), fewer than the "
+                        + bytes + " recorded at the last chunk commit");
+            }
+        }
+
+        try (FileChannel out = FileChannel.open(destination, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING)) {
+            copyPrefix(source, out, bytes);
+            out.force(true);
+        }
+        return destination;
+    }
+
+    private void copyPrefix(Path source, FileChannel out, long bytes) throws IOException {
+        if (bytes == 0) {
+            return;
+        }
+        try (FileChannel in = FileChannel.open(source, StandardOpenOption.READ)) {
+            long written = 0;
+            while (written < bytes) {
+                long transferred = out.transferFrom(in, written, bytes - written);
+                if (transferred <= 0) {
+                    throw new IOException("copy of " + source + " stalled after " + written + " of " + bytes
+                            + " byte(s)");
+                }
+                written += transferred;
+            }
+        }
+    }
+
+    /**
+     * Takes the old context, drops all its checkpoint keys, then adds them back under the new
+     * token. Manually brings the execution context up to the new checkpoint.
+     */
+    private void retarget(ExecutionContext context, Checkpoint checkpoint, long newToken) {
+        keysOf(context).stream()
+                .filter(PrototypePartitionNaming::isCheckpointKey)
+                .forEach(context::remove);
+
+        String data = PrototypePartitionNaming.dataWriterName(checkpoint.partitionIndex(), newToken);
+        String error = PrototypePartitionNaming.errorWriterName(checkpoint.partitionIndex(), newToken);
+        context.putLong(data + CURRENT_COUNT_SUFFIX, checkpoint.dataBytes());
+        context.putLong(data + WRITTEN_SUFFIX, checkpoint.dataLines());
+        context.putLong(error + CURRENT_COUNT_SUFFIX, checkpoint.errorBytes());
+        context.putLong(error + WRITTEN_SUFFIX, checkpoint.errorLines());
+        context.putLong(PrototypePartitionNaming.readerCursorKey(newToken), checkpoint.readerCursor());
+    }
+
+    /** A snapshot of the context's keys, safe to iterate while removing entries. */
+    private static List<String> keysOf(ExecutionContext context) {
+        return context.entrySet().stream().map(Map.Entry::getKey).toList();
+    }
+
+    private void deleteQuietly(List<Path> files) {
+        for (Path file : files) {
+            try {
+                Files.deleteIfExists(file);
+            } catch (IOException e) {
+                log.warn("copy-forward could not remove the partially seeded file {}", file, e);
+            }
+        }
+    }
+
+    /** A record of a partition's last checkpoint, including the token it belonged to */
+    private record Checkpoint(int partitionIndex, long token, long dataBytes, long dataLines,
+                              long errorBytes, long errorLines, long readerCursor) {
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -83,7 +83,7 @@ public class PrototypeJobRecovery {
 
     /**
      * If the partition is not in status UNKNOWN, and hasn't been completed, copy its work
-     * over to the new file
+     * over to the new file.
      */
     private int copyForward(String jobUuid, long newToken) {
         if (!props.isCopyForwardEnabled()) {
@@ -91,17 +91,26 @@ public class PrototypeJobRecovery {
             return 0;
         }
 
-        JobInstance instance = batchJobRepository.getJobInstance(PROTOTYPE_JOB_NAME,
-                new JobParametersBuilder().addString(JOB_UUID_PARAM, jobUuid).toJobParameters());
-        if (instance == null) {
-            return 0;
-        }
-
         int copied = 0;
-        for (String stepName : batchMeta.partitionStepNames(jobUuid, WORKER_STEP_NAME)) {
-            if (copyForwardPartition(jobUuid, instance, stepName, newToken)) {
-                copied++;
+        try {
+            JobInstance instance = batchJobRepository.getJobInstance(PROTOTYPE_JOB_NAME,
+                    new JobParametersBuilder().addString(JOB_UUID_PARAM, jobUuid).toJobParameters());
+            if (instance == null) {
+                return 0;
             }
+
+            for (String stepName : batchMeta.partitionStepNames(jobUuid, WORKER_STEP_NAME)) {
+                try {
+                    if (copyForwardPartition(jobUuid, instance, stepName, newToken)) {
+                        copied++;
+                    }
+                } catch (RuntimeException e) {
+                    log.warn("copy-forward for job {}: {} failed to copy, so the partition " +
+                            "will be restarted", jobUuid, stepName, e);
+                }
+            }
+        } catch (RuntimeException e) {
+            log.warn("copy-forward for job {} failed, so every incomplete partition will be restarted", jobUuid, e);
         }
         if (copied > 0) {
             log.info("copy-forward for job {}: seeded {} partition(s) into token {}", jobUuid, copied, newToken);
@@ -153,15 +162,15 @@ public class PrototypeJobRecovery {
                     checkpoint.dataBytes()));
             seeded.add(seedFile(streamingDir, contractNumber, checkpoint, newToken, ERROR_STREAM,
                     checkpoint.errorBytes()));
-        } catch (IOException e) {
+            retarget(context, checkpoint, newToken);
+            batchJobRepository.updateExecutionContext(last);
+        } catch (IOException | RuntimeException e) {
             deleteQuietly(seeded);
             log.warn("copy-forward for job {}: could not seed {} from token {}, so the partition must restart",
                     jobUuid, stepName, checkpoint.token(), e);
             return false;
         }
 
-        retarget(context, checkpoint, newToken);
-        batchJobRepository.updateExecutionContext(last);
         log.info("copy-forward for job {}: {} resumes at patient {} with {} data byte(s) and {} error byte(s) "
                         + "carried from token {} into token {}",
                 jobUuid, stepName, checkpoint.readerCursor(), checkpoint.dataBytes(), checkpoint.errorBytes(),
@@ -230,6 +239,9 @@ public class PrototypeJobRecovery {
                 StandardOpenOption.TRUNCATE_EXISTING)) {
             copyPrefix(source, out, bytes);
             out.force(true);
+        } catch (IOException | RuntimeException e) {
+            deleteQuietly(destination);
+            throw e;
         }
         return destination;
     }
@@ -275,12 +287,14 @@ public class PrototypeJobRecovery {
     }
 
     private void deleteQuietly(List<Path> files) {
-        for (Path file : files) {
-            try {
-                Files.deleteIfExists(file);
-            } catch (IOException e) {
-                log.warn("copy-forward could not remove the partially seeded file {}", file, e);
-            }
+        files.forEach(this::deleteQuietly);
+    }
+
+    private void deleteQuietly(Path file) {
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            log.warn("copy-forward could not remove the partially seeded file {}", file, e);
         }
     }
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
@@ -31,8 +31,6 @@ import java.util.List;
 public class PrototypeOutputAssembler {
 
     private static final int BYTES_PER_MB = 1024 * 1024;
-    private static final String DATA_SUFFIX = "";
-    private static final String ERROR_SUFFIX = "_error";
 
     private final SearchConfig searchConfig;
     private final JobOutputRepository jobOutputRepository;
@@ -77,14 +75,16 @@ public class PrototypeOutputAssembler {
         Files.createDirectories(jobRoot);
 
         // Data stream is required: a missing data winner means the delivered output would be incomplete.
-        List<Path> dataWinners = promoteWinners(partitions, contractNumber, DATA_SUFFIX, streamingDir, finishedDir,
-                jobUuid, true);
-        List<Path> dataRollover = concatenate(dataWinners, contractNumber, jobRoot, rolloverBytes, DATA_SUFFIX);
+        List<Path> dataWinners = promoteWinners(partitions, contractNumber, PrototypePartitionNaming.DATA_STREAM,
+                streamingDir, finishedDir, jobUuid, true);
+        List<Path> dataRollover = concatenate(dataWinners, contractNumber, jobRoot, rolloverBytes,
+                PrototypePartitionNaming.DATA_STREAM);
 
         // Error stream is optional: a partition with no serialization failures has an empty error file.
-        List<Path> errorWinners = promoteWinners(partitions, contractNumber, ERROR_SUFFIX, streamingDir, finishedDir,
-                jobUuid, false);
-        List<Path> errorRollover = concatenate(errorWinners, contractNumber, jobRoot, rolloverBytes, ERROR_SUFFIX);
+        List<Path> errorWinners = promoteWinners(partitions, contractNumber, PrototypePartitionNaming.ERROR_STREAM,
+                streamingDir, finishedDir, jobUuid, false);
+        List<Path> errorRollover = concatenate(errorWinners, contractNumber, jobRoot, rolloverBytes,
+                PrototypePartitionNaming.ERROR_STREAM);
 
         List<JobOutput> outputs = new ArrayList<>(dataRollover.size() + errorRollover.size());
         registerOutputs(dataRollover, job, outputs);
@@ -148,8 +148,8 @@ public class PrototypeOutputAssembler {
                                       String jobUuid, boolean required) throws IOException {
         List<Path> promoted = new ArrayList<>(partitions.size());
         for (PrototypeBatchMetadataRepository.CompletedPartition partition : partitions) {
-            String name = contractNumber + "_partition" + partition.partitionIndex()
-                    + "_t" + partition.token() + suffix + ".ndjson";
+            String name = PrototypePartitionNaming.fileName(contractNumber, partition.partitionIndex(),
+                    partition.token(), suffix);
             Path source = streamingDir.resolve(name);
             Path dest = finishedDir.resolve(name);
             if (Files.isRegularFile(source)) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypePartitionNaming.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypePartitionNaming.java
@@ -19,11 +19,18 @@ final class PrototypePartitionNaming {
     /** Spring Batch's lines-writer suffix for the writer */
     static final String WRITTEN_SUFFIX = ".written";
 
+    /** The word that marks a partition in both the step name and output file name */
+    static final String PARTITION_TOKEN = "partition";
+
     private static final String READER_CURSOR_PREFIX = "beneficiary.reader.cursor.t";
     private static final String DATA_WRITER_PREFIX = "ndjsonDataWriter.p";
     private static final String ERROR_WRITER_PREFIX = "ndjsonErrorWriter.p";
     private static final String TOKEN_INFIX = ".t";
+    private static final String NAME_DELIMITER = "_";
+    private static final String FILE_TOKEN_INFIX = NAME_DELIMITER + "t";
     private static final String NDJSON_SUFFIX = ".ndjson";
+
+    private static final String STEP_NAME_SEPARATOR = ":";
 
     /**
      * Look at a given execution context and figure out what token its last committed chunk belongs to.
@@ -40,7 +47,18 @@ final class PrototypePartitionNaming {
      * @param streamSuffix {@link #DATA_STREAM} or {@link #ERROR_STREAM}
      */
     static String fileName(String contractNumber, int partitionIndex, long fenceToken, String streamSuffix) {
-        return contractNumber + "_partition" + partitionIndex + "_t" + fenceToken + streamSuffix + NDJSON_SUFFIX;
+        return contractNumber + NAME_DELIMITER + PARTITION_TOKEN + partitionIndex
+                + FILE_TOKEN_INFIX + fenceToken + streamSuffix + NDJSON_SUFFIX;
+    }
+
+    /** The partitioner's key for a partition, which Spring Batch turns into the partition's step name. */
+    static String partitionName(int partitionIndex) {
+        return PARTITION_TOKEN + partitionIndex;
+    }
+
+    /** SQL pattern matching the step name of every partition of the given worker step. */
+    static String partitionStepNamePattern(String workerStepName) {
+        return workerStepName + STEP_NAME_SEPARATOR + PARTITION_TOKEN + "%";
     }
 
     static String dataWriterName(int partitionIndex, long fenceToken) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypePartitionNaming.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypePartitionNaming.java
@@ -1,0 +1,67 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import java.util.regex.Pattern;
+
+/**
+ * Handles all the file naming and checkpoint naming
+ */
+final class PrototypePartitionNaming {
+
+    /** File name suffix for the exported EOBS */
+    static final String DATA_STREAM = "";
+
+    /** File name suffix for the error files */
+    static final String ERROR_STREAM = "_error";
+
+    /** Spring Batch's byte offset suffix for the writer */
+    static final String CURRENT_COUNT_SUFFIX = ".current.count";
+
+    /** Spring Batch's lines-writer suffix for the writer */
+    static final String WRITTEN_SUFFIX = ".written";
+
+    private static final String READER_CURSOR_PREFIX = "beneficiary.reader.cursor.t";
+    private static final String DATA_WRITER_PREFIX = "ndjsonDataWriter.p";
+    private static final String ERROR_WRITER_PREFIX = "ndjsonErrorWriter.p";
+    private static final String TOKEN_INFIX = ".t";
+    private static final String NDJSON_SUFFIX = ".ndjson";
+
+    /**
+     * Look at a given execution context and figure out what token its last committed chunk belongs to.
+     * This is how copy-forward knows which file to copy from.
+     */
+    static final Pattern DATA_WRITER_OFFSET_KEY = Pattern.compile(
+            Pattern.quote(DATA_WRITER_PREFIX) + "\\d+" + Pattern.quote(TOKEN_INFIX) + "(\\d+)"
+                    + Pattern.quote(CURRENT_COUNT_SUFFIX));
+
+    private PrototypePartitionNaming() {
+    }
+
+    /**
+     * @param streamSuffix {@link #DATA_STREAM} or {@link #ERROR_STREAM}
+     */
+    static String fileName(String contractNumber, int partitionIndex, long fenceToken, String streamSuffix) {
+        return contractNumber + "_partition" + partitionIndex + "_t" + fenceToken + streamSuffix + NDJSON_SUFFIX;
+    }
+
+    static String dataWriterName(int partitionIndex, long fenceToken) {
+        return DATA_WRITER_PREFIX + partitionIndex + TOKEN_INFIX + fenceToken;
+    }
+
+    static String errorWriterName(int partitionIndex, long fenceToken) {
+        return ERROR_WRITER_PREFIX + partitionIndex + TOKEN_INFIX + fenceToken;
+    }
+
+    static String readerCursorKey(long fenceToken) {
+        return READER_CURSOR_PREFIX + fenceToken;
+    }
+
+    /**
+     * True for any reader or writer key this package owns, so that recovery can clean up
+     * old executions.
+     */
+    static boolean isCheckpointKey(String key) {
+        return key.startsWith(READER_CURSOR_PREFIX)
+                || key.startsWith(DATA_WRITER_PREFIX)
+                || key.startsWith(ERROR_WRITER_PREFIX);
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -36,4 +36,9 @@ public class PrototypeProperties {
 
     /** How long shutdown waits for the batch execution to finish cleaning up before shutting down. */
     private long shutdownAwaitMs = 32000;
+
+    /**
+     * Whether hard recovery restarts partitions from scratch or from the last good chunk
+     */
+    private boolean copyForwardEnabled = true;
 }

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -35,6 +35,8 @@ pause-resume.prototype.max-start-attempts=50
 pause-resume.prototype.item-retry-limit=3
 # how long shutdown waits for stopped batch executions to drain before flipping job status
 pause-resume.prototype.shutdown-await-ms=32000
+# whether hard recovery restarts a crashed partition from scratch, or tries to restart it from last good chunk
+pause-resume.prototype.copy-forward-enabled=true
 # lease TTL in seconds: a job_lease whose heartbeat is older than this is eligible for hard recovery
 job.lock.ttl=40
 # how often a worker renews its job_lease heartbeat, in milliseconds (must be well under job.lock.ttl)

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCopyForwardIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCopyForwardIntegrationTest.java
@@ -1,0 +1,127 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.job.model.Job;
+import gov.cms.ab2d.job.model.JobStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the copy-forward feature. After a hard crash, we check
+ * to see if we can recover each in-progress partition, and if we can, copy the contents
+ * of the old file to the new one instead of restarting the partition.
+ */
+class PrototypeCopyForwardIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
+
+    private static final int CHUNKS_BEFORE_CRASH = 3;
+
+    @Autowired
+    private PrototypeProperties props;
+
+    @AfterEach
+    void restoreCopyForward() {
+        props.setCopyForwardEnabled(true);
+    }
+
+    @Test
+    @DisplayName("A hard-crashed partition resumes from its last chunk instead of being redone")
+    void hardCrashResumesTheInFlightPartition() throws Exception {
+        Job job = createSubmittedV3Job("copy-fwd");
+        String uuid = job.getJobUuid();
+
+        crashMidPartition(uuid, "test-copy-forward-owner", "STARTED");
+
+        Job recovered = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, recovered.getStatus(), "a hard-crashed job should recover to SUCCESSFUL");
+        assertEveryBeneExactlyOnceInOutput(uuid);
+
+        // When the job restarts after crashing mid-partition, we expect it to only restart chunks that
+        // were in-progress. We do CHUNKS_BEFORE_CRASH number of chunks before crashing. If the recovery
+        // restarts the partition from scratch, we'd expect to see CHUNKS_BEFORE_CRASH * CHUNK_SIZE duplicates
+        // because we'd be redoing all the chunks. If it's restarting from the last good chunk, we expect to see
+        // at most CHUNK_SIZE duplicates, since only one chunk will be in progress at a time.
+        List<Long> refetched = duplicates(processedLog);
+        assertTrue(refetched.size() <= CHUNK_SIZE,
+                "copy-forward should only redo the chunks that were in-progress");
+    }
+
+    @Test
+    @DisplayName("With copy-forward off, the same crash redoes everything the partition had committed")
+    void disablingCopyForwardRedoesTheInFlightPartition() throws Exception {
+        props.setCopyForwardEnabled(false);
+        Job job = createSubmittedV3Job("no-copy-fwd");
+        String uuid = job.getJobUuid();
+
+        long committedBeforeCrash = crashMidPartition(uuid, "test-no-copy-forward-owner", "STARTED");
+
+        Job recovered = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, recovered.getStatus(), "the job should still recover to SUCCESSFUL");
+        assertEveryBeneExactlyOnceInOutput(uuid);
+
+        // this is the behaviour copy-forward replaces, and the contrast that gives the test above its meaning
+        assertTrue(duplicates(processedLog).size() >= committedBeforeCrash,
+                "the number of duplicates is too small, the partition did not restart entirely");
+    }
+
+    @Test
+    @DisplayName("A partition left UNKNOWN is redone from scratch and the job still completes")
+    void unknownPartitionIsRedone() throws Exception {
+        Job job = createSubmittedV3Job("unknown-no-copy");
+        String uuid = job.getJobUuid();
+
+        // UNKNOWN is Spring Batch saying it cannot vouch for the output file, so the checkpoint is not trusted
+        long committedBeforeCrash = crashMidPartition(uuid, "test-unknown-owner", "UNKNOWN");
+        assertTrue(workerStepStatuses(uuid).contains("UNKNOWN"), "UNKNOWN status not set or healed prematurely");
+
+        Job recovered = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, recovered.getStatus(),
+                "an UNKNOWN partition should be healed, redone, and the job should still finish");
+        assertEveryBeneExactlyOnceInOutput(uuid);
+        assertTrue(duplicates(processedLog).size() >= committedBeforeCrash,
+                "an UNKNOWN partition must not be resumed");
+    }
+
+    /**
+     * Run a job until one partition has finished and the next has committed several chunks, then abandon the
+     * worker and leave the batch metadata looking like a crash.
+     *
+     * @return how many beneficiaries were processed, which is the number we expect copy-forward to save
+     */
+    private long crashMidPartition(String uuid, String threadName, String inflightStepStatus) throws Exception {
+        RunningWorker owner = startWorkerUntilOnePartitionDone(uuid, threadName);
+        waitUntil(() -> committedReadsInFlight(uuid) >= (long) CHUNKS_BEFORE_CRASH * CHUNK_SIZE
+                || isTerminal(jobRepository.findByJobUuid(uuid)), 90);
+
+        long committed = committedReadsInFlight(uuid);
+        owner.killHard();
+        forceHardCrashState(uuid, inflightStepStatus);
+
+        assertTrue(committed >= (long) CHUNKS_BEFORE_CRASH * CHUNK_SIZE,
+                "not enough chunks were committed while running the worker");
+        assertTrue(processedLog.size() < TOTAL_BENES,
+                "the job finished before it could be crashed");
+        return committed;
+    }
+
+    /**
+     * Beneficiaries committed by partitions that have not finished.
+     */
+    private long committedReadsInFlight(String uuid) {
+        Long reads = jdbc.queryForObject(
+                "SELECT COALESCE(SUM(se.read_count), 0) FROM batch_step_execution se "
+                        + "JOIN batch_job_execution_params p ON p.job_execution_id = se.job_execution_id "
+                        + "WHERE p.parameter_name = 'jobUuid' AND p.parameter_value = ? "
+                        + "  AND se.step_name LIKE ? AND se.status <> 'COMPLETED'",
+                Long.class, uuid, WORKER_STEP_LIKE);
+        return reads == null ? 0L : reads;
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeHardRecoveryIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeHardRecoveryIntegrationTest.java
@@ -17,9 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Hard-recovery tests for scenarios where the old owner of the job is truly dead/crashed.
  * The job should be healed and restarted.
- * Hard-recovery currently restarts partitions from scratch for safety, but there is opportunity
- * to recover old partitions so long as they can be knowably healed (i.e. they are not UNKNOWN status)
- * Completed partitions get skipped either way, so they are not redone.
  */
 class PrototypeHardRecoveryIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7377

## 🛠 Changes

Adds the copy-forward feature, which restarts partitions from their last good chunk instead of restarting completely when the worker is hard-recovering a job. Also adds a naming helper to handle file suffix/prefix conventions, and a job recovery file to hold the recovery code. 

## ℹ️ Context

When recovering a crashed job, workers must decide how to handle old in-progress work. Prior to these changes, any in-progress partition would be cleared and restarted from scratch when recovering a job, which potentially throws away a significant amount of work done by the crashed worker. 

Since the worker commits its work in chunks, the recovering worker can avoid restarting the partition altogether by taking the known-good chunks and copying the data from the file forward into the new file created as part of recovery. If Spring Batch has left any of the steps as "UNKNOWN", then we do not copy anything forward and instead restart the partition, as we can no longer be certain that the data in the file is good. 

## 🧪 Validation

Local test passes by subjecting the worker to a hard kill and restarting it, with partitions restarting from checkpoints.
