### PR TITLE
Bump CDAP service module ref for benes-searched view update

### DIFF
--- a/ops/services/30-worker/main.tf
+++ b/ops/services/30-worker/main.tf
@@ -124,7 +124,7 @@ module "cluster" {
 }
 
 module "service" {
-  source = "github.com/CMSgov/cdap//terraform/modules/service?ref=52af0763fab4e65b29ead8bf88774f0bad4bdd87"
+  source = "github.com/CMSgov/cdap//terraform/modules/service?ref=9e5873303a56eb3360ca9eae93e5c96fc6f3ec64"
 
   cluster_arn                       = module.cluster.this.arn
   cpu                               = local.ecs_task_def_cpu_worker


### PR DESCRIPTION

## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7399

## ℹ️ Context
Bumps the `30-worker` `service` module ref from `52af076` to `9e58733` (CDAP `main`).

CDAP PR [#579](https://github.com/CMSgov/cdap/pull/579) Replace view definition with updated timestamp format" updates the ab2d_prod_benes_searched Insights view. That change lives in the CDAP repo; this bump pulls it into the ab2d 30-worker stack so it gets applied.

## Change
ops/services/30-worker/main.tf

- cdap//terraform/modules/service?ref=52af0763fab4e65b29ead8bf88774f0bad4bdd87
+ cdap//terraform/modules/service?ref=9e5873303a56eb3360ca9eae93e5c96fc6f3ec64

## 🧪 Validation
- Requires terraform init -upgrade to re-download the module at the new ref.