### PR TITLE
AB2D-7395 Use batched inserts for daily IDR <-> worker sync

### DIFF
--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -296,10 +296,12 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             audit.log(action, null, contract, null, Map.of("rowsInserted", rowsInserted));
         } catch (Exception e) {
             /**
-             * if {@link #batchCopyFromStagingToCoverage} throws an exception, it will record an audit event
-             * rethrow exception to rollback transaction
+             * If {@link #batchCopyFromStagingToCoverage} throws an exception, it will record an audit event
+             * If this step fails, there may be incomplete attribution data copied from staging to the recent coverage
+             * table. The sync will be re-attempted the next time the cron job fires OR when a job is run, so this
+             * will correct itself eventually
              */
-           throw e;
+            return SYNC_FAILED_FOR_CONTRACT;
         }
 
         val rowsInCoverageAfterCopy = executeTimedQuery(
@@ -312,11 +314,11 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         if (rowsInStaging != rowsInCoverageAfterCopy) {
             log.error("[V3] Row count in staging ({}) != row count in coverage ({}) for contract {}",
                     rowsInStaging,
-                    rowsInCoverageBeforeCopy,
+                    rowsInCoverageAfterCopy,
                     contract
             );
             result = SYNC_FAILED_FOR_CONTRACT;
-            audit.log(action, result, contract, "rowsInStaging does not match rowsInCoverageBeforeCopy", Map.of("rowsInStaging", rowsInStaging, "rowsInCoverageBeforeCopy", rowsInCoverageBeforeCopy));
+            audit.log(action, result, contract, "rowsInStaging does not match rowsInCoverageAfterCopy", Map.of("rowsInStaging", rowsInStaging, "rowsInCoverageAfterCopy", rowsInCoverageAfterCopy));
             metrics.recordImport(source, contract, result, rowsInStaging, rowsInCoverageBeforeCopy, rowsInCoverageAfterCopy);
             return result;
         }
@@ -486,7 +488,6 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                 rs.getLong(3)
             );
         });
-
 
         var rowsInsertedTotal = 0;
         for (Map.Entry<YearMonthRecord, Long> entry : periodCountByMonth.entrySet()) {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 
+import java.time.YearMonth;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -486,32 +487,22 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             );
         });
 
-        val insertRowsByMonth = """
-        with inserted_rows as (
-            insert into %s select * from %s
-            where contract = :contract and year = :year and month = :month
-            returning *
-        )
-        select count(*) from inserted_rows;
-        """.formatted(COVERAGE_V3_TABLE_RECENT, COVERAGE_V3_STAGING_TABLE);
 
         var rowsInsertedTotal = 0;
         for (Map.Entry<YearMonthRecord, Long> entry : periodCountByMonth.entrySet()) {
+            val rowsInsertedForMonth = batchCopyFromStagingToCoverage(template, contract, entry.getKey());
+            rowsInsertedTotal += rowsInsertedForMonth;
+
             val year = entry.getKey().getYear();
             val month = entry.getKey().getMonth();
             val rowCountForMonth = entry.getValue();
-
-            val parameters = Map.of("contract", contract, "year", year, "month", month);
-            val rowsInsertedForMonth = DataAccessUtils.intResult(template.queryForList(insertRowsByMonth, parameters, Integer.class));
-            rowsInsertedTotal += rowsInsertedForMonth;
-
             val yearMonthToString = "%s-%s".formatted(year, month);
             if (rowsInsertedForMonth != rowCountForMonth) {
                 audit.log(
                     COPY_FROM_STAGING,
                     SYNC_FAILED_FOR_CONTRACT,
                     contract,
-                    "rowsInsertedForMonth does not match expectedRowsInsertedTotal",
+                    "rowsInsertedForMonth does not match rowCountForMonth",
                     Map.of(
                         "rowsInsertedForMonth", rowsInsertedForMonth,
                         "rowCountForMonth", rowCountForMonth,
@@ -530,6 +521,23 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         }
 
         return rowsInsertedTotal;
+    }
+
+    int batchCopyFromStagingToCoverage(NamedParameterJdbcTemplate template, String contract, YearMonthRecord yearMonthPeriod) {
+        val year = yearMonthPeriod.getYear();
+        val month = yearMonthPeriod.getMonth();
+
+        val insertRowsByMonth = """
+        with inserted_rows as (
+            insert into %s select * from %s
+            where contract = :contract and year = :year and month = :month
+            returning *
+        )
+        select count(*) from inserted_rows;
+        """.formatted(COVERAGE_V3_TABLE_RECENT, COVERAGE_V3_STAGING_TABLE);
+
+        val parameters = Map.of("contract", contract, "year", year, "month", month);
+        return DataAccessUtils.intResult(template.queryForList(insertRowsByMonth, parameters, Integer.class));
     }
 
     int moveToHistoricalInternal(final String contract) {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -8,13 +8,9 @@ import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.ResultSetExtractor;
-import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -22,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -511,7 +505,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             val rowsInsertedForMonth = DataAccessUtils.intResult(template.queryForList(insertRowsByMonth, parameters, Integer.class));
             rowsInsertedTotal += rowsInsertedForMonth;
 
-            val periodToString = "%s-%s".formatted(year, month);
+            val yearMonthToString = "%s-%s".formatted(year, month);
             if (rowsInsertedForMonth != rowCountForMonth) {
                 audit.log(
                     COPY_FROM_STAGING,
@@ -521,7 +515,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                     Map.of(
                         "rowsInsertedForMonth", rowsInsertedForMonth,
                         "rowCountForMonth", rowCountForMonth,
-                        "period", periodToString
+                        "period", yearMonthToString
                     )
                 );
 
@@ -529,9 +523,9 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
                     rowsInsertedForMonth,
                     rowCountForMonth,
                     contract,
-                    periodToString
+                    yearMonthToString
                 );
-                throw new RuntimeException("batchCopyFromStagingToCoverage failed: rowsInsertedTotal != expectedRowsInsertedTotal");
+                throw new RuntimeException("batchCopyFromStagingToCoverage failed: rowsInsertedForMonth != rowCountForMonth");
             }
         }
 

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -3,13 +3,18 @@ package gov.cms.ab2d.coverage.service.v3;
 import datadog.trace.api.Trace;
 import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.common.util.DatadogSpans;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditAction;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -17,6 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -284,12 +292,18 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         audit.log(action, null, contract, null, Map.of("rowsInCoverageDeleted", rowsInCoverageDeleted));
 
         log.info("[V3] Preparing to copy rows from staging to coverage for contract {}...", contract);
-        val rowsInserted = executeTimedQuery(
-                format("[V3] copyFromStagingToCoverage contract=%s", contract),
-                () -> copyFromStagingToCoverage(contract)
-        );
-        log.info("[V3] Copied {} rows from staging to coverage for contract {}", rowsInserted, contract);
-        audit.log(action, null, contract, null, Map.of("rowsInserted", rowsInserted));
+        try {
+            val rowsInserted = executeTimedQuery(
+                format("[V3] batchCopyFromStagingToCoverage contract=%s", contract),
+                () -> batchCopyFromStagingToCoverage(contract)
+            );
+            log.info("[V3] Copied {} rows from staging to coverage for contract {}", rowsInserted, contract);
+            audit.log(action, null, contract, null, Map.of("rowsInserted", rowsInserted));
+        } catch (Exception e) {
+            /** if an exception is thrown, {@link #batchCopyFromStagingToCoverage} will record an audit event */
+           throw e;
+        }
+
 
         val rowsInCoverageAfterCopy = executeTimedQuery(
                 format("[V3] getCoveragePeriodCountForCoverageV3 contract=%s", contract),
@@ -450,8 +464,76 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         return executeQueryForContract(contract, formattedQuery);
     }
 
+    @Deprecated
+    // Replaced by batchCopyFromStagingToCoverage
     int copyFromStagingToCoverage(final String contract) {
         return executeQueryForContract(contract, COPY_FROM_STAGING_TO_COVERAGE_V3);
+    }
+
+    // Copy from staging to recent coverage for the given contract one month at a time
+    int batchCopyFromStagingToCoverage(final String contract) {
+        val template = new NamedParameterJdbcTemplate(this.dataSource);
+
+        val queryPeriodCountByMonth =
+        """
+        SELECT year, month, count(*)
+        FROM v3.coverage_v3
+        WHERE contract = :contract
+        GROUP BY contract, month, year
+        """;
+
+        val periodCountByMonth = new HashMap<YearMonthRecord, Long>();
+        template.query(queryPeriodCountByMonth, Map.of(contract, contract), rs -> {
+            periodCountByMonth.put(
+                new YearMonthRecord(rs.getInt(1), rs.getInt(2)),
+                rs.getLong(3)
+            );
+        });
+
+        val insertRowsByMonth = """
+        with inserted_rows as (
+            insert into %s select * from %s
+            where contract = :contract and year = :year and month = :month
+            returning *
+        )
+        select count(*) from inserted_rows;
+        """.formatted(COVERAGE_V3_TABLE_RECENT, COVERAGE_V3_STAGING_TABLE);
+
+        var rowsInsertedTotal = 0;
+        for (Map.Entry<YearMonthRecord, Long> entry : periodCountByMonth.entrySet()) {
+            val year = entry.getKey().getYear();
+            val month = entry.getKey().getMonth();
+            val rowCountForMonth = entry.getValue();
+
+            val parameters = Map.of("contract", contract, "year", year, "month", month);
+            val rowsInsertedForMonth = DataAccessUtils.intResult(template.queryForList(insertRowsByMonth, parameters, Integer.class));
+            rowsInsertedTotal += rowsInsertedForMonth;
+
+            val periodToString = "%s-%s".formatted(year, month);
+            if (rowsInsertedForMonth != rowCountForMonth) {
+                audit.log(
+                    COPY_FROM_STAGING,
+                    SYNC_FAILED_FOR_CONTRACT,
+                    contract,
+                    "rowsInsertedForMonth does not match expectedRowsInsertedTotal",
+                    Map.of(
+                        "rowsInsertedForMonth", rowsInsertedForMonth,
+                        "rowCountForMonth", rowCountForMonth,
+                        "period", periodToString
+                    )
+                );
+
+                log.error("rowsInsertedForMonth ({}) does not match rowCountForMonth({}) for contract {} and period {}",
+                    rowsInsertedForMonth,
+                    rowCountForMonth,
+                    contract,
+                    periodToString
+                );
+                throw new RuntimeException("batchCopyFromStagingToCoverage failed: rowsInsertedTotal != expectedRowsInsertedTotal");
+            }
+        }
+
+        return rowsInsertedTotal;
     }
 
     int moveToHistoricalInternal(final String contract) {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -479,10 +479,10 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         val queryPeriodCountByMonth =
         """
         SELECT year, month, count(*)
-        FROM v3.coverage_v3
+        FROM %s
         WHERE contract = :contract
         GROUP BY contract, month, year
-        """;
+        """.formatted(COVERAGE_V3_STAGING_TABLE);
 
         val periodCountByMonth = new HashMap<YearMonthRecord, Long>();
         template.query(queryPeriodCountByMonth, Map.of("contract", contract), rs -> {

--- a/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
+++ b/coverage/src/main/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImpl.java
@@ -300,10 +300,12 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
             log.info("[V3] Copied {} rows from staging to coverage for contract {}", rowsInserted, contract);
             audit.log(action, null, contract, null, Map.of("rowsInserted", rowsInserted));
         } catch (Exception e) {
-            /** if an exception is thrown, {@link #batchCopyFromStagingToCoverage} will record an audit event */
+            /**
+             * if {@link #batchCopyFromStagingToCoverage} throws an exception, it will record an audit event
+             * rethrow exception to rollback transaction
+             */
            throw e;
         }
-
 
         val rowsInCoverageAfterCopy = executeTimedQuery(
                 format("[V3] getCoveragePeriodCountForCoverageV3 contract=%s", contract),
@@ -483,7 +485,7 @@ public class CoverageV3SyncServiceImpl  implements CoverageV3SyncService {
         """;
 
         val periodCountByMonth = new HashMap<YearMonthRecord, Long>();
-        template.query(queryPeriodCountByMonth, Map.of(contract, contract), rs -> {
+        template.query(queryPeriodCountByMonth, Map.of("contract", contract), rs -> {
             periodCountByMonth.put(
                 new YearMonthRecord(rs.getInt(1), rs.getInt(2)),
                 rs.getLong(3)

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -353,7 +353,7 @@ class CoverageV3SyncServiceImplTest {
 		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
 		when(lock.tryLock()).thenReturn(true);
 
-		assertThrows(RuntimeException.class, () -> service.copyFromStagingTablesToRecent("Z5555", CoverageV3SyncSource.CRON_JOB));
+		service.copyFromStagingTablesToRecent("Z5555", CoverageV3SyncSource.CRON_JOB);
 
 		assertTrue(out.getOut().contains("rowsInsertedForMonth (0) does not match rowCountForMonth(2) for contract Z5555 and period 2026-2"));
 

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -307,7 +307,7 @@ class CoverageV3SyncServiceImplTest {
 	}
 
 	@Test
-	void testBatchCopy_SimulateDataIntegrityError(CapturedOutput out) {
+	void testBatchCopy_SimulateSyncFailure(CapturedOutput out) {
 		 new JdbcTemplate(container.getDataSource()).execute(
 		"""
 		INSERT INTO v3.coverage_v3_staging(patient_id, contract, "year", "month", current_mbi)

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -7,6 +7,7 @@ import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLogImpl;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -240,6 +241,8 @@ class CoverageV3SyncServiceImplTest {
 
 
 	@Test
+	@Disabled
+	// TODO Revert
 	void copyFromStagingTablesToRecent_SourceJobHandler() {
 		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
 		when(lock.tryLock()).thenReturn(true);

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -1,17 +1,14 @@
 package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
-import gov.cms.ab2d.common.util.DatadogSpans;
 import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLogImpl;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -27,7 +24,6 @@ import static gov.cms.ab2d.common.util.PropertyConstants.*;
 import static gov.cms.ab2d.coverage.service.v3.CoverageV3SyncResult.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @Testcontainers

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -2,6 +2,7 @@ package gov.cms.ab2d.coverage.service.v3;
 
 import gov.cms.ab2d.common.properties.PropertiesService;
 import gov.cms.ab2d.coverage.CoverageV3PostgresContainer;
+import gov.cms.ab2d.coverage.model.YearMonthRecord;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLog;
 import gov.cms.ab2d.coverage.service.v3.audit.CoverageV3AuditLogImpl;
 import lombok.val;
@@ -13,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -302,6 +304,63 @@ class CoverageV3SyncServiceImplTest {
 
 		assertTrue(service.isContractAttested("ATT1"));
 		System.out.println();
+	}
+
+	@Test
+	void testBatchCopy_SimulateDataIntegrityError(CapturedOutput out) {
+		 new JdbcTemplate(container.getDataSource()).execute(
+		"""
+		INSERT INTO v3.coverage_v3_staging(patient_id, contract, "year", "month", current_mbi)
+		VALUES
+		    (100, 'Z5555', 2025, 12, 'M100'),
+		    (100, 'Z5555', 2026, 1,  'M100'),
+		    (100, 'Z5555', 2026, 2,  'M100'),
+		    (100, 'Z5555', 2026, 3,  'M100'),
+		    (200, 'Z5555', 2025, 12, 'M100'),
+		    (200, 'Z5555', 2026, 1,  'M200'),
+		    (200, 'Z5555', 2026, 2,  'M200'),
+		    (200, 'Z5555', 2026, 3,  'M200')
+		""");
+
+		service = new CoverageV3SyncServiceImpl(
+				container.getDataSource(),
+				lockWrapper,
+				lockWrapper,
+				audit,
+				metrics,
+				propertiesService
+		) {
+			@Override
+			boolean isTestContract(String contract) {
+				return false;
+			}
+
+			@Override
+			boolean isContractAttested(String contract) {
+				return true;
+			}
+
+			@Override
+			int batchCopyFromStagingToCoverage(NamedParameterJdbcTemplate template, String contract, YearMonthRecord yearMonthPeriod) {
+				if (yearMonthPeriod.getMonth() == 2 && yearMonthPeriod.getYear() == 2026) {
+					return 0;
+				}
+				return super.batchCopyFromStagingToCoverage(template, contract, yearMonthPeriod);
+			}
+		};
+
+		when(propertiesService.isToggleOn(V3_AUDIT_LOGGING_ENABLED, false)).thenReturn(true);
+		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
+		when(lock.tryLock()).thenReturn(true);
+
+		assertThrows(RuntimeException.class, () -> service.copyFromStagingTablesToRecent("Z5555", CoverageV3SyncSource.CRON_JOB));
+
+		assertTrue(out.getOut().contains("rowsInsertedForMonth (0) does not match rowCountForMonth(2) for contract Z5555 and period 2026-2"));
+
+		assertAuditLogEquals(getAuditLogs().get(3),
+		"""
+		{action=COPY_FROM_STAGING, result=SYNC_FAILED_FOR_CONTRACT, contract=Z5555, log=rowsInsertedForMonth does not match rowCountForMonth, data={"period": "2026-2", "rowCountForMonth": 2, "rowsInsertedForMonth": 0}}
+		""");
 	}
 
 	void assertAuditLogEquals(Map<String, Object> result, String string) {

--- a/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
+++ b/coverage/src/test/java/gov/cms/ab2d/coverage/service/v3/CoverageV3SyncServiceImplTest.java
@@ -241,8 +241,6 @@ class CoverageV3SyncServiceImplTest {
 
 
 	@Test
-	@Disabled
-	// TODO Revert
 	void copyFromStagingTablesToRecent_SourceJobHandler() {
 		when(lockWrapper.getCoverageLock(any())).thenReturn(lock);
 		when(lock.tryLock()).thenReturn(true);


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7395

## 🛠 Changes

Use batched inserts for daily IDR <-> worker sync

## ℹ️ Context

Our largest contract has 8.8 million beneficiaries for each year-month period in the staging table. 

For syncing attribution data from staging to the recent coverage table, inserts are now done for each year-month period at a time (8.8 million) instead of all (26.7 million).

<img width="237" height="101" alt="image" src="https://github.com/user-attachments/assets/9df55138-2cc2-4d4f-897c-ce6dd6ac6855" />


## 🧪 Validation

Existing tests pass and added a new test to simulate a sync failure.  
