### PR TITLE
AB2D-7381/Pause/Resume monitoring and alerts

### DIFF
--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -207,3 +207,5 @@ databaseChangeLog:
       file: db/changelog/v2026/create_job_lease_table.sql
   - include:
       file: db/changelog/v2026/spring-batch-schema-postgresql.sql
+  - include:
+      file: db/changelog/v2026/add_job_lease_alerted_at.sql

--- a/common/src/main/resources/db/changelog/v2026/add_job_lease_alerted_at.sql
+++ b/common/src/main/resources/db/changelog/v2026/add_job_lease_alerted_at.sql
@@ -1,0 +1,4 @@
+-- Cooldown marker for the pause/resume prototype's stranded-job alert.
+-- Stamped when a worker claims the right to alert about an unrecovered lease, so that many workers polling
+-- on a short interval produce one alert per job per cooldown instead of one per worker per poll.
+ALTER TABLE ab2d.job_lease ADD COLUMN IF NOT EXISTS alerted_at TIMESTAMPTZ;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -41,7 +41,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PROD_LIST;
+import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_COMPLETED;
+import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_FAILURE;
 import static gov.cms.ab2d.job.model.JobStatus.CANCELLED;
 import static gov.cms.ab2d.job.model.JobStatus.FAILED;
 import static gov.cms.ab2d.job.model.JobStatus.IN_PROGRESS;
@@ -86,6 +88,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private final JobProgressService jobProgressService;
     private final JobProgressUpdateService jobProgressUpdateService;
     private final SQSEventClient eventLogger;
+    private final PrototypeMetrics metrics;
     // per-JVM diagnostic identity recorded on the lease so logs/monitoring can attribute ownership
     private final String owner = "worker-" + java.util.UUID.randomUUID();
     private final PrototypeProperties props;
@@ -112,6 +115,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             JobProgressService jobProgressService,
             JobProgressUpdateService jobProgressUpdateService,
             SQSEventClient eventLogger,
+            PrototypeMetrics metrics,
             BeneficiaryItemReader beneficiaryItemReader,
             EobItemProcessor eobItemProcessor,
             ItemStreamWriter<SerializedEobs> ndjsonItemWriter,
@@ -132,6 +136,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         this.jobProgressService = jobProgressService;
         this.jobProgressUpdateService = jobProgressUpdateService;
         this.eventLogger = eventLogger;
+        this.metrics = metrics;
         this.beneficiaryItemReader = beneficiaryItemReader;
         this.eobItemProcessor = eobItemProcessor;
         this.ndjsonItemWriter = ndjsonItemWriter;
@@ -167,6 +172,9 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         PrototypeJobRecovery.Ownership ownership = recovery.acquire(jobUuid, owner);
         long fenceToken = ownership.fenceToken();
         boolean softResume = ownership.softResume();
+        // Recorded before the run so a job that never gets any further is still visible as an attempt, and
+        // so soft resumes (a clean pause picked back up) are countable apart from hard recoveries (a crash).
+        metrics.jobStarted(jobUuid, contractNumber, ownership.mode(), fenceToken);
 
         // Start renewing the heartbeat
         leaseRenewer.track(jobUuid, fenceToken);
@@ -179,20 +187,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
 
             // Only build the aggregated attribution table on a fresh start
             JobExecution last = batchJobRepository.getLastJobExecution(PROTOTYPE_JOB_NAME, parameters);
-            if (last == null) {
-                log.info("no prior batch execution for job {} - creating aggregated attribution table", jobUuid);
-                coverageV3Service.createAggregatedAttributionTable(contractNumber);
-            } else if (!coverageV3Service.aggregatedTableExists(contractNumber)) {
-                // A prior worker that failed terminally or was fenced out may have dropped the aggregated
-                // table. We safely remake it because a hard recovery re-runs the partitioner from scratch anyway.
-                log.warn("prior batch execution {} for job {} but aggregated table for contract {} is missing - "
-                        + "rebuilding ({} at token {})",
-                        last.getId(), jobUuid, contractNumber, softResume ? "soft resume" : "hard recovery", fenceToken);
-                coverageV3Service.createAggregatedAttributionTable(contractNumber);
-            } else {
-                log.info("prior batch execution {} for job {} - {} at token {} (reusing aggregated table)",
-                        last.getId(), jobUuid, softResume ? "soft resume" : "hard recovery", fenceToken);
-            }
+            prepareAggregatedTable(last, jobUuid, contractNumber, softResume, fenceToken);
 
             // job progress is initialized on startup since we could be restarting
             // a job that was already in progress
@@ -217,6 +212,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             if (wasFencedOut(jobUuid, fenceToken)) {
                 log.info("prototype job {} was superseded (ran under token {}, newer token now holds the lease) - "
                         + "exiting quietly with no resubmit", jobUuid, fenceToken);
+                metrics.fencedOut(jobUuid, contractNumber, fenceToken, "after_run");
                 return jobRepository.findByJobUuid(jobUuid);
             }
 
@@ -224,6 +220,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             Job current = jobRepository.findByJobUuid(jobUuid);
             if (current != null && current.getStatus() == CANCELLED) {
                 log.warn("prototype job {} was cancelled during processing; leaving CANCELLED and cleaning up", jobUuid);
+                metrics.jobCancelled(jobUuid, contractNumber);
                 coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
                 outputAssembler.deleteJobDirectory(jobUuid);
                 return current;
@@ -245,7 +242,8 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 // and fsynced its file to the saved offset.
                 // The last thing we do is mark the job as suspended. If we crash here, we'll just hard-recover
                 // anyway, which is unfortunate, but will avoid corruption/mistakes.
-                jobLease.markCleanSuspend(jobUuid, fenceToken);
+                boolean cleanSuspend = jobLease.markCleanSuspend(jobUuid, fenceToken);
+                metrics.jobSuspended(jobUuid, contractNumber, fenceToken, cleanSuspend);
                 job.setStatus(SUBMITTED);
                 job.setStatusMessage("Paused via prototype");
             } else if (hasThresholdException(execution) || thresholdExceeded(jobUuid)) {
@@ -264,12 +262,15 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             if (wasFencedOut(jobUuid, fenceToken)) {
                 log.info("prototype job {} threw while superseded (ran under token {}, newer token now holds the "
                         + "lease) - exiting quietly, the current owner is responsible for this job", jobUuid, fenceToken);
+                metrics.fencedOut(jobUuid, contractNumber, fenceToken, "exception");
                 return jobRepository.findByJobUuid(jobUuid);
             }
             // issues with launching are terminal and fail the job without retry
             log.error("prototype job {} failed to launch", jobUuid, e);
+            String message = "Prototype execution failed: " + e.getMessage();
+            alertJobFailed(job, jobUuid, contractNumber, PrototypeMetrics.FailureReason.LAUNCH_FAILED, message);
             job.setStatus(FAILED);
-            job.setStatusMessage("Prototype execution failed: " + e.getMessage());
+            job.setStatusMessage(message);
             coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
         } finally {
             leaseRenewer.untrack(jobUuid);
@@ -289,18 +290,55 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     }
 
     /**
+     * Build the aggregated attribution table on a fresh start, and rebuild it on a resume if a prior worker
+     * dropped it on its way out. Reused as-is otherwise, since it is the immutable snapshot the partitions
+     * are cut from.
+     */
+    private void prepareAggregatedTable(JobExecution last, String jobUuid, String contractNumber,
+                                        boolean softResume, long fenceToken) {
+        if (last == null) {
+            log.info("no prior batch execution for job {} - creating aggregated attribution table", jobUuid);
+            coverageV3Service.createAggregatedAttributionTable(contractNumber);
+        } else if (!coverageV3Service.aggregatedTableExists(contractNumber)) {
+            // A prior worker that failed terminally or was fenced out may have dropped the aggregated
+            // table. We safely remake it because a hard recovery re-runs the partitioner from scratch anyway.
+            log.warn("prior batch execution {} for job {} but aggregated table for contract {} is missing - "
+                    + "rebuilding ({} at token {})",
+                    last.getId(), jobUuid, contractNumber, softResume ? "soft resume" : "hard recovery", fenceToken);
+            coverageV3Service.createAggregatedAttributionTable(contractNumber);
+        } else {
+            log.info("prior batch execution {} for job {} - {} at token {} (reusing aggregated table)",
+                    last.getId(), jobUuid, softResume ? "soft resume" : "hard recovery", fenceToken);
+        }
+    }
+
+    /**
      * Increment the jobs failed attempts, then send it back to be resubmitted
      */
     private void applyFailureOutcome(Job job, String contractNumber, String jobUuid, String message) {
         int failures = batchMeta.failedExecutionCount(jobUuid);
         int maxFailureAttempts = props.getMaxFailureAttempts();
         if (failures < maxFailureAttempts) {
+            // A resumable failure is not a job outcome yet, so it does not alert as one. It does get counted,
+            // and once the remaining attempts run low it is traced to the AB2D channel as an early warning.
+            boolean approachingMax =
+                    maxFailureAttempts - failures <= props.getFailureAttemptsWarnRemaining();
+            metrics.jobFailureAttempt(jobUuid, contractNumber, failures, maxFailureAttempts, approachingMax);
+            if (approachingMax) {
+                eventLogger.trace(String.format(
+                        "AB2D pause/resume: job %s for contract %s has failed %d of %d allowed attempts and "
+                                + "will fail terminally if it keeps failing. Last failure: %s",
+                        jobUuid, contractNumber, failures, maxFailureAttempts, message), PUBLIC_LIST);
+            }
             job.setStatus(SUBMITTED);
             job.setStatusMessage(message + " (attempt " + failures + " of " + maxFailureAttempts + "; will resume)");
             log.warn("prototype job {} failed ({}/{} attempts) - resubmitting for resume", jobUuid, failures, maxFailureAttempts);
         } else {
+            String failureMessage = message + " (failed after " + failures + " attempts)";
+            alertJobFailed(job, jobUuid, contractNumber, PrototypeMetrics.FailureReason.ATTEMPTS_EXHAUSTED,
+                    failureMessage);
             job.setStatus(FAILED);
-            job.setStatusMessage(message + " (failed after " + failures + " attempts)");
+            job.setStatusMessage(failureMessage);
             log.error("prototype job {} exhausted {} failure attempts - marking FAILED", jobUuid, maxFailureAttempts);
             coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
         }
@@ -311,9 +349,29 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      */
     private void applyThresholdFailure(Job job, String contractNumber, String jobUuid) {
         log.error("prototype job {} failed: too many patient records in the job had failures", jobUuid);
+        ProgressTracker tracker = jobProgressService.getStatus(jobUuid);
+        if (tracker != null) {
+            metrics.thresholdExceeded(jobUuid, contractNumber, tracker.getPatientFailureCount(),
+                    tracker.getTotalCount());
+        }
+        String message = "Failed: too many patient records in the job had failures";
+        alertJobFailed(job, jobUuid, contractNumber, PrototypeMetrics.FailureReason.THRESHOLD_EXCEEDED, message);
         job.setStatus(FAILED);
-        job.setStatusMessage("Failed: too many patient records in the job had failures");
+        job.setStatusMessage(message);
         coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
+    }
+
+    /**
+     * Every terminal failure in this processor goes through here so all three paths - the failure threshold,
+     * exhausted resume attempts, and a launch/teardown exception - alert to Slack and count under the same
+     * metric with a reason tag. Called before the status is set so the event carries the failure message.
+     */
+    private void alertJobFailed(Job job, String jobUuid, String contractNumber,
+                                PrototypeMetrics.FailureReason reason, String message) {
+        metrics.jobFailed(jobUuid, contractNumber, reason, message);
+        eventLogger.logAndAlert(job.buildJobStatusChangeEvent(FAILED,
+                EOB_JOB_FAILURE + " Prototype job " + jobUuid + " for contract " + contractNumber
+                        + " failed (" + reason.tagValue() + "): " + message), PUBLIC_LIST);
     }
 
     /**
@@ -339,6 +397,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         String message = String.format("%s via prototype: processed %d patients into %d file(s)",
                 EOB_JOB_COMPLETED, processed, job.getJobOutputs().size());
         eventLogger.logAndAlert(job.buildJobStatusChangeEvent(SUCCESSFUL, message), PROD_LIST);
+        metrics.jobCompleted(jobUuid, job.getContractNumber(), processed, job.getJobOutputs().size());
 
         job.setStatus(SUCCESSFUL);
         job.setStatusMessage("100%");
@@ -372,6 +431,8 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             return;
         }
         log.info("shutdown: stopping {} running prototype batch execution(s) before releasing jobs", running.size());
+        metrics.drainStarted(running.size());
+        long startedAt = System.currentTimeMillis();
         for (JobExecution je : running) {
             try {
                 jobOperator.stop(je);
@@ -383,21 +444,27 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         // Wait for the partition threads to actually finish before changing status
         // might need a TODO for a more robust system than a sleep
         long shutdownAwaitMs = props.getShutdownAwaitMs();
-        long deadline = System.currentTimeMillis() + shutdownAwaitMs;
+        long deadline = startedAt + shutdownAwaitMs;
         while (System.currentTimeMillis() < deadline) {
             if (batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).isEmpty()) {
                 log.info("shutdown: all prototype batch executions stopped");
+                metrics.drainFinished(true, System.currentTimeMillis() - startedAt, 0);
                 return;
             }
             try {
                 Thread.sleep(250);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
+                // Interrupted before the drain finished, so the jobs still running will be hard-recovered.
+                metrics.drainFinished(false, System.currentTimeMillis() - startedAt,
+                        batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).size());
                 return;
             }
         }
         log.warn("shutdown: prototype batch executions still running after {}ms; proceeding with status reset anyway",
                 shutdownAwaitMs);
+        metrics.drainFinished(false, System.currentTimeMillis() - startedAt,
+                batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).size());
     }
 
     /**
@@ -466,7 +533,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 .writer(ndjsonItemWriter)
                 // each chunk commit comes with a fence token which prevents
                 // us from committing work if we've lost the job
-                .listener(new PrototypeFenceGuard(jobLease, jobUuid, fenceToken))
+                .listener(new PrototypeFenceGuard(jobLease, metrics, jobUuid, fenceToken))
                 // per-chunk progress and failure reporting
                 .listener(new PrototypeProgressListener(jobChannelService, jobProgressService, jobUuid))
                 .faultTolerant()
@@ -474,7 +541,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 .retryLimit(props.getItemRetryLimit())
                 .skipPolicy(new PrototypeSkipPolicy())
                 // count each skipped beneficiary as one error against the error threshold
-                .skipListener(new PrototypeSkipCounter(jobChannelService, jobUuid));
+                .skipListener(new PrototypeSkipCounter(jobChannelService, metrics, jobUuid));
         TRANSIENT_EXCEPTIONS.forEach(workerStepBuilder::retry);
 
         Step workerStep = workerStepBuilder

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -174,7 +174,9 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         boolean softResume = ownership.softResume();
         // Recorded before the run so a job that never gets any further is still visible as an attempt, and
         // so soft resumes (a clean pause picked back up) are countable apart from hard recoveries (a crash).
-        metrics.jobStarted(jobUuid, contractNumber, ownership.mode(), fenceToken);
+        log.info("prototype job {} starting for contract {} as a {} claim at token {}",
+                jobUuid, contractNumber, ownership.mode().tagValue(), fenceToken);
+        metrics.jobStarted(contractNumber, ownership.mode());
 
         // Start renewing the heartbeat
         leaseRenewer.track(jobUuid, fenceToken);
@@ -212,7 +214,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             if (wasFencedOut(jobUuid, fenceToken)) {
                 log.info("prototype job {} was superseded (ran under token {}, newer token now holds the lease) - "
                         + "exiting quietly with no resubmit", jobUuid, fenceToken);
-                metrics.fencedOut(jobUuid, contractNumber, fenceToken, "after_run");
+                metrics.fencedOut(contractNumber, "after_run");
                 return jobRepository.findByJobUuid(jobUuid);
             }
 
@@ -220,7 +222,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             Job current = jobRepository.findByJobUuid(jobUuid);
             if (current != null && current.getStatus() == CANCELLED) {
                 log.warn("prototype job {} was cancelled during processing; leaving CANCELLED and cleaning up", jobUuid);
-                metrics.jobCancelled(jobUuid, contractNumber);
+                metrics.jobCancelled(contractNumber);
                 coverageV3Service.deleteAggregatedTableForContract(contractNumber, Optional.of(jobUuid));
                 outputAssembler.deleteJobDirectory(jobUuid);
                 return current;
@@ -243,7 +245,11 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
                 // The last thing we do is mark the job as suspended. If we crash here, we'll just hard-recover
                 // anyway, which is unfortunate, but will avoid corruption/mistakes.
                 boolean cleanSuspend = jobLease.markCleanSuspend(jobUuid, fenceToken);
-                metrics.jobSuspended(jobUuid, contractNumber, fenceToken, cleanSuspend);
+                if (!cleanSuspend) {
+                    log.warn("prototype job {} suspended WITHOUT a clean-suspend marker at token {} - the next "
+                            + "pickup will have to hard-recover", jobUuid, fenceToken);
+                }
+                metrics.jobSuspended(contractNumber, cleanSuspend);
                 job.setStatus(SUBMITTED);
                 job.setStatusMessage("Paused via prototype");
             } else if (hasThresholdException(execution) || thresholdExceeded(jobUuid)) {
@@ -262,7 +268,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             if (wasFencedOut(jobUuid, fenceToken)) {
                 log.info("prototype job {} threw while superseded (ran under token {}, newer token now holds the "
                         + "lease) - exiting quietly, the current owner is responsible for this job", jobUuid, fenceToken);
-                metrics.fencedOut(jobUuid, contractNumber, fenceToken, "exception");
+                metrics.fencedOut(contractNumber, "exception");
                 return jobRepository.findByJobUuid(jobUuid);
             }
             // issues with launching are terminal and fail the job without retry
@@ -323,7 +329,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             // and once the remaining attempts run low it is traced to the AB2D channel as an early warning.
             boolean approachingMax =
                     maxFailureAttempts - failures <= props.getFailureAttemptsWarnRemaining();
-            metrics.jobFailureAttempt(jobUuid, contractNumber, failures, maxFailureAttempts, approachingMax);
+            metrics.jobFailureAttempt(contractNumber, failures, maxFailureAttempts, approachingMax);
             if (approachingMax) {
                 eventLogger.trace(String.format(
                         "AB2D pause/resume: job %s for contract %s has failed %d of %d allowed attempts and "
@@ -348,12 +354,10 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      * Terminal failure because too many beneficiaries errored
      */
     private void applyThresholdFailure(Job job, String contractNumber, String jobUuid) {
-        log.error("prototype job {} failed: too many patient records in the job had failures", jobUuid);
         ProgressTracker tracker = jobProgressService.getStatus(jobUuid);
-        if (tracker != null) {
-            metrics.thresholdExceeded(jobUuid, contractNumber, tracker.getPatientFailureCount(),
-                    tracker.getTotalCount());
-        }
+        log.error("prototype job {} failed: too many patient records in the job had failures ({} of {})",
+                jobUuid, tracker == null ? -1 : tracker.getPatientFailureCount(),
+                tracker == null ? -1 : tracker.getTotalCount());
         String message = "Failed: too many patient records in the job had failures";
         alertJobFailed(job, jobUuid, contractNumber, PrototypeMetrics.FailureReason.THRESHOLD_EXCEEDED, message);
         job.setStatus(FAILED);
@@ -368,7 +372,9 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
      */
     private void alertJobFailed(Job job, String jobUuid, String contractNumber,
                                 PrototypeMetrics.FailureReason reason, String message) {
-        metrics.jobFailed(jobUuid, contractNumber, reason, message);
+        log.error("prototype job {} for contract {} FAILED ({}): {}", jobUuid, contractNumber,
+                reason.tagValue(), message);
+        metrics.jobFailed(contractNumber, reason);
         eventLogger.logAndAlert(job.buildJobStatusChangeEvent(FAILED,
                 EOB_JOB_FAILURE + " Prototype job " + jobUuid + " for contract " + contractNumber
                         + " failed (" + reason.tagValue() + "): " + message), PUBLIC_LIST);
@@ -397,7 +403,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         String message = String.format("%s via prototype: processed %d patients into %d file(s)",
                 EOB_JOB_COMPLETED, processed, job.getJobOutputs().size());
         eventLogger.logAndAlert(job.buildJobStatusChangeEvent(SUCCESSFUL, message), PROD_LIST);
-        metrics.jobCompleted(jobUuid, job.getContractNumber(), processed, job.getJobOutputs().size());
+        metrics.jobCompleted(job.getContractNumber(), processed);
 
         job.setStatus(SUCCESSFUL);
         job.setStatusMessage("100%");
@@ -431,7 +437,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             return;
         }
         log.info("shutdown: stopping {} running prototype batch execution(s) before releasing jobs", running.size());
-        metrics.drainStarted(running.size());
+        metrics.drainStarted();
         long startedAt = System.currentTimeMillis();
         for (JobExecution je : running) {
             try {
@@ -448,7 +454,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         while (System.currentTimeMillis() < deadline) {
             if (batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).isEmpty()) {
                 log.info("shutdown: all prototype batch executions stopped");
-                metrics.drainFinished(true, System.currentTimeMillis() - startedAt, 0);
+                metrics.drainFinished(true, System.currentTimeMillis() - startedAt);
                 return;
             }
             try {
@@ -456,15 +462,14 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 // Interrupted before the drain finished, so the jobs still running will be hard-recovered.
-                metrics.drainFinished(false, System.currentTimeMillis() - startedAt,
-                        batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).size());
+                log.warn("shutdown: interrupted before the drain finished; remaining jobs will be hard-recovered");
+                metrics.drainFinished(false, System.currentTimeMillis() - startedAt);
                 return;
             }
         }
         log.warn("shutdown: prototype batch executions still running after {}ms; proceeding with status reset anyway",
                 shutdownAwaitMs);
-        metrics.drainFinished(false, System.currentTimeMillis() - startedAt,
-                batchJobRepository.findRunningJobExecutions(PROTOTYPE_JOB_NAME).size());
+        metrics.drainFinished(false, System.currentTimeMillis() - startedAt);
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -47,19 +47,32 @@ public class PrototypeJobRecovery {
     private final PrototypeBatchMetadataRepository batchMeta;
     private final SearchConfig searchConfig;
     private final PrototypeProperties props;
+    private final PrototypeMetrics metrics;
 
     public PrototypeJobRecovery(JobLeaseRepository jobLease, JobRepository batchJobRepository,
                                 PrototypeBatchMetadataRepository batchMeta, SearchConfig searchConfig,
-                                PrototypeProperties props) {
+                                PrototypeProperties props, PrototypeMetrics metrics) {
         this.jobLease = jobLease;
         this.batchJobRepository = batchJobRepository;
         this.batchMeta = batchMeta;
         this.searchConfig = searchConfig;
         this.props = props;
+        this.metrics = metrics;
     }
 
     /** Record of whether this worker soft or hard restarted this job, and its token  */
     public record Ownership(long fenceToken, boolean softResume) {
+
+        /**
+         * How this worker came to own the job. A bump that produced the very first token means nobody held
+         * the job before, so there is nothing to recover; any higher token means a prior owner was displaced.
+         */
+        public ResumeMode mode() {
+            if (softResume) {
+                return ResumeMode.SOFT;
+            }
+            return fenceToken <= 1 ? ResumeMode.FRESH : ResumeMode.HARD;
+        }
     }
 
     /**
@@ -76,7 +89,12 @@ public class PrototypeJobRecovery {
         // Copy-forward runs first, to see if there are any UNKNOWN statuses
         // If no, it copies the old partition work to the new file
         // If yes, it doesn't copy anything forward, the partition will be restarted
-        copyForward(jobUuid, fenceToken);
+        CopyForwardResult copied = copyForward(jobUuid, fenceToken);
+        // Only a genuine takeover has partitions to carry forward. A first claim has none, and reporting
+        // zeroes for it would drown the signal we actually want out of this metric.
+        if (fenceToken > 1) {
+            metrics.copyForward(jobUuid, fenceToken, copied.seeded(), copied.restarted());
+        }
         batchMeta.healIndeterminateExecutions(jobUuid);
         return new Ownership(fenceToken, false);
     }
@@ -85,26 +103,30 @@ public class PrototypeJobRecovery {
      * If the partition is not in status UNKNOWN, and hasn't been completed, copy its work
      * over to the new file.
      */
-    private int copyForward(String jobUuid, long newToken) {
+    private CopyForwardResult copyForward(String jobUuid, long newToken) {
         if (!props.isCopyForwardEnabled()) {
             log.info("copy-forward is disabled for job {}", jobUuid);
-            return 0;
+            return CopyForwardResult.NONE;
         }
 
         int copied = 0;
+        int restarted = 0;
         try {
             JobInstance instance = batchJobRepository.getJobInstance(PROTOTYPE_JOB_NAME,
                     new JobParametersBuilder().addString(JOB_UUID_PARAM, jobUuid).toJobParameters());
             if (instance == null) {
-                return 0;
+                return CopyForwardResult.NONE;
             }
 
             for (String stepName : batchMeta.partitionStepNames(jobUuid, WORKER_STEP_NAME)) {
                 try {
-                    if (copyForwardPartition(jobUuid, instance, stepName, newToken)) {
-                        copied++;
+                    switch (copyForwardPartition(jobUuid, instance, stepName, newToken)) {
+                        case SEEDED -> copied++;
+                        case RESTARTED -> restarted++;
+                        default -> { /* the partition was already finished, there is nothing to carry */ }
                     }
                 } catch (RuntimeException e) {
+                    restarted++;
                     log.warn("copy-forward for job {}: {} failed to copy, so the partition " +
                             "will be restarted", jobUuid, stepName, e);
                 }
@@ -115,7 +137,26 @@ public class PrototypeJobRecovery {
         if (copied > 0) {
             log.info("copy-forward for job {}: seeded {} partition(s) into token {}", jobUuid, copied, newToken);
         }
-        return copied;
+        return new CopyForwardResult(copied, restarted);
+    }
+
+    /** How many in-flight partitions kept their committed chunks, and how many have to be redone. */
+    private record CopyForwardResult(int seeded, int restarted) {
+
+        private static final CopyForwardResult NONE = new CopyForwardResult(0, 0);
+    }
+
+    /** What happened to one partition during the copy-forward pass. */
+    private enum PartitionCopyOutcome {
+
+        /** Committed chunks were carried into the new token's file, the partition resumes mid-way. */
+        SEEDED,
+
+        /** Nothing could be carried, so the partition will be processed again from the beginning. */
+        RESTARTED,
+
+        /** The partition was already COMPLETED or never ran, so there is no in-flight work to carry. */
+        SKIPPED
     }
 
     /**
@@ -124,17 +165,17 @@ public class PrototypeJobRecovery {
      * completed, the executionContext is left untouched and the partition will
      * behave "normally". Normal in this case means restarting the partition from scratch.
      *
-     * @return true if the partition's checkpoint was updated
+     * @return what happened to the partition, so recovery can report how much work survived the crash
      */
-    private boolean copyForwardPartition(String jobUuid, JobInstance instance, String stepName, long newToken) {
+    private PartitionCopyOutcome copyForwardPartition(String jobUuid, JobInstance instance, String stepName, long newToken) {
         StepExecution last = batchJobRepository.getLastStepExecution(instance, stepName);
         if (last == null || last.getStatus() == BatchStatus.COMPLETED) {
-            return false;
+            return PartitionCopyOutcome.SKIPPED;
         }
         if (last.getStatus() == BatchStatus.UNKNOWN) {
             log.info("copy-forward for job {}: {} ended UNKNOWN, so its partition " +
                     "will be restarted", jobUuid, stepName);
-            return false;
+            return PartitionCopyOutcome.RESTARTED;
         }
 
         ExecutionContext context = last.getExecutionContext();
@@ -144,14 +185,14 @@ public class PrototypeJobRecovery {
             log.warn("copy-forward for job {}: {} is missing the contract number or partition index the " +
                             "partitioner writes, so the partition must be restarted",
                     jobUuid, stepName);
-            return false;
+            return PartitionCopyOutcome.RESTARTED;
         }
 
         Checkpoint checkpoint = readCheckpoint(context, partitionIndex);
         if (checkpoint == null) {
             log.info("copy-forward for job {}: {} has no committed chunks, so it " +
                     "will be restarted", jobUuid, stepName);
-            return false;
+            return PartitionCopyOutcome.RESTARTED;
         }
 
         Path streamingDir = searchConfig.getStreamingDir(jobUuid).toPath();
@@ -168,14 +209,14 @@ public class PrototypeJobRecovery {
             deleteQuietly(seeded);
             log.warn("copy-forward for job {}: could not seed {} from token {}, so the partition must restart",
                     jobUuid, stepName, checkpoint.token(), e);
-            return false;
+            return PartitionCopyOutcome.RESTARTED;
         }
 
         log.info("copy-forward for job {}: {} resumes at patient {} with {} data byte(s) and {} error byte(s) "
                         + "carried from token {} into token {}",
                 jobUuid, stepName, checkpoint.readerCursor(), checkpoint.dataBytes(), checkpoint.errorBytes(),
                 checkpoint.token(), newToken);
-        return true;
+        return PartitionCopyOutcome.SEEDED;
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -93,7 +93,9 @@ public class PrototypeJobRecovery {
         // Only a genuine takeover has partitions to carry forward. A first claim has none, and reporting
         // zeroes for it would drown the signal we actually want out of this metric.
         if (fenceToken > 1) {
-            metrics.copyForward(jobUuid, fenceToken, copied.seeded(), copied.restarted());
+            log.info("copy-forward for job {} at token {}: {} partition(s) carried forward, {} restarted",
+                    jobUuid, fenceToken, copied.seeded(), copied.restarted());
+            metrics.copyForward(copied.seeded(), copied.restarted());
         }
         batchMeta.healIndeterminateExecutions(jobUuid);
         return new Ownership(fenceToken, false);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetrics.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetrics.java
@@ -1,0 +1,298 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import com.timgroup.statsd.StatsDClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Datadog metrics and structured logging for the pause/resume prototype.
+ *
+ * Every lifecycle event the prototype can go through emits a counter so the whole pause/resume story is
+ * visible without reading logs: how a job was claimed (fresh/soft/hard), whether a shutdown drained, whether
+ * a worker was fenced out, how close a job is to exhausting its failure attempts, and how many leases are
+ * sitting stale. Each emit also logs, so a metric spike always has a matching log line to dig into.
+ *
+ * The {@link StatsDClient} bean prefixes everything with {@code ab2d}, so the metrics land in Datadog as
+ * {@code ab2d.worker.prototype.*}. The client is looked up through an {@link ObjectProvider} so that tests
+ * and any context without a DogStatsD sidecar degrade to a no-op instead of failing to start.
+ */
+@Slf4j
+@Component
+public class PrototypeMetrics {
+
+    // Job lifecycle
+    static final String JOB_STARTED = "worker.prototype.job.started";
+    static final String JOB_RECOVERED = "worker.prototype.job.recovered";
+    static final String JOB_COMPLETED = "worker.prototype.job.completed";
+    static final String JOB_CANCELLED = "worker.prototype.job.cancelled";
+    static final String JOB_PATIENTS_PROCESSED = "worker.prototype.job.patients_processed";
+
+    // Pause / resume
+    static final String JOB_SUSPENDED = "worker.prototype.job.suspended";
+    static final String COPY_FORWARD_SEEDED = "worker.prototype.copy_forward.seeded";
+    static final String COPY_FORWARD_RESTARTED = "worker.prototype.copy_forward.restarted";
+
+    // Shutdown drain
+    static final String DRAIN_STARTED = "worker.prototype.shutdown.drain_started";
+    static final String DRAIN_FINISHED = "worker.prototype.shutdown.drain_finished";
+    static final String DRAIN_DURATION_MS = "worker.prototype.shutdown.drain_duration_ms";
+
+    // Ownership / fencing
+    static final String JOB_FENCED_OUT = "worker.prototype.job.fenced_out";
+    static final String CHUNK_FENCE_LOST = "worker.prototype.chunk.fence_lost";
+    static final String LEASE_RENEW_FAILED = "worker.prototype.lease.renew_failed";
+    static final String LEASE_ACTIVE = "worker.prototype.lease.active";
+    static final String LEASE_STALE = "worker.prototype.lease.stale";
+    static final String LEASE_UNRECOVERED = "worker.prototype.lease.unrecovered";
+
+    // Failures
+    static final String JOB_FAILED = "worker.prototype.job.failed";
+    static final String JOB_FAILURE_ATTEMPT = "worker.prototype.job.failure_attempt";
+    static final String JOB_ATTEMPTS_REMAINING = "worker.prototype.job.attempts_remaining";
+    static final String JOB_APPROACHING_MAX_FAILURES = "worker.prototype.job.approaching_max_failures";
+    static final String JOB_THRESHOLD_EXCEEDED = "worker.prototype.job.threshold_exceeded";
+    static final String BENE_SKIPPED = "worker.prototype.bene.skipped";
+
+    private final String executionEnv;
+    private final StatsDClient statsDClient;
+
+    public PrototypeMetrics(
+            @Value("${execution.env:local}") String executionEnv,
+            ObjectProvider<StatsDClient> statsDClientProvider) {
+        this.executionEnv = executionEnv;
+        this.statsDClient = statsDClientProvider.getIfAvailable();
+        if (this.statsDClient == null) {
+            log.info("No StatsDClient bean available; pause/resume prototype metrics are disabled (no-op)");
+        }
+    }
+
+    /**
+     * A worker has claimed a job and is about to run it. {@code mode} separates a fresh start from the two
+     * kinds of resume, which is the top-level signal for "is recovery happening, and which kind".
+     */
+    public void jobStarted(String jobUuid, String contract, ResumeMode mode, long fenceToken) {
+        log.info("prototype metrics: job {} started contract={} mode={} token={}",
+                jobUuid, contract, mode.tagValue(), fenceToken);
+        increment(JOB_STARTED, tags(contract, "mode:" + mode.tagValue()));
+        if (mode.isRecovery()) {
+            // A second, recovery-only counter so a Datadog monitor can watch resumes without filtering
+            // every job start. Soft and hard stay separate on the mode tag.
+            increment(JOB_RECOVERED, tags(contract, "mode:" + mode.tagValue()));
+        }
+    }
+
+    /** The batch execution completed, the output assembled, and the job was marked SUCCESSFUL. */
+    public void jobCompleted(String jobUuid, String contract, int patientsProcessed, int outputFiles) {
+        log.info("prototype metrics: job {} completed contract={} patients={} files={}",
+                jobUuid, contract, patientsProcessed, outputFiles);
+        increment(JOB_COMPLETED, tags(contract));
+        count(JOB_PATIENTS_PROCESSED, patientsProcessed, tags(contract));
+    }
+
+    /** The job was cancelled out from under the worker while it was running. */
+    public void jobCancelled(String jobUuid, String contract) {
+        log.warn("prototype metrics: job {} cancelled mid-run contract={}", jobUuid, contract);
+        increment(JOB_CANCELLED, tags(contract));
+    }
+
+    /**
+     * The batch execution stopped for a shutdown and the job went back to SUBMITTED.
+     *
+     * @param cleanSuspend whether the clean-suspend marker was recorded. False means the next pickup has to
+     *                     hard-recover instead of resuming in place, which is the expensive path.
+     */
+    public void jobSuspended(String jobUuid, String contract, long fenceToken, boolean cleanSuspend) {
+        if (cleanSuspend) {
+            log.info("prototype metrics: job {} suspended cleanly contract={} token={}",
+                    jobUuid, contract, fenceToken);
+        } else {
+            log.warn("prototype metrics: job {} suspended WITHOUT a clean-suspend marker contract={} token={} - "
+                    + "the next pickup will have to hard-recover", jobUuid, contract, fenceToken);
+        }
+        increment(JOB_SUSPENDED, tags(contract, "clean:" + cleanSuspend));
+    }
+
+    /**
+     * Result of the hard-recovery copy-forward pass: how many partitions kept their committed chunks and how
+     * many had to be thrown away and redone.
+     */
+    public void copyForward(String jobUuid, long fenceToken, int seeded, int restarted) {
+        log.info("prototype metrics: job {} copy-forward token={} seeded={} restarted={}",
+                jobUuid, fenceToken, seeded, restarted);
+        if (seeded > 0) {
+            count(COPY_FORWARD_SEEDED, seeded, tags(null));
+        }
+        if (restarted > 0) {
+            count(COPY_FORWARD_RESTARTED, restarted, tags(null));
+        }
+    }
+
+    /** A shutdown started signalling running batch executions to stop at their next chunk boundary. */
+    public void drainStarted(int runningExecutions) {
+        log.info("prototype metrics: shutdown drain started executions={}", runningExecutions);
+        increment(DRAIN_STARTED, tags(null));
+    }
+
+    /**
+     * The shutdown drain finished. {@code drained=false} means the wait timed out with executions still
+     * running, so the affected jobs will be hard-recovered rather than resumed in place.
+     */
+    public void drainFinished(boolean drained, long elapsedMs, int stillRunning) {
+        if (drained) {
+            log.info("prototype metrics: shutdown drain finished in {}ms", elapsedMs);
+        } else {
+            log.warn("prototype metrics: shutdown drain timed out after {}ms with {} execution(s) still running",
+                    elapsedMs, stillRunning);
+        }
+        increment(DRAIN_FINISHED, tags(null, "drained:" + drained));
+        time(DRAIN_DURATION_MS, elapsedMs, tags(null, "drained:" + drained));
+    }
+
+    /**
+     * This worker ran under a token that is no longer current, so a peer owns the job now. Expected when a
+     * worker stalls past the lease TTL; a steady stream of these means heartbeats are not keeping up.
+     */
+    public void fencedOut(String jobUuid, String contract, long ranUnderToken, String phase) {
+        log.warn("prototype metrics: job {} fenced out contract={} ranUnderToken={} phase={}",
+                jobUuid, contract, ranUnderToken, phase);
+        increment(JOB_FENCED_OUT, tags(contract, "phase:" + phase));
+    }
+
+    /** A chunk commit was rejected because this worker no longer holds the lease. */
+    public void chunkFenceLost(String jobUuid, long token) {
+        log.warn("prototype metrics: job {} lost the fence at token {} while committing a chunk", jobUuid, token);
+        increment(CHUNK_FENCE_LOST, tags(null));
+    }
+
+    /** The scheduled heartbeat renewal found the lease no longer held at this worker's token. */
+    public void leaseRenewFailed(String jobUuid, long token) {
+        log.warn("prototype metrics: job {} lease renewal failed at token {}", jobUuid, token);
+        increment(LEASE_RENEW_FAILED, tags(null));
+    }
+
+    /**
+     * Fleet-wide view of IN_PROGRESS jobs and their leases.
+     *
+     * @param active      leases whose heartbeat is inside the TTL
+     * @param stale       leases past the TTL and therefore eligible for takeover
+     * @param unrecovered leases past the longer grace window, which means a takeover should already have
+     *                    happened and did not - recovery is broken
+     */
+    public void leaseHeartbeats(long active, long stale, long unrecovered) {
+        gauge(LEASE_ACTIVE, active, tags(null));
+        gauge(LEASE_STALE, stale, tags(null));
+        gauge(LEASE_UNRECOVERED, unrecovered, tags(null));
+        if (unrecovered > 0) {
+            log.error("prototype metrics: {} IN_PROGRESS job(s) past the recovery grace window "
+                    + "(active={}, stale={}) - recovery is not picking them up", unrecovered, active, stale);
+        } else if (stale > 0) {
+            log.info("prototype metrics: {} IN_PROGRESS job(s) with a stale lease awaiting takeover (active={})",
+                    stale, active);
+        }
+    }
+
+    /**
+     * A job reached a terminal FAILED state. One of the three failure paths in the processor.
+     */
+    public void jobFailed(String jobUuid, String contract, FailureReason reason, String message) {
+        log.error("prototype metrics: job {} FAILED contract={} reason={} message={}",
+                jobUuid, contract, reason.tagValue(), message);
+        increment(JOB_FAILED, tags(contract, "reason:" + reason.tagValue()));
+    }
+
+    /**
+     * A recoverable failure sent the job back to SUBMITTED for another attempt. Emits which attempt this is
+     * and how many are left, so a job grinding toward its cap is visible before it dies.
+     */
+    public void jobFailureAttempt(String jobUuid, String contract, int attempt, int maxAttempts,
+                                  boolean approachingMax) {
+        int remaining = Math.max(0, maxAttempts - attempt);
+        if (approachingMax) {
+            log.warn("prototype metrics: job {} failed attempt {} of {} contract={} - only {} attempt(s) left "
+                    + "before it fails terminally", jobUuid, attempt, maxAttempts, contract, remaining);
+        } else {
+            log.info("prototype metrics: job {} failed attempt {} of {} contract={} - will resume",
+                    jobUuid, attempt, maxAttempts, contract);
+        }
+        gauge(JOB_FAILURE_ATTEMPT, attempt, tags(contract));
+        gauge(JOB_ATTEMPTS_REMAINING, remaining, tags(contract));
+        if (approachingMax) {
+            increment(JOB_APPROACHING_MAX_FAILURES, tags(contract));
+        }
+    }
+
+    /** Too many beneficiaries errored, so the job is failed terminally rather than delivering a partial file. */
+    public void thresholdExceeded(String jobUuid, String contract, int failures, int total) {
+        log.error("prototype metrics: job {} exceeded the failure threshold contract={} failed={} of {}",
+                jobUuid, contract, failures, total);
+        increment(JOB_THRESHOLD_EXCEEDED, tags(contract));
+    }
+
+    /** One beneficiary was skipped after failing persistently. Counted against the failure threshold. */
+    public void beneSkipped(String jobUuid, String phase, Throwable cause) {
+        log.warn("prototype metrics: job {} skipped a beneficiary phase={} cause={}",
+                jobUuid, phase, cause == null ? "unknown" : cause.getClass().getSimpleName());
+        increment(BENE_SKIPPED, tags(null, "phase:" + phase,
+                "cause:" + (cause == null ? "unknown" : cause.getClass().getSimpleName())));
+    }
+
+    private void increment(String aspect, String[] tags) {
+        if (statsDClient != null) {
+            statsDClient.increment(aspect, tags);
+        }
+    }
+
+    private void count(String aspect, long value, String[] tags) {
+        if (statsDClient != null) {
+            statsDClient.count(aspect, value, tags);
+        }
+    }
+
+    private void gauge(String aspect, long value, String[] tags) {
+        if (statsDClient != null) {
+            statsDClient.gauge(aspect, value, tags);
+        }
+    }
+
+    private void time(String aspect, long millis, String[] tags) {
+        if (statsDClient != null) {
+            statsDClient.recordExecutionTime(aspect, millis, tags);
+        }
+    }
+
+    /**
+     * Every metric carries the environment. Contract is added when the caller knows it; the extra tags are
+     * the per-event dimensions.
+     */
+    private String[] tags(String contract, String... extra) {
+        List<String> tags = new ArrayList<>(2 + extra.length);
+        tags.add("environment:" + executionEnv);
+        if (contract != null) {
+            tags.add("contract:" + contract);
+        }
+        tags.addAll(List.of(extra));
+        return tags.toArray(new String[0]);
+    }
+
+    /** Which of the processor's failure paths ended the job. */
+    public enum FailureReason {
+
+        /** Too many beneficiaries errored during the run. */
+        THRESHOLD_EXCEEDED,
+
+        /** The batch execution failed repeatedly and ran out of resume attempts. */
+        ATTEMPTS_EXHAUSTED,
+
+        /** The batch job could not be launched or threw outside the execution itself. */
+        LAUNCH_FAILED;
+
+        public String tagValue() {
+            return name().toLowerCase();
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetrics.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetrics.java
@@ -10,12 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Datadog metrics and structured logging for the pause/resume prototype.
- *
- * Every lifecycle event the prototype can go through emits a counter so the whole pause/resume story is
- * visible without reading logs: how a job was claimed (fresh/soft/hard), whether a shutdown drained, whether
- * a worker was fenced out, how close a job is to exhausting its failure attempts, and how many leases are
- * sitting stale. Each emit also logs, so a metric spike always has a matching log line to dig into.
+ * Datadog metrics for the pause/resume prototype.
  *
  * The {@link StatsDClient} bean prefixes everything with {@code ab2d}, so the metrics land in Datadog as
  * {@code ab2d.worker.prototype.*}. The client is looked up through an {@link ObjectProvider} so that tests
@@ -25,9 +20,8 @@ import java.util.List;
 @Component
 public class PrototypeMetrics {
 
-    // Job lifecycle
+    // Job lifecycle. The resume mode is a tag on the start, so fresh/soft/hard are all one metric.
     static final String JOB_STARTED = "worker.prototype.job.started";
-    static final String JOB_RECOVERED = "worker.prototype.job.recovered";
     static final String JOB_COMPLETED = "worker.prototype.job.completed";
     static final String JOB_CANCELLED = "worker.prototype.job.cancelled";
     static final String JOB_PATIENTS_PROCESSED = "worker.prototype.job.patients_processed";
@@ -50,12 +44,11 @@ public class PrototypeMetrics {
     static final String LEASE_STALE = "worker.prototype.lease.stale";
     static final String LEASE_UNRECOVERED = "worker.prototype.lease.unrecovered";
 
-    // Failures
+    // Failures. The reason tag distinguishes the three terminal paths, including the failure threshold.
     static final String JOB_FAILED = "worker.prototype.job.failed";
     static final String JOB_FAILURE_ATTEMPT = "worker.prototype.job.failure_attempt";
     static final String JOB_ATTEMPTS_REMAINING = "worker.prototype.job.attempts_remaining";
     static final String JOB_APPROACHING_MAX_FAILURES = "worker.prototype.job.approaching_max_failures";
-    static final String JOB_THRESHOLD_EXCEEDED = "worker.prototype.job.threshold_exceeded";
     static final String BENE_SKIPPED = "worker.prototype.bene.skipped";
 
     private final String executionEnv;
@@ -72,31 +65,21 @@ public class PrototypeMetrics {
     }
 
     /**
-     * A worker has claimed a job and is about to run it. {@code mode} separates a fresh start from the two
-     * kinds of resume, which is the top-level signal for "is recovery happening, and which kind".
+     * A worker has claimed a job and is about to run it. The {@code mode} tag separates a fresh start from
+     * the two kinds of resume, so recoveries are counted by filtering rather than by a second metric.
      */
-    public void jobStarted(String jobUuid, String contract, ResumeMode mode, long fenceToken) {
-        log.info("prototype metrics: job {} started contract={} mode={} token={}",
-                jobUuid, contract, mode.tagValue(), fenceToken);
+    public void jobStarted(String contract, ResumeMode mode) {
         increment(JOB_STARTED, tags(contract, "mode:" + mode.tagValue()));
-        if (mode.isRecovery()) {
-            // A second, recovery-only counter so a Datadog monitor can watch resumes without filtering
-            // every job start. Soft and hard stay separate on the mode tag.
-            increment(JOB_RECOVERED, tags(contract, "mode:" + mode.tagValue()));
-        }
     }
 
     /** The batch execution completed, the output assembled, and the job was marked SUCCESSFUL. */
-    public void jobCompleted(String jobUuid, String contract, int patientsProcessed, int outputFiles) {
-        log.info("prototype metrics: job {} completed contract={} patients={} files={}",
-                jobUuid, contract, patientsProcessed, outputFiles);
+    public void jobCompleted(String contract, int patientsProcessed) {
         increment(JOB_COMPLETED, tags(contract));
         count(JOB_PATIENTS_PROCESSED, patientsProcessed, tags(contract));
     }
 
     /** The job was cancelled out from under the worker while it was running. */
-    public void jobCancelled(String jobUuid, String contract) {
-        log.warn("prototype metrics: job {} cancelled mid-run contract={}", jobUuid, contract);
+    public void jobCancelled(String contract) {
         increment(JOB_CANCELLED, tags(contract));
     }
 
@@ -106,14 +89,7 @@ public class PrototypeMetrics {
      * @param cleanSuspend whether the clean-suspend marker was recorded. False means the next pickup has to
      *                     hard-recover instead of resuming in place, which is the expensive path.
      */
-    public void jobSuspended(String jobUuid, String contract, long fenceToken, boolean cleanSuspend) {
-        if (cleanSuspend) {
-            log.info("prototype metrics: job {} suspended cleanly contract={} token={}",
-                    jobUuid, contract, fenceToken);
-        } else {
-            log.warn("prototype metrics: job {} suspended WITHOUT a clean-suspend marker contract={} token={} - "
-                    + "the next pickup will have to hard-recover", jobUuid, contract, fenceToken);
-        }
+    public void jobSuspended(String contract, boolean cleanSuspend) {
         increment(JOB_SUSPENDED, tags(contract, "clean:" + cleanSuspend));
     }
 
@@ -121,9 +97,7 @@ public class PrototypeMetrics {
      * Result of the hard-recovery copy-forward pass: how many partitions kept their committed chunks and how
      * many had to be thrown away and redone.
      */
-    public void copyForward(String jobUuid, long fenceToken, int seeded, int restarted) {
-        log.info("prototype metrics: job {} copy-forward token={} seeded={} restarted={}",
-                jobUuid, fenceToken, seeded, restarted);
+    public void copyForward(int seeded, int restarted) {
         if (seeded > 0) {
             count(COPY_FORWARD_SEEDED, seeded, tags(null));
         }
@@ -133,8 +107,7 @@ public class PrototypeMetrics {
     }
 
     /** A shutdown started signalling running batch executions to stop at their next chunk boundary. */
-    public void drainStarted(int runningExecutions) {
-        log.info("prototype metrics: shutdown drain started executions={}", runningExecutions);
+    public void drainStarted() {
         increment(DRAIN_STARTED, tags(null));
     }
 
@@ -142,13 +115,7 @@ public class PrototypeMetrics {
      * The shutdown drain finished. {@code drained=false} means the wait timed out with executions still
      * running, so the affected jobs will be hard-recovered rather than resumed in place.
      */
-    public void drainFinished(boolean drained, long elapsedMs, int stillRunning) {
-        if (drained) {
-            log.info("prototype metrics: shutdown drain finished in {}ms", elapsedMs);
-        } else {
-            log.warn("prototype metrics: shutdown drain timed out after {}ms with {} execution(s) still running",
-                    elapsedMs, stillRunning);
-        }
+    public void drainFinished(boolean drained, long elapsedMs) {
         increment(DRAIN_FINISHED, tags(null, "drained:" + drained));
         time(DRAIN_DURATION_MS, elapsedMs, tags(null, "drained:" + drained));
     }
@@ -157,51 +124,39 @@ public class PrototypeMetrics {
      * This worker ran under a token that is no longer current, so a peer owns the job now. Expected when a
      * worker stalls past the lease TTL; a steady stream of these means heartbeats are not keeping up.
      */
-    public void fencedOut(String jobUuid, String contract, long ranUnderToken, String phase) {
-        log.warn("prototype metrics: job {} fenced out contract={} ranUnderToken={} phase={}",
-                jobUuid, contract, ranUnderToken, phase);
+    public void fencedOut(String contract, String phase) {
         increment(JOB_FENCED_OUT, tags(contract, "phase:" + phase));
     }
 
     /** A chunk commit was rejected because this worker no longer holds the lease. */
-    public void chunkFenceLost(String jobUuid, long token) {
-        log.warn("prototype metrics: job {} lost the fence at token {} while committing a chunk", jobUuid, token);
+    public void chunkFenceLost() {
         increment(CHUNK_FENCE_LOST, tags(null));
     }
 
     /** The scheduled heartbeat renewal found the lease no longer held at this worker's token. */
-    public void leaseRenewFailed(String jobUuid, long token) {
-        log.warn("prototype metrics: job {} lease renewal failed at token {}", jobUuid, token);
+    public void leaseRenewFailed() {
         increment(LEASE_RENEW_FAILED, tags(null));
     }
 
     /**
-     * Fleet-wide view of IN_PROGRESS jobs and their leases.
+     * Fleet-wide view of IN_PROGRESS jobs and their leases. The three buckets are mutually exclusive.
      *
      * @param active      leases whose heartbeat is inside the TTL
-     * @param stale       leases past the TTL and therefore eligible for takeover
-     * @param unrecovered leases past the longer grace window, which means a takeover should already have
-     *                    happened and did not - recovery is broken
+     * @param stale       leases past the TTL but still inside the grace window, so a takeover is expected
+     * @param unrecovered leases past the grace window, which means a takeover should already have happened
+     *                    and did not - recovery is broken
      */
     public void leaseHeartbeats(long active, long stale, long unrecovered) {
         gauge(LEASE_ACTIVE, active, tags(null));
         gauge(LEASE_STALE, stale, tags(null));
         gauge(LEASE_UNRECOVERED, unrecovered, tags(null));
-        if (unrecovered > 0) {
-            log.error("prototype metrics: {} IN_PROGRESS job(s) past the recovery grace window "
-                    + "(active={}, stale={}) - recovery is not picking them up", unrecovered, active, stale);
-        } else if (stale > 0) {
-            log.info("prototype metrics: {} IN_PROGRESS job(s) with a stale lease awaiting takeover (active={})",
-                    stale, active);
-        }
     }
 
     /**
-     * A job reached a terminal FAILED state. One of the three failure paths in the processor.
+     * A job reached a terminal FAILED state. The reason tag covers all three failure paths, including the
+     * failure threshold, so no separate threshold metric is needed.
      */
-    public void jobFailed(String jobUuid, String contract, FailureReason reason, String message) {
-        log.error("prototype metrics: job {} FAILED contract={} reason={} message={}",
-                jobUuid, contract, reason.tagValue(), message);
+    public void jobFailed(String contract, FailureReason reason) {
         increment(JOB_FAILED, tags(contract, "reason:" + reason.tagValue()));
     }
 
@@ -209,34 +164,16 @@ public class PrototypeMetrics {
      * A recoverable failure sent the job back to SUBMITTED for another attempt. Emits which attempt this is
      * and how many are left, so a job grinding toward its cap is visible before it dies.
      */
-    public void jobFailureAttempt(String jobUuid, String contract, int attempt, int maxAttempts,
-                                  boolean approachingMax) {
-        int remaining = Math.max(0, maxAttempts - attempt);
-        if (approachingMax) {
-            log.warn("prototype metrics: job {} failed attempt {} of {} contract={} - only {} attempt(s) left "
-                    + "before it fails terminally", jobUuid, attempt, maxAttempts, contract, remaining);
-        } else {
-            log.info("prototype metrics: job {} failed attempt {} of {} contract={} - will resume",
-                    jobUuid, attempt, maxAttempts, contract);
-        }
+    public void jobFailureAttempt(String contract, int attempt, int maxAttempts, boolean approachingMax) {
         gauge(JOB_FAILURE_ATTEMPT, attempt, tags(contract));
-        gauge(JOB_ATTEMPTS_REMAINING, remaining, tags(contract));
+        gauge(JOB_ATTEMPTS_REMAINING, Math.max(0, maxAttempts - attempt), tags(contract));
         if (approachingMax) {
             increment(JOB_APPROACHING_MAX_FAILURES, tags(contract));
         }
     }
 
-    /** Too many beneficiaries errored, so the job is failed terminally rather than delivering a partial file. */
-    public void thresholdExceeded(String jobUuid, String contract, int failures, int total) {
-        log.error("prototype metrics: job {} exceeded the failure threshold contract={} failed={} of {}",
-                jobUuid, contract, failures, total);
-        increment(JOB_THRESHOLD_EXCEEDED, tags(contract));
-    }
-
     /** One beneficiary was skipped after failing persistently. Counted against the failure threshold. */
-    public void beneSkipped(String jobUuid, String phase, Throwable cause) {
-        log.warn("prototype metrics: job {} skipped a beneficiary phase={} cause={}",
-                jobUuid, phase, cause == null ? "unknown" : cause.getClass().getSimpleName());
+    public void beneSkipped(String phase, Throwable cause) {
         increment(BENE_SKIPPED, tags(null, "phase:" + phase,
                 "cause:" + (cause == null ? "unknown" : cause.getClass().getSimpleName())));
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -54,4 +54,11 @@ public class PrototypeProperties {
      * later is stranded.
      */
     private int leaseGraceMultiplier = 3;
+
+    /**
+     * How long a stranded job stays quiet after it has been reported. A stranded job stays stranded, so
+     * without a cooldown every worker would report it on every poll; the claim is stamped in the database so
+     * this rate limit holds across the whole fleet, not just per worker.
+     */
+    private int leaseAlertCooldownMinutes = 60;
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -41,4 +41,17 @@ public class PrototypeProperties {
      * Whether hard recovery restarts partitions from scratch or from the last good chunk
      */
     private boolean copyForwardEnabled = true;
+
+    /**
+     * How many attempts can be left before a failing job is reported as approaching its cap. Failing a job
+     * is expected and recoverable, but grinding toward the terminal failure is worth knowing about early.
+     */
+    private int failureAttemptsWarnRemaining = 2;
+
+    /**
+     * Multiple of the lease TTL after which an unrecovered IN_PROGRESS job means recovery is not working.
+     * A job past the TTL is normally taken over on the next poll, so anything still there several TTLs
+     * later is stranded.
+     */
+    private int leaseGraceMultiplier = 3;
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
@@ -42,7 +42,7 @@ public class PrototypeSkipCounter implements SkipListener<CoverageSummary, Seria
 
     private void recordSkip(String phase, Throwable t) {
         log.warn("job {}: skipping a beneficiary after a persistent failure in {}: {}", jobUuid, phase, t.toString());
-        metrics.beneSkipped(jobUuid, phase, t);
+        metrics.beneSkipped(phase, t);
         channel.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_ERRORED, 1);
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeSkipCounter.java
@@ -15,30 +15,34 @@ import org.springframework.batch.core.listener.SkipListener;
 public class PrototypeSkipCounter implements SkipListener<CoverageSummary, SerializedEobs> {
 
     private final JobChannelService channel;
+    private final PrototypeMetrics metrics;
     private final String jobUuid;
 
-    public PrototypeSkipCounter(JobChannelService channel, String jobUuid) {
+    public PrototypeSkipCounter(JobChannelService channel, PrototypeMetrics metrics, String jobUuid) {
         this.channel = channel;
+        this.metrics = metrics;
         this.jobUuid = jobUuid;
     }
 
     @Override
     public void onSkipInProcess(@NonNull CoverageSummary item, @NonNull Throwable t) {
-        recordSkip(t);
+        recordSkip("process", t);
     }
 
     @Override
     public void onSkipInRead(@NonNull Throwable t) {
-        recordSkip(t);
+        recordSkip("read", t);
     }
 
     @Override
     public void onSkipInWrite(@NonNull SerializedEobs item, @NonNull Throwable t) {
-        recordSkip(t);
+        recordSkip("write", t);
     }
 
-    private void recordSkip(Throwable t) {
-        log.warn("job {}: skipping a beneficiary after a persistent failure: {}", jobUuid, t.toString());
+
+    private void recordSkip(String phase, Throwable t) {
+        log.warn("job {}: skipping a beneficiary after a persistent failure in {}: {}", jobUuid, phase, t.toString());
+        metrics.beneSkipped(jobUuid, phase, t);
         channel.sendUpdate(jobUuid, JobMeasure.PATIENT_REQUESTS_ERRORED, 1);
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ResumeMode.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ResumeMode.java
@@ -1,0 +1,27 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+/**
+ * How a worker came to own a job. Recorded as a tag on the pause/resume metrics so that a fresh start,
+ * a clean pause that was picked back up, and a crash that had to be healed are all countable separately.
+ */
+public enum ResumeMode {
+
+    /** Nobody has ever held this job, so there is no prior work to resume. */
+    FRESH,
+
+    /** The prior owner suspended cleanly, so the same fence token and output files are adopted as-is. */
+    SOFT,
+
+    /** The prior owner died or was superseded, so the token was bumped and the batch state healed. */
+    HARD;
+
+    /** Lowercase name, used as the metric tag value. */
+    public String tagValue() {
+        return name().toLowerCase();
+    }
+
+    /** True for the two modes that pick up work a previous worker left behind. */
+    public boolean isRecovery() {
+        return this != FRESH;
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ResumeMode.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/ResumeMode.java
@@ -19,9 +19,4 @@ public enum ResumeMode {
     public String tagValue() {
         return name().toLowerCase();
     }
-
-    /** True for the two modes that pick up work a previous worker left behind. */
-    public boolean isRecovery() {
-        return this != FRESH;
-    }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/JobLeaseRepository.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/JobLeaseRepository.java
@@ -7,6 +7,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -76,6 +77,30 @@ public class JobLeaseRepository {
                    (heartbeat_at < now() - make_interval(secs => :ttlSeconds)) AS stale
               FROM ab2d.job_lease
              WHERE job_uuid = :jobUuid
+            """;
+
+    // Fleet-wide heartbeat health across every IN_PROGRESS job. Stale means past the TTL and therefore
+    // eligible for takeover, which is normal and self-healing. Unrecovered means past the longer grace
+    // window, so a takeover should already have happened and did not.
+    private static final String HEARTBEAT_HEALTH_SQL = """
+            SELECT
+                count(*) FILTER (WHERE l.heartbeat_at >= now() - make_interval(secs => :ttlSeconds)) AS active,
+                count(*) FILTER (WHERE l.heartbeat_at < now() - make_interval(secs => :ttlSeconds)) AS stale,
+                count(*) FILTER (WHERE l.heartbeat_at < now() - make_interval(secs => :graceSeconds))
+                    AS unrecovered
+              FROM ab2d.job_lease l
+              JOIN job j ON j.job_uuid = l.job_uuid
+             WHERE j.status = 'IN_PROGRESS'
+            """;
+
+    // The jobs behind an unrecovered count, so the alert can name them instead of just counting them.
+    private static final String UNRECOVERED_JOBS_SQL = """
+            SELECT l.job_uuid
+              FROM ab2d.job_lease l
+              JOIN job j ON j.job_uuid = l.job_uuid
+             WHERE j.status = 'IN_PROGRESS'
+               AND l.heartbeat_at < now() - make_interval(secs => :graceSeconds)
+             ORDER BY l.heartbeat_at
             """;
 
     private final NamedParameterJdbcTemplate jdbc;
@@ -175,7 +200,34 @@ public class JobLeaseRepository {
         }
     }
 
+    /**
+     * Count the IN_PROGRESS jobs whose lease heartbeat is healthy, stale, or so old that recovery should
+     * already have taken over.
+     *
+     * @param ttlSeconds   heartbeat age past which a job is eligible for takeover
+     * @param graceSeconds heartbeat age past which a takeover should already have happened
+     */
+    public HeartbeatHealth heartbeatHealth(int ttlSeconds, int graceSeconds) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("ttlSeconds", ttlSeconds)
+                .addValue("graceSeconds", graceSeconds);
+        HeartbeatHealth health = jdbc.queryForObject(HEARTBEAT_HEALTH_SQL, params,
+                (rs, rowNum) -> new HeartbeatHealth(rs.getLong("active"), rs.getLong("stale"),
+                        rs.getLong("unrecovered")));
+        return health == null ? new HeartbeatHealth(0, 0, 0) : health;
+    }
+
+    /** The job uuids whose heartbeat is older than the grace window. */
+    public List<String> unrecoveredJobUuids(int graceSeconds) {
+        return jdbc.queryForList(UNRECOVERED_JOBS_SQL,
+                new MapSqlParameterSource("graceSeconds", graceSeconds), String.class);
+    }
+
     /** Current lease state for a job. */
     public record Lease(String owner, long token, Long cleanSuspendToken, boolean heartbeatStale) {
+    }
+
+    /** How many IN_PROGRESS jobs have a healthy, stale, or long-past-stale lease heartbeat. */
+    public record HeartbeatHealth(long active, long stale, long unrecovered) {
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/JobLeaseRepository.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/JobLeaseRepository.java
@@ -79,13 +79,16 @@ public class JobLeaseRepository {
              WHERE job_uuid = :jobUuid
             """;
 
-    // Fleet-wide heartbeat health across every IN_PROGRESS job. Stale means past the TTL and therefore
-    // eligible for takeover, which is normal and self-healing. Unrecovered means past the longer grace
-    // window, so a takeover should already have happened and did not.
+    // Fleet-wide heartbeat health across every IN_PROGRESS job. The three buckets are mutually exclusive so
+    // the gauges sum to the total and nothing is double counted: active is inside the TTL, stale is past the
+    // TTL but still inside the grace window (a takeover is expected and normal), and unrecovered is past the
+    // grace window, meaning a takeover should already have happened and did not.
     private static final String HEARTBEAT_HEALTH_SQL = """
             SELECT
                 count(*) FILTER (WHERE l.heartbeat_at >= now() - make_interval(secs => :ttlSeconds)) AS active,
-                count(*) FILTER (WHERE l.heartbeat_at < now() - make_interval(secs => :ttlSeconds)) AS stale,
+                count(*) FILTER (WHERE l.heartbeat_at < now() - make_interval(secs => :ttlSeconds)
+                                   AND l.heartbeat_at >= now() - make_interval(secs => :graceSeconds))
+                    AS stale,
                 count(*) FILTER (WHERE l.heartbeat_at < now() - make_interval(secs => :graceSeconds))
                     AS unrecovered
               FROM ab2d.job_lease l
@@ -93,14 +96,20 @@ public class JobLeaseRepository {
              WHERE j.status = 'IN_PROGRESS'
             """;
 
-    // The jobs behind an unrecovered count, so the alert can name them instead of just counting them.
-    private static final String UNRECOVERED_JOBS_SQL = """
-            SELECT l.job_uuid
-              FROM ab2d.job_lease l
-              JOIN job j ON j.job_uuid = l.job_uuid
-             WHERE j.status = 'IN_PROGRESS'
+    // Claim the right to alert about stranded jobs, atomically. Stamping alerted_at in the same statement
+    // that selects the rows means only one worker wins a given job, and it cannot win again until the
+    // cooldown lapses - so N workers polling every minute produce one alert per job per cooldown, not N per
+    // minute. Only the claimed uuids are returned, so the caller alerts on exactly what it won.
+    private static final String CLAIM_UNRECOVERED_FOR_ALERT_SQL = """
+            UPDATE ab2d.job_lease l
+               SET alerted_at = now()
+              FROM job j
+             WHERE j.job_uuid = l.job_uuid
+               AND j.status = 'IN_PROGRESS'
                AND l.heartbeat_at < now() - make_interval(secs => :graceSeconds)
-             ORDER BY l.heartbeat_at
+               AND (l.alerted_at IS NULL
+                    OR l.alerted_at < now() - make_interval(secs => :cooldownSeconds))
+            RETURNING l.job_uuid
             """;
 
     private final NamedParameterJdbcTemplate jdbc;
@@ -202,7 +211,7 @@ public class JobLeaseRepository {
 
     /**
      * Count the IN_PROGRESS jobs whose lease heartbeat is healthy, stale, or so old that recovery should
-     * already have taken over.
+     * already have taken over. The three counts are mutually exclusive.
      *
      * @param ttlSeconds   heartbeat age past which a job is eligible for takeover
      * @param graceSeconds heartbeat age past which a takeover should already have happened
@@ -217,17 +226,28 @@ public class JobLeaseRepository {
         return health == null ? new HeartbeatHealth(0, 0, 0) : health;
     }
 
-    /** The job uuids whose heartbeat is older than the grace window. */
-    public List<String> unrecoveredJobUuids(int graceSeconds) {
-        return jdbc.queryForList(UNRECOVERED_JOBS_SQL,
-                new MapSqlParameterSource("graceSeconds", graceSeconds), String.class);
+    /**
+     * Claim the stranded jobs this worker should alert about, and stamp them so no worker alerts about them
+     * again until the cooldown lapses.
+     *
+     * @return only the job uuids this call won; empty when another worker already alerted, or when every
+     *         stranded job is still inside its cooldown
+     */
+    public List<String> claimUnrecoveredForAlert(int graceSeconds, int cooldownSeconds) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("graceSeconds", graceSeconds)
+                .addValue("cooldownSeconds", cooldownSeconds);
+        return jdbc.queryForList(CLAIM_UNRECOVERED_FOR_ALERT_SQL, params, String.class);
     }
 
     /** Current lease state for a job. */
     public record Lease(String owner, long token, Long cleanSuspendToken, boolean heartbeatStale) {
     }
 
-    /** How many IN_PROGRESS jobs have a healthy, stale, or long-past-stale lease heartbeat. */
+    /**
+     * How many IN_PROGRESS jobs have a healthy, stale, or long-past-stale lease heartbeat. Mutually
+     * exclusive, so the three add up to the number of IN_PROGRESS jobs holding a lease.
+     */
     public record HeartbeatHealth(long active, long stale, long unrecovered) {
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeFenceGuard.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeFenceGuard.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.processor.prototype.lease;
 
+import gov.cms.ab2d.worker.processor.prototype.PrototypeMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.batch.core.listener.ItemWriteListener;
@@ -13,17 +14,26 @@ import org.springframework.batch.infrastructure.item.Chunk;
 public class PrototypeFenceGuard implements ItemWriteListener<Object> {
 
     private final JobLeaseRepository jobLease;
+    private final PrototypeMetrics metrics;
     private final String jobUuid;
     private final long token;
 
-    public PrototypeFenceGuard(JobLeaseRepository jobLease, String jobUuid, long token) {
+    public PrototypeFenceGuard(JobLeaseRepository jobLease, PrototypeMetrics metrics, String jobUuid, long token) {
         this.jobLease = jobLease;
+        this.metrics = metrics;
         this.jobUuid = jobUuid;
         this.token = token;
     }
 
     @Override
     public void afterWrite(@NonNull Chunk<?> items) {
-        jobLease.assertHoldsAndBeat(jobUuid, token);
+        try {
+            jobLease.assertHoldsAndBeat(jobUuid, token);
+        } catch (FenceLostException e) {
+            // Record before rethrowing: the exception rolls the chunk back and unwinds the step, so this is
+            // the only place that knows a commit was refused because ownership moved.
+            metrics.chunkFenceLost(jobUuid, token);
+            throw e;
+        }
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeFenceGuard.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeFenceGuard.java
@@ -32,7 +32,8 @@ public class PrototypeFenceGuard implements ItemWriteListener<Object> {
         } catch (FenceLostException e) {
             // Record before rethrowing: the exception rolls the chunk back and unwinds the step, so this is
             // the only place that knows a commit was refused because ownership moved.
-            metrics.chunkFenceLost(jobUuid, token);
+            log.warn("job {} lost the fence at token {} while committing a chunk", jobUuid, token);
+            metrics.chunkFenceLost();
             throw e;
         }
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeJobLeaseRenewer.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeJobLeaseRenewer.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.worker.processor.prototype.lease;
 
+import gov.cms.ab2d.worker.processor.prototype.PrototypeMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -22,11 +23,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PrototypeJobLeaseRenewer {
 
     private final JobLeaseRepository jobLease;
+    private final PrototypeMetrics metrics;
     // map of jobId to the token this worker holds for it
     private final Map<String, Long> activeTokens = new ConcurrentHashMap<>();
 
-    public PrototypeJobLeaseRenewer(JobLeaseRepository jobLease) {
+    public PrototypeJobLeaseRenewer(JobLeaseRepository jobLease, PrototypeMetrics metrics) {
         this.jobLease = jobLease;
+        this.metrics = metrics;
     }
 
     public void track(String jobUuid, long token) {
@@ -48,6 +51,7 @@ public class PrototypeJobLeaseRenewer {
                 } else {
                     // we lost the lease, remove it from our active jobs
                     log.warn("lease for {} no longer held at token {}", jobUuid, token);
+                    metrics.leaseRenewFailed(jobUuid, token);
                     activeTokens.remove(jobUuid, token);
                 }
             } catch (Exception e) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeJobLeaseRenewer.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeJobLeaseRenewer.java
@@ -51,7 +51,7 @@ public class PrototypeJobLeaseRenewer {
                 } else {
                     // we lost the lease, remove it from our active jobs
                     log.warn("lease for {} no longer held at token {}", jobUuid, token);
-                    metrics.leaseRenewFailed(jobUuid, token);
+                    metrics.leaseRenewFailed();
                     activeTokens.remove(jobUuid, token);
                 }
             } catch (Exception e) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitor.java
@@ -24,6 +24,11 @@ import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
  *
  * Runs on every worker. The gauges are per-instance snapshots of the same shared table, so read them in
  * Datadog with max/avg by host rather than as a sum.
+ *
+ * Alerting is deliberately not per-poll. A stranded job stays stranded, so N workers polling every minute
+ * would otherwise emit N alerts a minute for hours. Instead each alert is claimed atomically in the database
+ * and stamped with a cooldown, which both dedupes across workers and rate-limits over time: one message per
+ * stranded job per cooldown, no matter how many workers are running.
  */
 @Slf4j
 @Component
@@ -60,7 +65,7 @@ public class PrototypeLeaseMonitor {
             metrics.leaseHeartbeats(health.active(), health.stale(), health.unrecovered());
 
             if (health.unrecovered() > 0) {
-                alertUnrecovered(health.unrecovered(), graceSeconds);
+                alertUnrecovered(graceSeconds);
             }
         } catch (Exception e) {
             // Monitoring must never take the worker down with it.
@@ -71,15 +76,27 @@ public class PrototypeLeaseMonitor {
     /**
      * Name the stranded jobs so an on-call engineer can go straight to them. Sent as a trace rather than a
      * full alert: it is an AB2D-team operational signal, not a customer-visible job outcome.
+     *
+     * Only the jobs this worker wins the claim for are reported. Losing the claim is the normal case when
+     * several workers poll at once, and means another worker has already said it.
      */
-    private void alertUnrecovered(long unrecovered, int graceSeconds) {
-        List<String> uuids = jobLease.unrecoveredJobUuids(graceSeconds);
+    private void alertUnrecovered(int graceSeconds) {
+        List<String> uuids = jobLease.claimUnrecoveredForAlert(graceSeconds, cooldownSeconds());
+        if (uuids.isEmpty()) {
+            log.debug("stranded jobs present but already alerted within the cooldown; staying quiet");
+            return;
+        }
         String message = String.format(
                 "AB2D pause/resume: %d IN_PROGRESS job(s) have had a dead lease for more than %ds "
                         + "(lease TTL %ds) and have not been recovered by any worker: %s",
-                unrecovered, graceSeconds, leaseTtlSeconds, uuids);
+                uuids.size(), graceSeconds, leaseTtlSeconds, uuids);
         log.error(message);
         eventLogger.trace(message, PUBLIC_LIST);
+    }
+
+    /** How long a stranded job stays quiet after being reported, so an incident does not flood Slack. */
+    private int cooldownSeconds() {
+        return props.getLeaseAlertCooldownMinutes() * 60;
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitor.java
@@ -1,0 +1,92 @@
+package gov.cms.ab2d.worker.processor.prototype.lease;
+
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
+import gov.cms.ab2d.worker.processor.prototype.PrototypeMetrics;
+import gov.cms.ab2d.worker.processor.prototype.PrototypeProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static gov.cms.ab2d.common.util.PropertyConstants.PAUSE_RESUME_PROTOTYPE_ENABLED;
+import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
+
+/**
+ * Watches the lease table so that recovery itself is observable rather than assumed.
+ *
+ * An IN_PROGRESS job whose heartbeat is older than the TTL is normal for a short window: the owner died and
+ * the next poll will take the job over. If the same job is still sitting there well past the TTL, nothing
+ * picked it up and the job is stranded - no worker is advancing it and no worker will fail it either. That
+ * is the failure mode this monitor exists to catch, so it gauges both counts and alerts on the second.
+ *
+ * Runs on every worker. The gauges are per-instance snapshots of the same shared table, so read them in
+ * Datadog with max/avg by host rather than as a sum.
+ */
+@Slf4j
+@Component
+public class PrototypeLeaseMonitor {
+
+    private final JobLeaseRepository jobLease;
+    private final PrototypeMetrics metrics;
+    private final PropertiesService propertiesService;
+    private final SQSEventClient eventLogger;
+    private final PrototypeProperties props;
+    private final int leaseTtlSeconds;
+
+    public PrototypeLeaseMonitor(JobLeaseRepository jobLease, PrototypeMetrics metrics,
+                                 PropertiesService propertiesService, SQSEventClient eventLogger,
+                                 PrototypeProperties props,
+                                 @Value("${job.lock.ttl}") int leaseTtlSeconds) {
+        this.jobLease = jobLease;
+        this.metrics = metrics;
+        this.propertiesService = propertiesService;
+        this.eventLogger = eventLogger;
+        this.props = props;
+        this.leaseTtlSeconds = leaseTtlSeconds;
+    }
+
+    @Scheduled(fixedDelayString = "${pause-resume.prototype.lease-monitor-ms:60000}")
+    public void reportLeaseHealth() {
+        if (!propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false)) {
+            return;
+        }
+
+        int graceSeconds = graceSeconds();
+        try {
+            JobLeaseRepository.HeartbeatHealth health = jobLease.heartbeatHealth(leaseTtlSeconds, graceSeconds);
+            metrics.leaseHeartbeats(health.active(), health.stale(), health.unrecovered());
+
+            if (health.unrecovered() > 0) {
+                alertUnrecovered(health.unrecovered(), graceSeconds);
+            }
+        } catch (Exception e) {
+            // Monitoring must never take the worker down with it.
+            log.error("prototype lease monitor failed to read heartbeat health", e);
+        }
+    }
+
+    /**
+     * Name the stranded jobs so an on-call engineer can go straight to them. Sent as a trace rather than a
+     * full alert: it is an AB2D-team operational signal, not a customer-visible job outcome.
+     */
+    private void alertUnrecovered(long unrecovered, int graceSeconds) {
+        List<String> uuids = jobLease.unrecoveredJobUuids(graceSeconds);
+        String message = String.format(
+                "AB2D pause/resume: %d IN_PROGRESS job(s) have had a dead lease for more than %ds "
+                        + "(lease TTL %ds) and have not been recovered by any worker: %s",
+                unrecovered, graceSeconds, leaseTtlSeconds, uuids);
+        log.error(message);
+        eventLogger.trace(message, PUBLIC_LIST);
+    }
+
+    /**
+     * How long past the TTL a dead lease has to sit before we call recovery broken. A multiple of the TTL so
+     * the two stay in step if the TTL is retuned.
+     */
+    private int graceSeconds() {
+        return Math.max(leaseTtlSeconds, leaseTtlSeconds * props.getLeaseGraceMultiplier());
+    }
+}

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -45,6 +45,8 @@ pause-resume.prototype.lease-renew-ms=20000
 pause-resume.prototype.lease-monitor-ms=60000
 # multiple of job.lock.ttl after which an unrecovered IN_PROGRESS job means recovery is not working
 pause-resume.prototype.lease-grace-multiplier=3
+# how long a stranded job stays quiet after being reported, so an incident does not flood Slack
+pause-resume.prototype.lease-alert-cooldown-minutes=60
 # how many resume attempts can be left before a repeatedly failing job is reported as approaching its cap
 pause-resume.prototype.failure-attempts-warn-remaining=2
 spring.liquibase.contexts=none

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -41,6 +41,12 @@ pause-resume.prototype.copy-forward-enabled=true
 job.lock.ttl=40
 # how often a worker renews its job_lease heartbeat, in milliseconds (must be well under job.lock.ttl)
 pause-resume.prototype.lease-renew-ms=20000
+# how often the lease monitor gauges heartbeat health for IN_PROGRESS jobs, in milliseconds
+pause-resume.prototype.lease-monitor-ms=60000
+# multiple of job.lock.ttl after which an unrecovered IN_PROGRESS job means recovery is not working
+pause-resume.prototype.lease-grace-multiplier=3
+# how many resume attempts can be left before a repeatedly failing job is reported as approaching its cap
+pause-resume.prototype.failure-attempts-warn-remaining=2
 spring.liquibase.contexts=none
 spring.liquibase.liquibase-schema=public
 spring.liquibase.default-schema=ab2d

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetricsTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetricsTest.java
@@ -1,0 +1,223 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import com.timgroup.statsd.StatsDClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.Invocation;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the pause/resume metric emitter. These assert the metric names and tag values that Datadog
+ * monitors and dashboards key off, so a rename here is caught rather than silently breaking an alert.
+ */
+class PrototypeMetricsTest {
+
+    private static final String ENV = "ab2d-dev";
+    private static final String CONTRACT = "Z0001";
+    private static final String JOB = "job-uuid";
+
+    private StatsDClient statsDClient;
+    private PrototypeMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        statsDClient = mock(StatsDClient.class);
+        metrics = new PrototypeMetrics(ENV, providerOf(statsDClient));
+    }
+
+    @Test
+    @DisplayName("A fresh start counts as a start but not as a recovery")
+    void freshStartIsNotARecovery() {
+        metrics.jobStarted(JOB, CONTRACT, ResumeMode.FRESH, 1L);
+
+        List<String[]> started = incrementTags(PrototypeMetrics.JOB_STARTED);
+        assertEquals(1, started.size(), "a start should be counted once");
+        assertTrue(Arrays.asList(started.get(0)).contains("mode:fresh"));
+        assertTrue(Arrays.asList(started.get(0)).contains("environment:" + ENV));
+        assertTrue(Arrays.asList(started.get(0)).contains("contract:" + CONTRACT));
+        assertTrue(incrementTags(PrototypeMetrics.JOB_RECOVERED).isEmpty(),
+                "a first claim has no prior work, so it is not a recovery");
+    }
+
+    @Test
+    @DisplayName("Soft and hard resumes are both recoveries but stay distinguishable by tag")
+    void softAndHardRecoveriesAreTaggedSeparately() {
+        metrics.jobStarted(JOB, CONTRACT, ResumeMode.SOFT, 4L);
+        metrics.jobStarted("other-job", CONTRACT, ResumeMode.HARD, 9L);
+
+        List<String[]> recovered = incrementTags(PrototypeMetrics.JOB_RECOVERED);
+        assertEquals(2, recovered.size(), "both resumes should count as recoveries");
+        assertTrue(Arrays.asList(recovered.get(0)).contains("mode:soft"));
+        assertTrue(Arrays.asList(recovered.get(1)).contains("mode:hard"));
+    }
+
+    @Test
+    @DisplayName("Each failure reason is tagged so the three failure paths can be told apart")
+    void failureReasonsAreTagged() {
+        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.THRESHOLD_EXCEEDED, "too many errors");
+        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.ATTEMPTS_EXHAUSTED, "out of attempts");
+        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED, "could not launch");
+
+        List<String[]> failed = incrementTags(PrototypeMetrics.JOB_FAILED);
+        assertEquals(3, failed.size(), "every failure path should be counted");
+        assertTrue(Arrays.asList(failed.get(0)).contains("reason:threshold_exceeded"));
+        assertTrue(Arrays.asList(failed.get(1)).contains("reason:attempts_exhausted"));
+        assertTrue(Arrays.asList(failed.get(2)).contains("reason:launch_failed"));
+    }
+
+    @Test
+    @DisplayName("A job running low on resume attempts is flagged, one with attempts to spare is not")
+    void approachingMaxFailuresOnlyCountsWhenAttemptsRunLow() {
+        metrics.jobFailureAttempt(JOB, CONTRACT, 2, 8, false);
+        assertTrue(incrementTags(PrototypeMetrics.JOB_APPROACHING_MAX_FAILURES).isEmpty(),
+                "an early failure is routine and should not raise the approaching-max signal");
+
+        metrics.jobFailureAttempt(JOB, CONTRACT, 7, 8, true);
+        assertEquals(1, incrementTags(PrototypeMetrics.JOB_APPROACHING_MAX_FAILURES).size());
+        assertEquals(1, gaugeValues(PrototypeMetrics.JOB_ATTEMPTS_REMAINING).stream()
+                .filter(value -> value == 1L).count(), "one attempt should be reported as remaining");
+    }
+
+    @Test
+    @DisplayName("A suspend records whether the clean-suspend marker was written")
+    void suspendRecordsWhetherItWasClean() {
+        metrics.jobSuspended(JOB, CONTRACT, 3L, true);
+        metrics.jobSuspended(JOB, CONTRACT, 3L, false);
+
+        List<String[]> suspended = incrementTags(PrototypeMetrics.JOB_SUSPENDED);
+        assertEquals(2, suspended.size());
+        assertTrue(Arrays.asList(suspended.get(0)).contains("clean:true"));
+        assertTrue(Arrays.asList(suspended.get(1)).contains("clean:false"),
+                "a suspend that could not be marked clean forces a hard recovery later, so it must be visible");
+    }
+
+    @Test
+    @DisplayName("A drain that times out is recorded as not drained, with its duration")
+    void drainRecordsOutcomeAndDuration() {
+        metrics.drainStarted(2);
+        metrics.drainFinished(false, 32000L, 2);
+
+        assertEquals(1, incrementTags(PrototypeMetrics.DRAIN_STARTED).size());
+        List<String[]> finished = incrementTags(PrototypeMetrics.DRAIN_FINISHED);
+        assertEquals(1, finished.size());
+        assertTrue(Arrays.asList(finished.get(0)).contains("drained:false"));
+        assertEquals(List.of(32000L), executionTimes(PrototypeMetrics.DRAIN_DURATION_MS));
+    }
+
+    @Test
+    @DisplayName("Skipped beneficiaries are tagged with the phase that dropped them")
+    void skippedBenesCarryPhase() {
+        metrics.beneSkipped(JOB, "process", new IllegalStateException("boom"));
+
+        List<String[]> skipped = incrementTags(PrototypeMetrics.BENE_SKIPPED);
+        assertEquals(1, skipped.size());
+        assertTrue(Arrays.asList(skipped.get(0)).contains("phase:process"));
+        assertTrue(Arrays.asList(skipped.get(0)).contains("cause:IllegalStateException"));
+    }
+
+    @Test
+    @DisplayName("Lease health gauges active, stale, and unrecovered separately")
+    void leaseHealthGaugesEachBucket() {
+        metrics.leaseHeartbeats(3, 2, 1);
+
+        assertEquals(List.of(3L), gaugeValues(PrototypeMetrics.LEASE_ACTIVE));
+        assertEquals(List.of(2L), gaugeValues(PrototypeMetrics.LEASE_STALE));
+        assertEquals(List.of(1L), gaugeValues(PrototypeMetrics.LEASE_UNRECOVERED));
+    }
+
+    @Test
+    @DisplayName("Copy-forward reports carried and restarted partitions, and stays quiet when there are none")
+    void copyForwardReportsBothOutcomes() {
+        metrics.copyForward(JOB, 2L, 0, 0);
+        assertTrue(counts(PrototypeMetrics.COPY_FORWARD_SEEDED).isEmpty()
+                        && counts(PrototypeMetrics.COPY_FORWARD_RESTARTED).isEmpty(),
+                "a recovery that carried nothing and restarted nothing has nothing to report");
+
+        metrics.copyForward(JOB, 3L, 2, 1);
+        assertEquals(List.of(2L), counts(PrototypeMetrics.COPY_FORWARD_SEEDED));
+        assertEquals(List.of(1L), counts(PrototypeMetrics.COPY_FORWARD_RESTARTED));
+    }
+
+    @Test
+    @DisplayName("Without a DogStatsD client the emitter is a no-op instead of failing")
+    void noStatsDClientIsANoOp() {
+        PrototypeMetrics noClient = new PrototypeMetrics(ENV, providerOf(null));
+
+        assertDoesNotThrow(() -> {
+            noClient.jobStarted(JOB, CONTRACT, ResumeMode.HARD, 2L);
+            noClient.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED, "boom");
+            noClient.jobFailureAttempt(JOB, CONTRACT, 7, 8, true);
+            noClient.leaseHeartbeats(1, 1, 1);
+            noClient.chunkFenceLost(JOB, 2L);
+            noClient.drainFinished(true, 10L, 0);
+        });
+    }
+
+    @Test
+    @DisplayName("Metrics without a contract still carry the environment tag")
+    void environmentIsAlwaysTagged() {
+        metrics.chunkFenceLost(JOB, 5L);
+
+        List<String[]> fenceLost = incrementTags(PrototypeMetrics.CHUNK_FENCE_LOST);
+        assertEquals(1, fenceLost.size());
+        assertTrue(Arrays.asList(fenceLost.get(0)).contains("environment:" + ENV));
+        assertFalse(Arrays.stream(fenceLost.get(0)).anyMatch(tag -> tag.startsWith("contract:")),
+                "a chunk-level fence loss has no contract to tag with");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<StatsDClient> providerOf(StatsDClient client) {
+        ObjectProvider<StatsDClient> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(client);
+        return provider;
+    }
+
+    /** The tag arrays passed to every {@code increment} of the given aspect, in call order. */
+    private List<String[]> incrementTags(String aspect) {
+        return argumentsOf("increment", aspect).stream().map(args -> (String[]) args[1]).toList();
+    }
+
+    /** The values passed to every {@code gauge} of the given aspect, in call order. */
+    private List<Long> gaugeValues(String aspect) {
+        return argumentsOf("gauge", aspect).stream().map(args -> ((Number) args[1]).longValue()).toList();
+    }
+
+    /** The values passed to every {@code count} of the given aspect, in call order. */
+    private List<Long> counts(String aspect) {
+        return argumentsOf("count", aspect).stream().map(args -> ((Number) args[1]).longValue()).toList();
+    }
+
+    /** The durations passed to every {@code recordExecutionTime} of the given aspect, in call order. */
+    private List<Long> executionTimes(String aspect) {
+        return argumentsOf("recordExecutionTime", aspect).stream()
+                .map(args -> ((Number) args[1]).longValue()).toList();
+    }
+
+    /**
+     * Raw invocation arguments are used instead of argument matchers because the DogStatsD API takes tags as
+     * varargs, which matchers flatten and make impossible to correlate back to the call that produced them.
+     */
+    private List<Object[]> argumentsOf(String method, String aspect) {
+        return mockingDetails(statsDClient).getInvocations().stream()
+                .filter(invocation -> invocation.getMethod().getName().equals(method))
+                .filter(invocation -> aspect.equals(rawArguments(invocation)[0]))
+                .map(PrototypeMetricsTest::rawArguments)
+                .toList();
+    }
+
+    private static Object[] rawArguments(Invocation invocation) {
+        return invocation.getRawArguments();
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetricsTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeMetricsTest.java
@@ -26,7 +26,6 @@ class PrototypeMetricsTest {
 
     private static final String ENV = "ab2d-dev";
     private static final String CONTRACT = "Z0001";
-    private static final String JOB = "job-uuid";
 
     private StatsDClient statsDClient;
     private PrototypeMetrics metrics;
@@ -38,41 +37,32 @@ class PrototypeMetricsTest {
     }
 
     @Test
-    @DisplayName("A fresh start counts as a start but not as a recovery")
-    void freshStartIsNotARecovery() {
-        metrics.jobStarted(JOB, CONTRACT, ResumeMode.FRESH, 1L);
+    @DisplayName("Every claim is one metric, with fresh/soft/hard separated by tag")
+    void everyClaimIsTaggedByMode() {
+        metrics.jobStarted(CONTRACT, ResumeMode.FRESH);
+        metrics.jobStarted(CONTRACT, ResumeMode.SOFT);
+        metrics.jobStarted(CONTRACT, ResumeMode.HARD);
 
         List<String[]> started = incrementTags(PrototypeMetrics.JOB_STARTED);
-        assertEquals(1, started.size(), "a start should be counted once");
+        assertEquals(3, started.size(), "one metric covers all three ways a job can be claimed");
         assertTrue(Arrays.asList(started.get(0)).contains("mode:fresh"));
+        assertTrue(Arrays.asList(started.get(1)).contains("mode:soft"));
+        assertTrue(Arrays.asList(started.get(2)).contains("mode:hard"));
         assertTrue(Arrays.asList(started.get(0)).contains("environment:" + ENV));
         assertTrue(Arrays.asList(started.get(0)).contains("contract:" + CONTRACT));
-        assertTrue(incrementTags(PrototypeMetrics.JOB_RECOVERED).isEmpty(),
-                "a first claim has no prior work, so it is not a recovery");
-    }
-
-    @Test
-    @DisplayName("Soft and hard resumes are both recoveries but stay distinguishable by tag")
-    void softAndHardRecoveriesAreTaggedSeparately() {
-        metrics.jobStarted(JOB, CONTRACT, ResumeMode.SOFT, 4L);
-        metrics.jobStarted("other-job", CONTRACT, ResumeMode.HARD, 9L);
-
-        List<String[]> recovered = incrementTags(PrototypeMetrics.JOB_RECOVERED);
-        assertEquals(2, recovered.size(), "both resumes should count as recoveries");
-        assertTrue(Arrays.asList(recovered.get(0)).contains("mode:soft"));
-        assertTrue(Arrays.asList(recovered.get(1)).contains("mode:hard"));
     }
 
     @Test
     @DisplayName("Each failure reason is tagged so the three failure paths can be told apart")
     void failureReasonsAreTagged() {
-        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.THRESHOLD_EXCEEDED, "too many errors");
-        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.ATTEMPTS_EXHAUSTED, "out of attempts");
-        metrics.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED, "could not launch");
+        metrics.jobFailed(CONTRACT, PrototypeMetrics.FailureReason.THRESHOLD_EXCEEDED);
+        metrics.jobFailed(CONTRACT, PrototypeMetrics.FailureReason.ATTEMPTS_EXHAUSTED);
+        metrics.jobFailed(CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED);
 
         List<String[]> failed = incrementTags(PrototypeMetrics.JOB_FAILED);
         assertEquals(3, failed.size(), "every failure path should be counted");
-        assertTrue(Arrays.asList(failed.get(0)).contains("reason:threshold_exceeded"));
+        assertTrue(Arrays.asList(failed.get(0)).contains("reason:threshold_exceeded"),
+                "the failure threshold is a reason tag, so no separate threshold metric is needed");
         assertTrue(Arrays.asList(failed.get(1)).contains("reason:attempts_exhausted"));
         assertTrue(Arrays.asList(failed.get(2)).contains("reason:launch_failed"));
     }
@@ -80,11 +70,11 @@ class PrototypeMetricsTest {
     @Test
     @DisplayName("A job running low on resume attempts is flagged, one with attempts to spare is not")
     void approachingMaxFailuresOnlyCountsWhenAttemptsRunLow() {
-        metrics.jobFailureAttempt(JOB, CONTRACT, 2, 8, false);
+        metrics.jobFailureAttempt(CONTRACT, 2, 8, false);
         assertTrue(incrementTags(PrototypeMetrics.JOB_APPROACHING_MAX_FAILURES).isEmpty(),
                 "an early failure is routine and should not raise the approaching-max signal");
 
-        metrics.jobFailureAttempt(JOB, CONTRACT, 7, 8, true);
+        metrics.jobFailureAttempt(CONTRACT, 7, 8, true);
         assertEquals(1, incrementTags(PrototypeMetrics.JOB_APPROACHING_MAX_FAILURES).size());
         assertEquals(1, gaugeValues(PrototypeMetrics.JOB_ATTEMPTS_REMAINING).stream()
                 .filter(value -> value == 1L).count(), "one attempt should be reported as remaining");
@@ -93,8 +83,8 @@ class PrototypeMetricsTest {
     @Test
     @DisplayName("A suspend records whether the clean-suspend marker was written")
     void suspendRecordsWhetherItWasClean() {
-        metrics.jobSuspended(JOB, CONTRACT, 3L, true);
-        metrics.jobSuspended(JOB, CONTRACT, 3L, false);
+        metrics.jobSuspended(CONTRACT, true);
+        metrics.jobSuspended(CONTRACT, false);
 
         List<String[]> suspended = incrementTags(PrototypeMetrics.JOB_SUSPENDED);
         assertEquals(2, suspended.size());
@@ -106,8 +96,8 @@ class PrototypeMetricsTest {
     @Test
     @DisplayName("A drain that times out is recorded as not drained, with its duration")
     void drainRecordsOutcomeAndDuration() {
-        metrics.drainStarted(2);
-        metrics.drainFinished(false, 32000L, 2);
+        metrics.drainStarted();
+        metrics.drainFinished(false, 32000L);
 
         assertEquals(1, incrementTags(PrototypeMetrics.DRAIN_STARTED).size());
         List<String[]> finished = incrementTags(PrototypeMetrics.DRAIN_FINISHED);
@@ -119,7 +109,7 @@ class PrototypeMetricsTest {
     @Test
     @DisplayName("Skipped beneficiaries are tagged with the phase that dropped them")
     void skippedBenesCarryPhase() {
-        metrics.beneSkipped(JOB, "process", new IllegalStateException("boom"));
+        metrics.beneSkipped("process", new IllegalStateException("boom"));
 
         List<String[]> skipped = incrementTags(PrototypeMetrics.BENE_SKIPPED);
         assertEquals(1, skipped.size());
@@ -140,12 +130,12 @@ class PrototypeMetricsTest {
     @Test
     @DisplayName("Copy-forward reports carried and restarted partitions, and stays quiet when there are none")
     void copyForwardReportsBothOutcomes() {
-        metrics.copyForward(JOB, 2L, 0, 0);
+        metrics.copyForward(0, 0);
         assertTrue(counts(PrototypeMetrics.COPY_FORWARD_SEEDED).isEmpty()
                         && counts(PrototypeMetrics.COPY_FORWARD_RESTARTED).isEmpty(),
                 "a recovery that carried nothing and restarted nothing has nothing to report");
 
-        metrics.copyForward(JOB, 3L, 2, 1);
+        metrics.copyForward(2, 1);
         assertEquals(List.of(2L), counts(PrototypeMetrics.COPY_FORWARD_SEEDED));
         assertEquals(List.of(1L), counts(PrototypeMetrics.COPY_FORWARD_RESTARTED));
     }
@@ -156,19 +146,19 @@ class PrototypeMetricsTest {
         PrototypeMetrics noClient = new PrototypeMetrics(ENV, providerOf(null));
 
         assertDoesNotThrow(() -> {
-            noClient.jobStarted(JOB, CONTRACT, ResumeMode.HARD, 2L);
-            noClient.jobFailed(JOB, CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED, "boom");
-            noClient.jobFailureAttempt(JOB, CONTRACT, 7, 8, true);
+            noClient.jobStarted(CONTRACT, ResumeMode.HARD);
+            noClient.jobFailed(CONTRACT, PrototypeMetrics.FailureReason.LAUNCH_FAILED);
+            noClient.jobFailureAttempt(CONTRACT, 7, 8, true);
             noClient.leaseHeartbeats(1, 1, 1);
-            noClient.chunkFenceLost(JOB, 2L);
-            noClient.drainFinished(true, 10L, 0);
+            noClient.chunkFenceLost();
+            noClient.drainFinished(true, 10L);
         });
     }
 
     @Test
     @DisplayName("Metrics without a contract still carry the environment tag")
     void environmentIsAlwaysTagged() {
-        metrics.chunkFenceLost(JOB, 5L);
+        metrics.chunkFenceLost();
 
         List<String[]> fenceLost = incrementTags(PrototypeMetrics.CHUNK_FENCE_LOST);
         assertEquals(1, fenceLost.size());

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeObservabilityIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeObservabilityIntegrationTest.java
@@ -70,8 +70,6 @@ class PrototypeObservabilityIntegrationTest extends AbstractPrototypeRecoveryInt
         assertTrue(tagsOf("increment", PrototypeMetrics.JOB_FAILED).stream()
                         .anyMatch(tags -> tags.contains("reason:threshold_exceeded")),
                 "the terminal failure should count under its own reason tag");
-        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_THRESHOLD_EXCEEDED).isEmpty(),
-                "the threshold trip itself should be countable separately from the failure");
         // The skipped beneficiaries are what tripped the threshold, so they must be visible too.
         assertTrue(tagsOf("increment", PrototypeMetrics.BENE_SKIPPED).size() >= failBenes.size(),
                 "every skipped beneficiary should be counted, saw "
@@ -147,10 +145,10 @@ class PrototypeObservabilityIntegrationTest extends AbstractPrototypeRecoveryInt
         Job resumed = prototypeJobProcessor.process(uuid);
 
         assertEquals(JobStatus.SUCCESSFUL, resumed.getStatus());
-        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
                         .anyMatch(tags -> tags.contains("mode:soft")),
                 "picking a cleanly paused job back up is a soft recovery");
-        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
                         .anyMatch(tags -> tags.contains("mode:hard")),
                 "a clean pause must not be reported as a crash recovery");
     }
@@ -171,10 +169,10 @@ class PrototypeObservabilityIntegrationTest extends AbstractPrototypeRecoveryInt
         assertTrue(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
                         .anyMatch(tags -> tags.contains("mode:fresh")),
                 "the original run should have been recorded as a fresh start");
-        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
                         .anyMatch(tags -> tags.contains("mode:hard")),
                 "taking over a crashed job is a hard recovery");
-        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
                         .anyMatch(tags -> tags.contains("mode:soft")),
                 "a crash must not be reported as a clean pause");
         // Copy-forward is what decides how much of the crashed partition survived, so it is reported either
@@ -230,8 +228,12 @@ class PrototypeObservabilityIntegrationTest extends AbstractPrototypeRecoveryInt
         JobLeaseRepository.HeartbeatHealth stranded = jobLease.heartbeatHealth(ttl, grace);
         assertEquals(before.unrecovered() + 1, stranded.unrecovered(),
                 "a job nobody recovered past the grace window is stranded and must be visible");
-        assertTrue(jobLease.unrecoveredJobUuids(grace).contains(uuid),
+        assertEquals(before.stale(), stranded.stale(),
+                "the buckets are mutually exclusive - a stranded job must not also be counted as stale");
+        assertTrue(jobLease.claimUnrecoveredForAlert(grace, 3600).contains(uuid),
                 "the stranded job should be nameable, not just countable");
+        assertFalse(jobLease.claimUnrecoveredForAlert(grace, 3600).contains(uuid),
+                "a second claim inside the cooldown must return nothing, so workers cannot flood Slack");
     }
 
     /**

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeObservabilityIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeObservabilityIntegrationTest.java
@@ -1,0 +1,286 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import com.timgroup.statsd.StatsDClient;
+import gov.cms.ab2d.coverage.model.CoverageSummary;
+import gov.cms.ab2d.eventclient.events.JobStatusChangeEvent;
+import gov.cms.ab2d.eventclient.events.LoggableEvent;
+import gov.cms.ab2d.job.model.Job;
+import gov.cms.ab2d.job.model.JobStatus;
+import gov.cms.ab2d.worker.processor.prototype.lease.JobLeaseRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.Invocation;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Observability coverage for the prototype: every terminal failure path must reach Slack, and a resume must
+ * be countable in Datadog with soft and hard recoveries kept apart.
+ *
+ * {@code max-failure-attempts=1} makes the first batch failure terminal, which is what lets the
+ * attempts-exhausted path be reached without failing the same job eight times.
+ */
+@TestPropertySource(properties = {
+        "pause-resume.prototype.max-failure-attempts=1",
+        "pause-resume.prototype.failure-attempts-warn-remaining=2"
+})
+class PrototypeObservabilityIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
+
+    @MockitoBean
+    private StatsDClient statsDClient;
+
+    @Test
+    @DisplayName("Failure path 1 of 3: tripping the failure threshold alerts to Slack and counts its reason")
+    void thresholdFailureAlerts() throws Exception {
+        Job job = createSubmittedV3Job("obs-threshold");
+        String uuid = job.getJobUuid();
+        Set<Long> failBenes = Set.of(6L, 14L);
+
+        // Two failures out of 20 reaches the 10% threshold, so the job fails terminally.
+        doAnswer(inv -> {
+            CoverageSummary patient = inv.getArgument(1);
+            if (failBenes.contains(patientId(patient))) {
+                throw new IllegalStateException("persistent failure for bene " + patientId(patient));
+            }
+            return oneEobFor(patient);
+        }).when(patientClaimsProcessor).getEobBundleResources(any(), any());
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.FAILED, result.getStatus());
+        assertTrue(failureAlertMessage(uuid).contains("threshold_exceeded"),
+                "the Slack alert should name the failure path: " + failureAlertMessage(uuid));
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_FAILED).stream()
+                        .anyMatch(tags -> tags.contains("reason:threshold_exceeded")),
+                "the terminal failure should count under its own reason tag");
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_THRESHOLD_EXCEEDED).isEmpty(),
+                "the threshold trip itself should be countable separately from the failure");
+        // The skipped beneficiaries are what tripped the threshold, so they must be visible too.
+        assertTrue(tagsOf("increment", PrototypeMetrics.BENE_SKIPPED).size() >= failBenes.size(),
+                "every skipped beneficiary should be counted, saw "
+                        + tagsOf("increment", PrototypeMetrics.BENE_SKIPPED).size());
+        assertTrue(tagsOf("increment", PrototypeMetrics.BENE_SKIPPED).stream()
+                        .allMatch(tags -> tags.contains("phase:process")),
+                "these beneficiaries failed while their claims were being fetched");
+    }
+
+    @Test
+    @DisplayName("Failure path 2 of 3: running out of resume attempts alerts to Slack and counts its reason")
+    void attemptsExhaustedFailureAlerts() throws Exception {
+        Job job = createSubmittedV3Job("obs-attempts");
+        String uuid = job.getJobUuid();
+
+        // Fail inside the partitioner. The batch execution ends FAILED without a threshold breach, which is
+        // the resumable path - and with max-failure-attempts=1 the first failure exhausts the budget.
+        doThrow(new IllegalStateException("partitioning blew up"))
+                .when(coverageV3Service).getPartitionBoundaryPatientIds(eq(CONTRACT), anyInt());
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.FAILED, result.getStatus(),
+                "with no attempts left the job must fail terminally rather than resubmit");
+        assertTrue(failureAlertMessage(uuid).contains("attempts_exhausted"),
+                "the Slack alert should name the failure path: " + failureAlertMessage(uuid));
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_FAILED).stream()
+                        .anyMatch(tags -> tags.contains("reason:attempts_exhausted")),
+                "the terminal failure should count under its own reason tag");
+    }
+
+    @Test
+    @DisplayName("Failure path 3 of 3: a launch failure alerts to Slack and counts its reason")
+    void launchFailureAlerts() throws Exception {
+        Job job = createSubmittedV3Job("obs-launch");
+        String uuid = job.getJobUuid();
+
+        // Blow up before the batch job is ever launched, which is the outer catch in the processor.
+        doThrow(new IllegalStateException("cannot build the aggregated table"))
+                .when(coverageV3Service).createAggregatedAttributionTable(CONTRACT);
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.FAILED, result.getStatus());
+        assertTrue(failureAlertMessage(uuid).contains("launch_failed"),
+                "the Slack alert should name the failure path: " + failureAlertMessage(uuid));
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_FAILED).stream()
+                        .anyMatch(tags -> tags.contains("reason:launch_failed")),
+                "the terminal failure should count under its own reason tag");
+    }
+
+    @Test
+    @DisplayName("A clean pause and its pickup are counted as a soft recovery, not a hard one")
+    void softResumeIsCountedSeparately() throws Exception {
+        Job job = createSubmittedV3Job("obs-soft");
+        String uuid = job.getJobUuid();
+
+        RunningWorker worker = startWorkerUntilOnePartitionDone(uuid, "test-obs-soft-worker");
+        prototypeJobProcessor.stopForShutdown();
+        worker.awaitReturn(90);
+        assertEquals(JobStatus.SUBMITTED, jobRepository.findByJobUuid(uuid).getStatus());
+
+        // The pause itself is observable, and it recorded that the clean-suspend marker was written.
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_SUSPENDED).stream()
+                        .anyMatch(tags -> tags.contains("clean:true")),
+                "a graceful shutdown should record a clean suspend");
+        assertFalse(tagsOf("increment", PrototypeMetrics.DRAIN_STARTED).isEmpty(),
+                "the shutdown drain should be observable");
+        assertTrue(tagsOf("increment", PrototypeMetrics.DRAIN_FINISHED).stream()
+                        .anyMatch(tags -> tags.contains("drained:true")),
+                "the drain finished before the timeout, which is what makes the soft resume possible");
+
+        Job resumed = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, resumed.getStatus());
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+                        .anyMatch(tags -> tags.contains("mode:soft")),
+                "picking a cleanly paused job back up is a soft recovery");
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+                        .anyMatch(tags -> tags.contains("mode:hard")),
+                "a clean pause must not be reported as a crash recovery");
+    }
+
+    @Test
+    @DisplayName("A crashed job's takeover is counted as a hard recovery, with what copy-forward salvaged")
+    void hardRecoveryIsCountedSeparately() throws Exception {
+        Job job = createSubmittedV3Job("obs-hard");
+        String uuid = job.getJobUuid();
+
+        RunningWorker owner = startWorkerUntilOnePartitionDone(uuid, "test-obs-hard-worker");
+        owner.killHard();
+        forceHardCrashState(uuid, "STARTED");
+
+        Job recovered = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, recovered.getStatus());
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_STARTED).stream()
+                        .anyMatch(tags -> tags.contains("mode:fresh")),
+                "the original run should have been recorded as a fresh start");
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+                        .anyMatch(tags -> tags.contains("mode:hard")),
+                "taking over a crashed job is a hard recovery");
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_RECOVERED).stream()
+                        .anyMatch(tags -> tags.contains("mode:soft")),
+                "a crash must not be reported as a clean pause");
+        // Copy-forward is what decides how much of the crashed partition survived, so it is reported either
+        // way: as carried chunks or as a partition that had to start over.
+        assertFalse(counted("count", PrototypeMetrics.COPY_FORWARD_SEEDED).isEmpty()
+                        && counted("count", PrototypeMetrics.COPY_FORWARD_RESTARTED).isEmpty(),
+                "a hard recovery should report what copy-forward did with the in-flight partition");
+    }
+
+    @Test
+    @DisplayName("A successful job neither alerts a failure nor counts one")
+    void successDoesNotAlertFailure() throws Exception {
+        Job job = createSubmittedV3Job("obs-success");
+        String uuid = job.getJobUuid();
+
+        Job result = prototypeJobProcessor.process(uuid);
+
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus());
+        assertTrue(tagsOf("increment", PrototypeMetrics.JOB_FAILED).isEmpty(),
+                "a successful job must not report a failure");
+        assertTrue(failureAlertMessages(uuid).isEmpty(),
+                "a successful job must not raise a failure alert: " + failureAlertMessages(uuid));
+        assertFalse(tagsOf("increment", PrototypeMetrics.JOB_COMPLETED).isEmpty(),
+                "a successful job should be countable");
+    }
+
+    @Test
+    @DisplayName("An IN_PROGRESS job counts as stale once its heartbeat passes the TTL, then as unrecovered")
+    void deadHeartbeatsAreCountedStaleThenUnrecovered() {
+        Job job = createSubmittedV3Job("obs-lease");
+        String uuid = job.getJobUuid();
+        jdbc.update("UPDATE job SET status = 'IN_PROGRESS' WHERE job_uuid = ?", uuid);
+
+        int ttl = 40;
+        int grace = ttl * 3;
+        JobLeaseRepository.HeartbeatHealth before = jobLease.heartbeatHealth(ttl, grace);
+
+        // A live owner: the heartbeat is fresh, so the job is healthy and nothing should take it over.
+        jobLease.bump(uuid, "test-lease-owner");
+        JobLeaseRepository.HeartbeatHealth live = jobLease.heartbeatHealth(ttl, grace);
+        assertEquals(before.active() + 1, live.active(), "a job with a fresh heartbeat should count as active");
+        assertEquals(before.stale(), live.stale(), "a live owner is not a takeover candidate");
+
+        // The owner dies. Past the TTL the job is a takeover candidate, which is expected and self-healing.
+        ageHeartbeat(uuid, ttl + 20);
+        JobLeaseRepository.HeartbeatHealth stale = jobLease.heartbeatHealth(ttl, grace);
+        assertEquals(before.stale() + 1, stale.stale(), "a dead heartbeat past the TTL should count as stale");
+        assertEquals(before.unrecovered(), stale.unrecovered(),
+                "just past the TTL a takeover has not had time to happen yet");
+
+        // Still nobody picked it up well past the grace window, which means recovery is broken.
+        ageHeartbeat(uuid, grace + 60);
+        JobLeaseRepository.HeartbeatHealth stranded = jobLease.heartbeatHealth(ttl, grace);
+        assertEquals(before.unrecovered() + 1, stranded.unrecovered(),
+                "a job nobody recovered past the grace window is stranded and must be visible");
+        assertTrue(jobLease.unrecoveredJobUuids(grace).contains(uuid),
+                "the stranded job should be nameable, not just countable");
+    }
+
+    /**
+     * The message of the FAILED status-change event sent to Slack for the given job. Fails the test if the
+     * processor did not alert at all, which is the condition each failure-path test is really asserting.
+     */
+    private String failureAlertMessage(String jobUuid) {
+        return failureAlertMessages(jobUuid).stream().findFirst()
+                .orElseThrow(() -> new AssertionError("no FAILED Slack alert was sent for job " + jobUuid));
+    }
+
+    /** Descriptions of every FAILED status-change event alerted to Slack for the given job. */
+    private List<String> failureAlertMessages(String jobUuid) {
+        ArgumentCaptor<LoggableEvent> event = ArgumentCaptor.forClass(LoggableEvent.class);
+        verify(eventLogger, atLeast(0)).logAndAlert(event.capture(), any());
+        return event.getAllValues().stream()
+                .filter(JobStatusChangeEvent.class::isInstance)
+                .map(JobStatusChangeEvent.class::cast)
+                .filter(e -> jobUuid.equals(e.getJobId()))
+                .filter(e -> JobStatus.FAILED.name().equals(e.getNewStatus()))
+                .map(JobStatusChangeEvent::getDescription)
+                .toList();
+    }
+
+    /** Tag lists passed to each call of the given DogStatsD method for the given aspect. */
+    private List<List<String>> tagsOf(String method, String aspect) {
+        return invocationArgs(method, aspect).stream()
+                .map(args -> Arrays.asList((String[]) args[args.length - 1]))
+                .toList();
+    }
+
+    /** Values passed to each call of a value-carrying DogStatsD method for the given aspect. */
+    private List<Long> counted(String method, String aspect) {
+        return invocationArgs(method, aspect).stream().map(args -> ((Number) args[1]).longValue()).toList();
+    }
+
+    /**
+     * Raw invocation arguments rather than matchers: the DogStatsD API takes tags as varargs, which matchers
+     * flatten and make impossible to correlate back to the call that produced them.
+     */
+    private List<Object[]> invocationArgs(String method, String aspect) {
+        return mockingDetails(statsDClient).getInvocations().stream()
+                .filter(invocation -> invocation.getMethod().getName().equals(method))
+                .filter(invocation -> aspect.equals(rawArguments(invocation)[0]))
+                .map(PrototypeObservabilityIntegrationTest::rawArguments)
+                .toList();
+    }
+
+    private static Object[] rawArguments(Invocation invocation) {
+        return invocation.getRawArguments();
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitorTest.java
@@ -35,6 +35,8 @@ class PrototypeLeaseMonitorTest {
     private static final int TTL_SECONDS = 40;
     private static final int GRACE_MULTIPLIER = 3;
     private static final int GRACE_SECONDS = TTL_SECONDS * GRACE_MULTIPLIER;
+    private static final int COOLDOWN_MINUTES = 60;
+    private static final int COOLDOWN_SECONDS = COOLDOWN_MINUTES * 60;
 
     private JobLeaseRepository jobLease;
     private PrototypeMetrics metrics;
@@ -51,6 +53,7 @@ class PrototypeLeaseMonitorTest {
 
         PrototypeProperties props = new PrototypeProperties();
         props.setLeaseGraceMultiplier(GRACE_MULTIPLIER);
+        props.setLeaseAlertCooldownMinutes(COOLDOWN_MINUTES);
         monitor = new PrototypeLeaseMonitor(jobLease, metrics, propertiesService, eventLogger, props, TTL_SECONDS);
     }
 
@@ -75,7 +78,7 @@ class PrototypeLeaseMonitorTest {
 
         verify(metrics).leaseHeartbeats(2, 1, 0);
         verify(eventLogger, never()).trace(anyString(), any());
-        verify(jobLease, never()).unrecoveredJobUuids(anyInt());
+        verify(jobLease, never()).claimUnrecoveredForAlert(anyInt(), anyInt());
     }
 
     @Test
@@ -84,7 +87,8 @@ class PrototypeLeaseMonitorTest {
         enabled();
         when(jobLease.heartbeatHealth(TTL_SECONDS, GRACE_SECONDS))
                 .thenReturn(new JobLeaseRepository.HeartbeatHealth(0, 2, 2));
-        when(jobLease.unrecoveredJobUuids(GRACE_SECONDS)).thenReturn(List.of("job-a", "job-b"));
+        when(jobLease.claimUnrecoveredForAlert(GRACE_SECONDS, COOLDOWN_SECONDS))
+                .thenReturn(List.of("job-a", "job-b"));
 
         monitor.reportLeaseHealth();
 
@@ -95,6 +99,34 @@ class PrototypeLeaseMonitorTest {
                 "the alert should name the stranded jobs so they can be chased: " + message.getValue());
         assertTrue(message.getValue().contains(String.valueOf(GRACE_SECONDS)),
                 "the alert should say how long the jobs have been dead: " + message.getValue());
+    }
+
+    @Test
+    @DisplayName("Losing the alert claim keeps the worker quiet, so N workers do not send N messages")
+    void losingTheClaimSendsNothing() {
+        enabled();
+        when(jobLease.heartbeatHealth(TTL_SECONDS, GRACE_SECONDS))
+                .thenReturn(new JobLeaseRepository.HeartbeatHealth(0, 0, 2));
+        // Another worker already claimed these, or they are still inside their cooldown.
+        when(jobLease.claimUnrecoveredForAlert(GRACE_SECONDS, COOLDOWN_SECONDS)).thenReturn(List.of());
+
+        monitor.reportLeaseHealth();
+
+        verify(metrics).leaseHeartbeats(0, 0, 2);
+        verify(eventLogger, never()).trace(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("The cooldown is passed to the claim, so a stranded job is reported once per cooldown")
+    void cooldownIsAppliedToTheClaim() {
+        enabled();
+        when(jobLease.heartbeatHealth(TTL_SECONDS, GRACE_SECONDS))
+                .thenReturn(new JobLeaseRepository.HeartbeatHealth(0, 0, 1));
+        when(jobLease.claimUnrecoveredForAlert(anyInt(), anyInt())).thenReturn(List.of("job-a"));
+
+        monitor.reportLeaseHealth();
+
+        verify(jobLease).claimUnrecoveredForAlert(GRACE_SECONDS, COOLDOWN_SECONDS);
     }
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/lease/PrototypeLeaseMonitorTest.java
@@ -1,0 +1,129 @@
+package gov.cms.ab2d.worker.processor.prototype.lease;
+
+import gov.cms.ab2d.common.properties.PropertiesService;
+import gov.cms.ab2d.eventclient.clients.SQSEventClient;
+import gov.cms.ab2d.worker.processor.prototype.PrototypeMetrics;
+import gov.cms.ab2d.worker.processor.prototype.PrototypeProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static gov.cms.ab2d.common.util.PropertyConstants.PAUSE_RESUME_PROTOTYPE_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The lease monitor is what makes a stranded job visible, so these cover the three things that matter: it
+ * stays out of the way when the prototype is off, it reports the heartbeat buckets when it is on, and it
+ * names the stranded jobs when recovery has clearly stopped working.
+ */
+class PrototypeLeaseMonitorTest {
+
+    private static final int TTL_SECONDS = 40;
+    private static final int GRACE_MULTIPLIER = 3;
+    private static final int GRACE_SECONDS = TTL_SECONDS * GRACE_MULTIPLIER;
+
+    private JobLeaseRepository jobLease;
+    private PrototypeMetrics metrics;
+    private PropertiesService propertiesService;
+    private SQSEventClient eventLogger;
+    private PrototypeLeaseMonitor monitor;
+
+    @BeforeEach
+    void setUp() {
+        jobLease = mock(JobLeaseRepository.class);
+        metrics = mock(PrototypeMetrics.class);
+        propertiesService = mock(PropertiesService.class);
+        eventLogger = mock(SQSEventClient.class);
+
+        PrototypeProperties props = new PrototypeProperties();
+        props.setLeaseGraceMultiplier(GRACE_MULTIPLIER);
+        monitor = new PrototypeLeaseMonitor(jobLease, metrics, propertiesService, eventLogger, props, TTL_SECONDS);
+    }
+
+    @Test
+    @DisplayName("With the prototype turned off the monitor does not touch the database or emit anything")
+    void disabledPrototypeIsSilent() {
+        when(propertiesService.isToggleOn(PAUSE_RESUME_PROTOTYPE_ENABLED, false)).thenReturn(false);
+
+        monitor.reportLeaseHealth();
+
+        verifyNoInteractions(jobLease, metrics, eventLogger);
+    }
+
+    @Test
+    @DisplayName("Stale leases are reported but not alerted, since a takeover is expected to happen")
+    void staleLeasesAreReportedWithoutAlerting() {
+        enabled();
+        when(jobLease.heartbeatHealth(TTL_SECONDS, GRACE_SECONDS))
+                .thenReturn(new JobLeaseRepository.HeartbeatHealth(2, 1, 0));
+
+        monitor.reportLeaseHealth();
+
+        verify(metrics).leaseHeartbeats(2, 1, 0);
+        verify(eventLogger, never()).trace(anyString(), any());
+        verify(jobLease, never()).unrecoveredJobUuids(anyInt());
+    }
+
+    @Test
+    @DisplayName("A lease dead past the grace window alerts and names the stranded jobs")
+    void unrecoveredLeasesAlertWithJobIds() {
+        enabled();
+        when(jobLease.heartbeatHealth(TTL_SECONDS, GRACE_SECONDS))
+                .thenReturn(new JobLeaseRepository.HeartbeatHealth(0, 2, 2));
+        when(jobLease.unrecoveredJobUuids(GRACE_SECONDS)).thenReturn(List.of("job-a", "job-b"));
+
+        monitor.reportLeaseHealth();
+
+        verify(metrics).leaseHeartbeats(0, 2, 2);
+        ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+        verify(eventLogger).trace(message.capture(), any());
+        assertTrue(message.getValue().contains("job-a") && message.getValue().contains("job-b"),
+                "the alert should name the stranded jobs so they can be chased: " + message.getValue());
+        assertTrue(message.getValue().contains(String.valueOf(GRACE_SECONDS)),
+                "the alert should say how long the jobs have been dead: " + message.getValue());
+    }
+
+    @Test
+    @DisplayName("The grace window is a multiple of the lease TTL, so the two stay in step")
+    void graceWindowScalesWithTtl() {
+        enabled();
+        PrototypeProperties props = new PrototypeProperties();
+        props.setLeaseGraceMultiplier(5);
+        PrototypeLeaseMonitor scaled =
+                new PrototypeLeaseMonitor(jobLease, metrics, propertiesService, eventLogger, props, 10);
+        when(jobLease.heartbeatHealth(10, 50))
+                .thenReturn(new JobLeaseRepository.HeartbeatHealth(1, 0, 0));
+
+        scaled.reportLeaseHealth();
+
+        verify(jobLease).heartbeatHealth(10, 50);
+    }
+
+    @Test
+    @DisplayName("A database problem in the monitor never takes the worker down with it")
+    void databaseFailureIsSwallowed() {
+        enabled();
+        when(jobLease.heartbeatHealth(anyInt(), anyInt())).thenThrow(new IllegalStateException("db is down"));
+
+        assertDoesNotThrow(() -> monitor.reportLeaseHealth());
+        verify(metrics, never()).leaseHeartbeats(anyLong(), anyLong(), anyLong());
+    }
+
+    private void enabled() {
+        when(propertiesService.isToggleOn(eq(PAUSE_RESUME_PROTOTYPE_ENABLED), eq(false))).thenReturn(true);
+    }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7381

## 🛠 Changes

- `PrototypeMetrics`: DogStatsD metrics for the pause/resume lifecycle (job start tagged soft/hard/fresh recovery, shutdown drain, clean suspend, fence-token loss, failure attempts, threshold breaches, skipped benes)
- `PrototypeLeaseMonitor`: scheduled sweep gauging stale vs unrecovered lease heartbeats, so a job nothing recovers is visible

## ℹ️ Context

The prototype processor should emit failure to Slack. There are three failure paths in the PrototypeJobProcessor and each one should alert.

## 🧪 Validation
Integration tests passed https://github.com/CMSgov/ab2d/actions/runs/33019696215

Deployed in dev
Example of metric
<img width="1044" height="586" alt="Screenshot 2026-08-26 at 2 35 25 PM" src="https://github.com/user-attachments/assets/b31d3905-3d20-4672-9374-eb66e6609327" />

All added metrics
<img width="330" height="329" alt="Screenshot 2026-08-26 at 3 17 06 PM" src="https://github.com/user-attachments/assets/d7867e83-b914-4727-88fa-8a803beeb647" />


