### PR TITLE
AB2D-7408 Multi job support

### DIFF
--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchConfiguration.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeBatchConfiguration.java
@@ -3,13 +3,11 @@ package gov.cms.ab2d.worker.processor.prototype;
 import javax.sql.DataSource;
 import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.DataSourceInitializer;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Isolation;
 
 /**
  * Have to manually set up config due to name collision (and since we want to use a persistent DB)
@@ -29,9 +27,11 @@ public class PrototypeBatchConfiguration extends DefaultBatchConfiguration {
     @Override
     public JobRepository jobRepository() {
         try {
-            JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+            JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
             factory.setDataSource(dataSource);
             factory.setTransactionManager(transactionManager);
+            // prevent two jobs starting at the same time from failing
+            factory.setIsolationLevelForCreateEnum(Isolation.READ_COMMITTED);
             factory.afterPropertiesSet();
             return factory.getObject();
         } catch (Exception e) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeItemTaskExecutor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeItemTaskExecutor.java
@@ -1,0 +1,56 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import gov.cms.ab2d.worker.config.RoundRobinBlockingQueue;
+import org.jspecify.annotations.NonNull;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+/**
+ * Sets the round-robin queue category for the normal TaskExecutor.
+ * Basically, it's a decorator that handles the "hack" portion of getting
+ * the round-robin queue to recognize different categories.
+ */
+public class PrototypeItemTaskExecutor implements AsyncTaskExecutor {
+
+    private final AsyncTaskExecutor delegate;
+    private final String jobUuid;
+
+    public PrototypeItemTaskExecutor(AsyncTaskExecutor delegate, String jobUuid) {
+        this.delegate = delegate;
+        this.jobUuid = jobUuid;
+    }
+
+    @Override
+    public void execute(@NonNull Runnable task) {
+        RoundRobinBlockingQueue.CATEGORY_HOLDER.set(jobUuid);
+        try {
+            delegate.execute(task);
+        } finally {
+            RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();
+        }
+    }
+
+    @Override
+    @NonNull
+    public Future<?> submit(@NonNull Runnable task) {
+        RoundRobinBlockingQueue.CATEGORY_HOLDER.set(jobUuid);
+        try {
+            return delegate.submit(task);
+        } finally {
+            RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();
+        }
+    }
+
+    @Override
+    @NonNull
+    public <T> Future<T> submit(@NonNull Callable<T> task) {
+        RoundRobinBlockingQueue.CATEGORY_HOLDER.set(jobUuid);
+        try {
+            return delegate.submit(task);
+        } finally {
+            RoundRobinBlockingQueue.CATEGORY_HOLDER.remove();
+        }
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobProcessorImpl.java
@@ -26,6 +26,7 @@ import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.infrastructure.item.ItemStreamWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
@@ -42,6 +43,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PROD_LIST;
 import static gov.cms.ab2d.eventclient.config.Ab2dEnvironment.PUBLIC_LIST;
 import static gov.cms.ab2d.eventclient.events.SlackEvents.EOB_JOB_COMPLETED;
@@ -102,7 +104,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
     private final EobItemProcessor eobItemProcessor;
     private final ItemStreamWriter<SerializedEobs> ndjsonItemWriter;
     // shared by every job on this worker
-    private final AsyncTaskExecutor itemTaskExecutor;
+    private final AsyncTaskExecutor patientClaimsPool;
 
     public PrototypeJobProcessorImpl(
             JobRepository jobRepository,
@@ -124,6 +126,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
             EobItemProcessor eobItemProcessor,
             ItemStreamWriter<SerializedEobs> ndjsonItemWriter,
             PrototypeProperties props,
+            @Qualifier("patientProcessorThreadPool") Executor patientProcessorThreadPool,
             @Value("${failure.threshold}") int failureThreshold,
             @Value("${audit.files.ttl.hours}") int auditFilesTtlHours) {
         this.jobRepository = jobRepository;
@@ -144,7 +147,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         this.beneficiaryItemReader = beneficiaryItemReader;
         this.eobItemProcessor = eobItemProcessor;
         this.ndjsonItemWriter = ndjsonItemWriter;
-        this.itemTaskExecutor = itemTaskExecutor(props.getItemConcurrency());
+        this.patientClaimsPool = (AsyncTaskExecutor) patientProcessorThreadPool;
         this.props = props;
         this.failureThreshold = failureThreshold;
         this.auditFilesTtlHours = auditFilesTtlHours;
@@ -562,7 +565,7 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         TRANSIENT_EXCEPTIONS.forEach(workerStepBuilder::retry);
 
         if (props.isItemConcurrencyEnabled()) {
-            workerStepBuilder.taskExecutor(itemTaskExecutor);
+            workerStepBuilder.taskExecutor(new PrototypeItemTaskExecutor(patientClaimsPool, jobUuid));
         }
 
         Step workerStep = workerStepBuilder
@@ -590,18 +593,6 @@ public class PrototypeJobProcessorImpl implements PrototypeJobProcessor {
         return new JobBuilder(PROTOTYPE_JOB_NAME, batchJobRepository)
                 .start(managerStep)
                 .build();
-    }
-
-    /**
-     * Async executor for concurrent chunk work. Uses virtual threads since most threads
-     * are idle waiting for BFD. The concurrency limit prevents a small group of virtual
-     * threads from absolutely hammering BFD with a million requests.
-     */
-    private static AsyncTaskExecutor itemTaskExecutor(int concurrencyLimit) {
-        SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("proto-item-");
-        executor.setVirtualThreads(true);
-        executor.setConcurrencyLimit(Math.max(1, concurrencyLimit));
-        return executor;
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeProperties.java
@@ -30,12 +30,6 @@ public class PrototypeProperties {
      */
     private boolean itemConcurrencyEnabled = true;
 
-    /**
-     * Ceiling on beneficiaries being fetched at once, across every prototype job on this worker.
-     * The processor uses virtual threads, so it is not bounded by number of threads.
-     */
-    private int itemConcurrency = 128;
-
     /** How many times a job's batch execution can fail before it is marked terminally failed. */
     private int maxFailureAttempts = 8;
 

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -27,8 +27,6 @@ pause-resume.prototype.chunk-size=100
 pause-resume.prototype.concurrency=4
 # process benes in a chunk asynchronously
 pause-resume.prototype.item-concurrency-enabled=true
-# ceiling on benes being fetched across all jobs
-pause-resume.prototype.item-concurrency=128
 # benes per partition
 pause-resume.prototype.partition-size=1000
 # how many times a job can fail before it's marked as actually failing

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
@@ -221,6 +221,11 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
 
     /** Persist a fresh SUBMITTED R4V3 job for test contract. */
     protected Job createSubmittedV3Job(String uuidPrefix) {
+        return createSubmittedV3Job(uuidPrefix, CONTRACT);
+    }
+
+    /** Persist a fresh SUBMITTED R4V3 job for a given contract. */
+    protected Job createSubmittedV3Job(String uuidPrefix, String contractNumber) {
         PdpClient pdpClient = new PdpClient();
         pdpClient.setClientId(uuidPrefix + "-client");
         pdpClient.setOrganization(uuidPrefix + "-org");
@@ -236,7 +241,7 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
         job.setOutputFormat(FHIR_NDJSON_CONTENT_TYPE);
         job.setCreatedAt(OffsetDateTime.now());
         job.setFhirVersion(R4V3);
-        job.setContractNumber(CONTRACT);
+        job.setContractNumber(contractNumber);
 
         job = jobRepository.saveAndFlush(job);
         addJobForCleanup(job);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeConcurrentItemIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeConcurrentItemIntegrationTest.java
@@ -93,8 +93,8 @@ class PrototypeConcurrentItemIntegrationTest extends AbstractPrototypeRecoveryIn
 
         assertTrue(new HashSet<>(threadNames).size() > 1,
                 "expected more than one worker thread to serve the partition, saw " + new HashSet<>(threadNames));
-        assertTrue(threadNames.stream().allMatch(name -> name.startsWith("proto-item-")),
-                "bene work should run on the prototype item executor");
+        assertTrue(threadNames.stream().allMatch(name -> name.startsWith("pcp-")),
+                "bene work should run on the shared patient claims pool");
     }
 
     @Test


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7408

## 🛠 Changes

The async executor was switched to match what the current processor uses, so we get it's async processing and usage of the round robin queue. The PrototypeItemTaskExecutor essentially just delegates the task off to the original queue while handling the round robin queue's submission quirk.

## ℹ️ Context

This brings the prototype in line with the current processor in terms of working on multiple jobs at the same time, and using the round robin queue to work on jobs fairly.

## 🧪 Validation

Tested locally by running multiple jobs of different sizes on the same worker.
