### PR TITLE
AB2D-7399 Set worker HikariCP minimumIdle to reduce idle DB connections

### DIFF
--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.datasource.username=${AB2D_DB_USER}
 spring.datasource.password=${AB2D_DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.hikari.maximumPoolSize=100
+spring.datasource.hikari.minimumIdle=10
 
 ## --------------------- @SCHEDULED annotation thread pool size
 spring.task.scheduling.pool.size=8


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7399

## 🛠 Changes

`worker/src/main/resources/application.properties`

```
  spring.datasource.hikari.maximumPoolSize=100
+ spring.datasource.hikari.minimumIdle=10
```

Adds `minimumIdle=10` to the worker's HikariCP configuration. Maximum pool size is unchanged (100).

## ℹ️ Context

HikariCP defaults `minimumIdle` to equal `maximumPoolSize`. Because the worker sets `maximumPoolSize=100` with no `minimumIdle`, the pool keeps **100 database connections open at all times**, even when the worker is idle — an unnecessary standing load on the database.

Setting `minimumIdle=10` lets the pool shrink to 10 idle connections during quiet periods, while still growing back up to the maximum of 100 under load . Peak connection capacity is unchanged, so job throughput and performance are unaffected — this only reduces the idle-time connection footprint.

No new dependencies, security controls, or data flows are affected.

## 🧪 Validation

- `maximumPoolSize` stays at 100, With `minimumIdle=10`, an idle worker holds ~10 connections instead of 100; HikariCP grows the pool on demand up to 100 and reaps back down to 10 after the idle timeout.
- Verify post-deploy via HikariCP pool metrics / DB `pg_stat_activity`: idle worker connection count should drop from ~100 toward ~10.
