### PR TITLE
AB2D-7375 use async executor

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/JobCancellationWriteListener.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/JobCancellationWriteListener.java
@@ -1,12 +1,11 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
-import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.job.model.JobStatus;
 import gov.cms.ab2d.job.repository.JobRepository;
 import gov.cms.ab2d.worker.processor.SerializedEobs;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.springframework.batch.core.listener.ChunkListener;
+import org.springframework.batch.core.listener.ItemWriteListener;
 import org.springframework.batch.core.scope.context.StepContext;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.core.step.StepExecution;
@@ -17,18 +16,18 @@ import org.springframework.batch.infrastructure.item.Chunk;
  * the worker step at the next chunk boundary
  */
 @Slf4j
-public class JobCancellationChunkListener implements ChunkListener<CoverageSummary, SerializedEobs> {
+public class JobCancellationWriteListener implements ItemWriteListener<SerializedEobs> {
 
     private final JobRepository jobRepository;
     private final String jobUuid;
 
-    public JobCancellationChunkListener(JobRepository jobRepository, String jobUuid) {
+    public JobCancellationWriteListener(JobRepository jobRepository, String jobUuid) {
         this.jobRepository = jobRepository;
         this.jobUuid = jobUuid;
     }
 
     @Override
-    public void beforeChunk(@NonNull Chunk<CoverageSummary> chunk) {
+    public void beforeWrite(@NonNull Chunk<? extends SerializedEobs> chunk) {
         if (jobRepository.getJobStatusOfJob(jobUuid) != JobStatus.CANCELLED) {
             return;
         }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -16,6 +16,7 @@ import gov.cms.ab2d.worker.processor.prototype.lease.PrototypeFenceGuard;
 import gov.cms.ab2d.worker.processor.prototype.lease.PrototypeJobLeaseRenewer;
 import gov.cms.ab2d.worker.service.JobChannelService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -26,6 +27,7 @@ import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.infrastructure.item.ItemStreamWriter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
@@ -96,6 +98,8 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private final BeneficiaryItemReader beneficiaryItemReader;
     private final EobItemProcessor eobItemProcessor;
     private final ItemStreamWriter<SerializedEobs> ndjsonItemWriter;
+    // shared by every job on this worker
+    private final AsyncTaskExecutor itemTaskExecutor;
 
     public PrototypeJobProcessorImpl(
             JobRepository jobRepository,
@@ -135,6 +139,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         this.beneficiaryItemReader = beneficiaryItemReader;
         this.eobItemProcessor = eobItemProcessor;
         this.ndjsonItemWriter = ndjsonItemWriter;
+        this.itemTaskExecutor = itemTaskExecutor(props.getItemConcurrency());
         this.props = props;
         this.failureThreshold = failureThreshold;
         this.auditFilesTtlHours = auditFilesTtlHours;
@@ -355,8 +360,16 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
 
     /** True if the batch failed because a chunk tripped the failure threshold mid-run. */
     private boolean hasThresholdException(JobExecution execution) {
+        return failedWith(execution, ThresholdExceededException.class);
+    }
+
+    /**
+     * True if any of the execution's failures is, or wraps, the given type.
+     */
+    private static boolean failedWith(JobExecution execution, Class<? extends Throwable> type) {
         return execution.getAllFailureExceptions().stream()
-                .anyMatch(ThresholdExceededException.class::isInstance);
+                .flatMap(failure -> ExceptionUtils.getThrowableList(failure).stream())
+                .anyMatch(type::isInstance);
     }
 
     /**
@@ -433,8 +446,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      * True if the execution failed because it was interrupted
      */
     private boolean wasInterrupted(JobExecution execution) {
-        return execution.getAllFailureExceptions().stream()
-                .anyMatch(InterruptedException.class::isInstance);
+        return failedWith(execution, InterruptedException.class);
     }
 
     /**
@@ -477,9 +489,13 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 .skipListener(new PrototypeSkipCounter(jobChannelService, jobUuid));
         TRANSIENT_EXCEPTIONS.forEach(workerStepBuilder::retry);
 
+        if (props.isItemConcurrencyEnabled()) {
+            workerStepBuilder.taskExecutor(itemTaskExecutor);
+        }
+
         Step workerStep = workerStepBuilder
                 // abort the step at the next chunk boundary if the job is cancelled mid-run
-                .listener(new JobCancellationChunkListener(jobRepository, jobUuid))
+                .listener(new JobCancellationWriteListener(jobRepository, jobUuid))
                 .allowStartIfComplete(false)
                 // should basically never trip
                 .startLimit(props.getMaxStartAttempts())
@@ -502,6 +518,18 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         return new JobBuilder(PROTOTYPE_JOB_NAME, batchJobRepository)
                 .start(managerStep)
                 .build();
+    }
+
+    /**
+     * Async executor for concurrent chunk work. Uses virtual threads since most threads
+     * are idle waiting for BFD. The concurrency limit prevents a small group of virtual
+     * threads from absolutely hammering BFD with a million requests.
+     */
+    private static AsyncTaskExecutor itemTaskExecutor(int concurrencyLimit) {
+        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("proto-item-");
+        executor.setVirtualThreads(true);
+        executor.setConcurrencyLimit(Math.max(1, concurrencyLimit));
+        return executor;
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProgressListener.java
@@ -1,6 +1,5 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
-import gov.cms.ab2d.coverage.model.CoverageSummary;
 import gov.cms.ab2d.worker.processor.JobMeasure;
 import gov.cms.ab2d.worker.processor.JobProgressService;
 import gov.cms.ab2d.worker.processor.ProgressTracker;
@@ -8,7 +7,7 @@ import gov.cms.ab2d.worker.processor.SerializedEobs;
 import gov.cms.ab2d.worker.service.JobChannelService;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.springframework.batch.core.listener.ChunkListener;
+import org.springframework.batch.core.listener.ItemWriteListener;
 import org.springframework.batch.core.scope.context.StepContext;
 import org.springframework.batch.core.scope.context.StepSynchronizationManager;
 import org.springframework.batch.core.step.StepExecution;
@@ -21,17 +20,17 @@ import java.util.Map;
  * Reports per-chunk progress to {@link ProgressTracker} and aborts the step when the failure
  * threshold is exceeded. A single instance is shared by all partition worker threads.
  *
- * The read/write counts come from the {@link StepExecution}, which this callback is not passed,
+ * The read counts come from the {@link StepExecution}, which this callback is not passed,
  * so it is read from the step context.
  */
 @Slf4j
-public class PrototypeProgressListener implements ChunkListener<CoverageSummary, SerializedEobs> {
+public class PrototypeProgressListener implements ItemWriteListener<SerializedEobs> {
 
     private final JobChannelService channel;
     private final JobProgressService progress;
     private final String jobUuid;
-    // stepExecutionId -> last reported [read, write] for the current run
-    private final Map<Long, long[]> reported = new HashMap<>();
+    // stepExecutionId -> last reported read count for the current run
+    private final Map<Long, Long> reportedReads = new HashMap<>();
 
     public PrototypeProgressListener(JobChannelService channel, JobProgressService progress, String jobUuid) {
         this.channel = channel;
@@ -40,28 +39,24 @@ public class PrototypeProgressListener implements ChunkListener<CoverageSummary,
     }
 
     @Override
-    public synchronized void afterChunk(@NonNull Chunk<SerializedEobs> chunk) {
+    public synchronized void afterWrite(@NonNull Chunk<? extends SerializedEobs> chunk) {
         StepExecution stepExecution = currentStepExecution();
         if (stepExecution == null) {
-            log.warn("job {} afterChunk with no bound step context; skipping progress update", jobUuid);
+            log.warn("job {} afterWrite with no bound step context; skipping progress update", jobUuid);
             return;
         }
 
         long read = stepExecution.getReadCount();
-        long write = stepExecution.getWriteCount();
-
-        long[] last = reported.getOrDefault(stepExecution.getId(), new long[2]);
-        long readDelta = read - last[0];
-        long writeDelta = write - last[1];
-        reported.put(stepExecution.getId(), new long[]{read, write});
+        long readDelta = read - reportedReads.getOrDefault(stepExecution.getId(), 0L);
+        reportedReads.put(stepExecution.getId(), read);
 
         // read count includes benes that were skipped, the subset that were skipped is counted
         // separately by the SkipCounter
         if (readDelta > 0) {
             channel.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_PROCESSED, readDelta);
         }
-        if (writeDelta > 0) {
-            channel.sendUpdate(jobUuid, JobMeasure.PATIENTS_WITH_EOBS, writeDelta);
+        if (!chunk.isEmpty()) {
+            channel.sendUpdate(jobUuid, JobMeasure.PATIENTS_WITH_EOBS, chunk.size());
         }
 
         // Optimistic abort by checking failures against the failure threshold.

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -25,6 +25,17 @@ public class PrototypeProperties {
     /** Number of partitions processed concurrently. */
     private int concurrency = 4;
 
+    /**
+     * Whether a partition processes its chunk's beneficiaries concurrently.
+     */
+    private boolean itemConcurrencyEnabled = true;
+
+    /**
+     * Ceiling on beneficiaries being fetched at once, across every prototype job on this worker.
+     * The processor uses virtual threads, so it is not bounded by number of threads.
+     */
+    private int itemConcurrency = 128;
+
     /** How many times a job's batch execution can fail before it is marked terminally failed. */
     private int maxFailureAttempts = 8;
 

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -21,10 +21,14 @@ pause-resume.prototype.item-delay-ms=0
 # DEV CRASH TESTING - sets the probability that the worker just crashes
 # for testing purposes only
 pause-resume.prototype.crash-probability=0
-# granularity for pause/resume checkpointing
+# granularity for pause/resume checkpointing, and the widest fan-out one partition can reach
 pause-resume.prototype.chunk-size=100
 # number of partitions processed concurrently
 pause-resume.prototype.concurrency=4
+# process benes in a chunk asynchronously
+pause-resume.prototype.item-concurrency-enabled=true
+# ceiling on benes being fetched across all jobs
+pause-resume.prototype.item-concurrency=128
 # benes per partition
 pause-resume.prototype.partition-size=1000
 # how many times a job can fail before it's marked as actually failing

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
@@ -87,7 +87,7 @@ import static org.mockito.Mockito.when;
         "pause-resume.prototype.concurrency=1",
         "pause-resume.prototype.chunk-size=2",
         // high slowdown to avoid flakiness
-        "pause-resume.prototype.item-delay-ms=150",
+        "pause-resume.prototype.item-delay-ms=300",
         "pause-resume.prototype.shutdown-await-ms=20000",
         "job.lock.ttl=60",
         "logging.level.gov.cms.ab2d.worker.processor.prototype=INFO",

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeConcurrentItemIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeConcurrentItemIntegrationTest.java
@@ -1,0 +1,154 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.coverage.model.CoverageSummary;
+import gov.cms.ab2d.job.model.Job;
+import gov.cms.ab2d.job.model.JobStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import java.net.SocketTimeoutException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+/**
+ * Tests concurrent item processing. Checks that the work is actually being done in parallel, that
+ * retry/failure/skipping is item-level so that one bad bene doesn't fail the whole chunk.
+ */
+@TestPropertySource(properties = {
+        // we don't need a delay for this test
+        "pause-resume.prototype.item-delay-ms=0"
+})
+class PrototypeConcurrentItemIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
+
+    private static final long TARGET_BENE = 6L;
+    private static final long CHUNK_MATE = 5L;
+
+    /** Every call made to "bfd". */
+    private final Map<Long, AtomicInteger> attempts = new ConcurrentHashMap<>();
+
+    private int attemptsFor(long bene) {
+        AtomicInteger count = attempts.get(bene);
+        return count == null ? 0 : count.get();
+    }
+
+    private void recordAttempt(long bene) {
+        attempts.computeIfAbsent(bene, k -> new AtomicInteger()).incrementAndGet();
+    }
+
+    @Test
+    @DisplayName("A chunk's beneficiaries are fetched in parallel")
+    void chunkBenesAreProcessedConcurrently() throws Exception {
+        Job job = createSubmittedV3Job("item-concurrent");
+        String uuid = job.getJobUuid();
+
+        // The mocked answer causes a processed bene to wait around until this latch opens
+        // the latch opens when it counts down twice
+        // If the benes are being processed in parallel:
+        //  bene 1 finishes and counts down the latch
+        //  bene 1 waits for the latch to open
+        //  at the same time, bene 2 on a different thread finishes
+        //  bene 2 counts down, the latch opens, both benes complete
+        // If the benes are being processed in series:
+        //  bene 1 finishes and counts down the latch
+        //  bene 1 waits for the latch to open
+        //  the latch doesn't open since bene 2 isn't being processed
+        //  bene 1 times out
+        //  bene 2 starts and the same thing happens, it times out
+        //  the test knows that the benes are not being processed in parallel
+        CountDownLatch bothInFlight = new CountDownLatch(2);
+        AtomicBoolean timedOut = new AtomicBoolean(false);
+        List<String> threadNames = new CopyOnWriteArrayList<>();
+
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            threadNames.add(Thread.currentThread().getName());
+            bothInFlight.countDown();
+            if (!bothInFlight.await(15, TimeUnit.SECONDS)) {
+                timedOut.set(true);
+            }
+            return oneEobFor(patient);
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertFalse(timedOut.get(),
+                "the chunk was not processed in parallel, one or more benes timed out");
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus());
+        assertEveryBeneExactlyOnceInOutput(uuid);
+
+        assertTrue(new HashSet<>(threadNames).size() > 1,
+                "expected more than one worker thread to serve the partition, saw " + new HashSet<>(threadNames));
+        assertTrue(threadNames.stream().allMatch(name -> name.startsWith("proto-item-")),
+                "bene work should run on the prototype item executor");
+    }
+
+    @Test
+    @DisplayName("A transient failure retries only the beneficiary that failed, not its chunk")
+    void transientFailureRetriesOnlyTheFailingBene() throws Exception {
+        Job job = createSubmittedV3Job("item-retry");
+        String uuid = job.getJobUuid();
+
+        // bene 6 fails twice with a retryable exception, then succeeds within the retry limit of 3
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            long id = patientId(patient);
+            recordAttempt(id);
+            if (id == TARGET_BENE && attemptsFor(id) <= 2) {
+                throw new SocketTimeoutException("transient failure " + attemptsFor(id) + " for bene " + id);
+            }
+            return oneEobFor(patient);
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a bene that recovers within its retries is not an error");
+        assertEquals(3, attemptsFor(TARGET_BENE), "bene " + TARGET_BENE + " should have been retried until it succeeded");
+        assertEquals(1, attemptsFor(CHUNK_MATE),
+                "bene " + CHUNK_MATE + " shares a chunk with " + TARGET_BENE + " and must not be re-fetched for it");
+        assertEveryBeneExactlyOnceInOutput(uuid);
+    }
+
+    @Test
+    @DisplayName("A skipped beneficiary still lets the rest of its chunk commit")
+    void skippedBeneDoesNotCostItsChunkMates() throws Exception {
+        Job job = createSubmittedV3Job("item-skip");
+        String uuid = job.getJobUuid();
+
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            long id = patientId(patient);
+            recordAttempt(id);
+            if (id == TARGET_BENE) {
+                throw new IllegalStateException("persistent failure for bene " + id);
+            }
+            return oneEobFor(patient);
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        // one failure out of twenty is under the 10% threshold
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus());
+        assertEquals(1, attemptsFor(TARGET_BENE), "a non-transient failure should not be retried");
+        assertEquals(1, attemptsFor(CHUNK_MATE), "the chunk-mate of a skipped bene should not be retried");
+
+        Set<Long> delivered = new HashSet<>(benesIn(deliveredOutputFiles(uuid)));
+        assertFalse(delivered.contains(TARGET_BENE), "the skipped bene should not be in the output");
+        assertTrue(delivered.contains(CHUNK_MATE), "the chunk-mate of the skipped bene should still be output");
+        assertEquals(TOTAL_BENES - 1, delivered.size(), "total benes delivered does not include skipped bene");
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobPauseResumeIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobPauseResumeIntegrationTest.java
@@ -97,4 +97,37 @@ class PrototypeJobPauseResumeIntegrationTest extends AbstractPrototypeRecoveryIn
         assertTrue(finishedFiles(uuid).isEmpty() && streamingFiles(uuid).isEmpty(),
                 "streaming/ and finished/ working directories should be cleaned up after success");
     }
+
+    @Test
+    @DisplayName("A cancelled job stops at the next chunk instead of finishing")
+    void jobStopsShortWhenCancelledMidRun() throws Exception {
+        Job job = createSubmittedV3Job("cancel-it");
+        String uuid = job.getJobUuid();
+
+        // start the worker and let it do one partition
+        RunningWorker worker = startWorkerUntilOnePartitionDone(uuid, "test-cancel-worker");
+        int processedBeforeCancel = new HashSet<>(processedLog).size();
+        log.info("=== {} of {} benes processed, cancelling job {} mid-run ===",
+                processedBeforeCancel, TOTAL_BENES, uuid);
+
+        // directly change the job status to canceled
+        assertEquals(1, jdbc.update("UPDATE job SET status = 'CANCELLED' WHERE job_uuid = ?", uuid),
+                "expected exactly one job row to cancel for " + uuid);
+
+        // wait until the worker notices the job's been canceled
+        worker.awaitReturn(90);
+
+        Set<Long> distinctProcessed = new HashSet<>(processedLog);
+        assertEquals(JobStatus.CANCELLED, jobRepository.findByJobUuid(uuid).getStatus(),
+                "a cancelled job should be left CANCELLED");
+
+        // check to make sure the batch did didn't finish
+        assertTrue(distinctProcessed.size() < TOTAL_BENES,
+                "all " + TOTAL_BENES + " benes were processed, so the cancellation was never noticed mid-run");
+
+        // check to make sure the job got cleaned up
+        assertTrue(deliveredOutputFiles(uuid).isEmpty() && finishedFiles(uuid).isEmpty()
+                        && streamingFiles(uuid).isEmpty(),
+                "a cancelled job should leave no output or working files behind");
+    }
 }


### PR DESCRIPTION
## 🎫 Ticket

[https://jira.cms.gov/browse/AB2D-7375](https://jira.cms.gov/browse/AB2D-7375)

## 🛠 Changes

Makes the processor use an async executor with virtual threads. 

## ℹ️ Context

The prototype processor used to process benes in series, and its concurrency was limited to working on multiple different partitions at once. 

Now it processes benes in parallel and still processes partitions in parallel. 

## 🧪 Validation

Tests pass, and pause/resume works as intended locally
