### PR TITLE
AB2D-7374 Crash/fault injection for the pause-resume prototype worker

### DIFF
--- a/docs/prototype-crash-testing.md
+++ b/docs/prototype-crash-testing.md
@@ -1,0 +1,92 @@
+# Prototype crash testing runbook
+
+The pause/resume prototype worker has recovery paths for crashes at each stage of a job
+(partitioning, reading, processing, file writing, assembly). Unit and integration tests cover these
+in-process. This runbook is for the other half: proving a **deployed** worker container recovers from a
+real crash without corrupting or duplicating output.
+
+Crash injection is off by default and is only meant for `dev`/`test`. **Never arm it in prod.**
+
+## How the injector works
+
+`CrashInjector` halts the JVM (`Runtime.getRuntime().halt(137)`) at a chosen pipeline point, so the
+container dies exactly like a real crash - no shutdown hooks, no cleanup. It is controlled by two
+properties:
+
+| Property | Env var | Meaning |
+| --- | --- | --- |
+| `pause-resume.prototype.crash-probability` | `PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY` | Chance (0-1) of crashing each time the armed point is hit. `0` = off. |
+| `pause-resume.prototype.crash-at` | `PAUSE_RESUME_PROTOTYPE_CRASH_AT` | Which point crashes: `process`, `read`, `write`, or `assemble`. |
+
+A small probability (e.g. `0.01`) crashes somewhere in the middle of a large job, which is the
+interesting case for recovery. `1.0` crashes at the first opportunity.
+
+## Option A: crash the worker from the inside (injector)
+
+Use this to test a crash at a specific pipeline stage.
+
+1. Point the worker task at a crash stage and probability. In `dev` you can set these as env vars on the
+   worker ECS task definition (they flow into Spring via relaxed binding - no code change needed):
+
+   ```
+   PAUSE_RESUME_PROTOTYPE_CRASH_AT=write
+   PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY=0.02
+   ```
+
+2. Redeploy the worker so the new task definition is live.
+3. Submit a job large enough to span several chunks.
+4. Watch the task die and ECS start a replacement. The replacement picks the job back up (hard recovery:
+   new lease token, new files) and finishes it.
+5. **Reset `PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY=0` and redeploy** when you are done.
+
+Repeat with `crash-at=read`, `process`, and `assemble` to exercise each stage.
+
+## Option B: crash the container from the outside (AWS FIS / ECS)
+
+Use this to test an infrastructure-level kill (task stopped mid-job) rather than a specific stage.
+
+- **AWS FIS**: run an experiment with the `aws:ecs:stop-task` action targeting a running worker task
+  while a job is in progress.
+- **Manual equivalent**: find the running task and stop it:
+
+  ```
+  aws ecs list-tasks --cluster <worker-cluster> --service-name <worker-service>
+  aws ecs stop-task --cluster <worker-cluster> --task <task-arn> --reason "crash recovery test"
+  ```
+
+ECS replaces the task; the replacement recovers the in-flight job the same way.
+
+## Watch it in the logs
+
+The crash/recovery lifecycle is logged with greppable markers so you can follow it end to end. In order,
+you should see:
+
+| Marker | What it means |
+| --- | --- |
+| `CRASH-INJECTION ARMED at '<point>'` | the worker started in crash-test mode (logged once at startup) |
+| `CRASH-INJECTION firing at '<point>'` | the crash just happened - the worker is halting (exit 137) |
+| `RECOVERY for job <uuid>: HARD RECOVERY` | a replacement worker fenced the dead one and is redoing incomplete partitions |
+| `finished with status COMPLETED` | the job's batch run completed on the replacement |
+| `assembly for job <uuid>: ... new JobOutput row(s)` | the final output was assembled and delivered |
+
+A quick way to pull the whole story for a job:
+
+```
+grep -E "CRASH-INJECTION|RECOVERY for job|finished with status|assembly for job" <worker-logs>
+```
+
+(A graceful shutdown logs `SOFT RESUME` instead of `HARD RECOVERY` - same job, no lost work, resumed
+from the last checkpoint.)
+
+## What to verify after recovery
+
+For the job that was interrupted:
+
+- Job status ends `SUCCESSFUL` (not stuck `IN_PROGRESS` or `FAILED`).
+- Output has **every beneficiary exactly once** - no missing benes, no duplicates.
+- No torn lines in the output files (every line is a complete resource).
+- No duplicate `job_output` rows for the job.
+
+These are the same guarantees the integration tests assert
+(`assertEveryBeneExactlyOnceInOutput` and the crash-point tests); this runbook confirms they hold on a
+real container too.

--- a/docs/prototype-crash-testing.md
+++ b/docs/prototype-crash-testing.md
@@ -1,35 +1,33 @@
 # Prototype crash testing runbook
 
-The pause/resume prototype worker has recovery paths for crashes at each stage of a job
-(partitioning, reading, processing, file writing, assembly). Unit and integration tests cover these
-in-process. This runbook is for the other half: proving a **deployed** worker container recovers from a
-real crash without corrupting or duplicating output.
+The pause/resume prototype worker recovers from a crash while reading, processing, writing, or assembling
+a job (partitioning has no resume - it just re-runs from scratch on restart). Unit and integration tests
+cover these in-process. This runbook is for the other half: proving a deployed worker container recovers
+from a real crash without corrupting or duplicating output.
 
-Crash injection is off by default and is only meant for `dev`/`test`. As a backstop the injector reads
-`execution.env` and **refuses to arm in prod or sandbox** even if the properties are set, so it can only
-ever crash a dev/test worker.
+Crash injection is off by default and is only meant for dev/test. As a backstop the injector reads
+'execution.env' and only arms in dev/test/local - it denies prod, sandbox, and any env it doesn't
+recognise, so a misconfigured value fails closed and can never crash a real environment.
 
 ## How the injector works
 
-`CrashInjector` halts the JVM (`Runtime.getRuntime().halt(137)`) at a chosen pipeline point, so the
-container dies exactly like a real crash - no shutdown hooks, no cleanup. It is controlled by two
-properties:
+CrashInjector halts the JVM (Runtime.getRuntime().halt(137)) at a chosen pipeline point, so the container
+dies exactly like a real crash - no shutdown hooks, no cleanup. It is controlled by two properties:
 
-| Property | Env var | Meaning |
-| --- | --- | --- |
-| `pause-resume.prototype.crash-probability` | `PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY` | Chance (0-1) of crashing each time the armed point is hit. `0` = off. |
-| `pause-resume.prototype.crash-at` | `PAUSE_RESUME_PROTOTYPE_CRASH_AT` | Which point crashes: `process`, `read`, `write`, or `assemble`. |
+- 'pause-resume.prototype.crash-probability' (env 'PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY') - chance
+  0-1 of crashing each time the armed point is hit. 0 = off.
+- 'pause-resume.prototype.crash-at' (env 'PAUSE_RESUME_PROTOTYPE_CRASH_AT') - which point crashes:
+  process, read, write, or assemble.
 
-An unrecognised `crash-at`, or a prod/sandbox `execution.env`, leaves the injector disarmed and logs why.
-
-A small probability (e.g. `0.01`) crashes somewhere in the middle of a large job, which is the
-interesting case for recovery. `1.0` crashes at the first opportunity.
+An unrecognised crash-at, or an execution.env that isn't dev/test/local, leaves the injector disarmed and
+logs why. A small probability like 0.01 crashes somewhere in the middle of a large job, which is the
+interesting case for recovery. 1.0 crashes at the first opportunity.
 
 ## Option A: crash the worker from the inside (injector)
 
 Use this to test a crash at a specific pipeline stage.
 
-1. Point the worker task at a crash stage and probability. In `dev` you can set these as env vars on the
+1. Point the worker task at a crash stage and probability. In dev you can set these as env vars on the
    worker ECS task definition (they flow into Spring via relaxed binding - no code change needed):
 
    ```
@@ -41,17 +39,17 @@ Use this to test a crash at a specific pipeline stage.
 3. Submit a job large enough to span several chunks.
 4. Watch the task die and ECS start a replacement. The replacement picks the job back up (hard recovery:
    new lease token, new files) and finishes it.
-5. **Reset `PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY=0` and redeploy** when you are done.
+5. Reset PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY=0 and redeploy when you are done.
 
-Repeat with `crash-at=read`, `process`, and `assemble` to exercise each stage.
+Repeat with crash-at=read, process, and assemble to exercise each stage.
 
 ## Option B: crash the container from the outside (AWS FIS / ECS)
 
 Use this to test an infrastructure-level kill (task stopped mid-job) rather than a specific stage.
 
-- **AWS FIS**: run an experiment with the `aws:ecs:stop-task` action targeting a running worker task
-  while a job is in progress.
-- **Manual equivalent**: find the running task and stop it:
+- AWS FIS: run an experiment with the 'aws:ecs:stop-task' action targeting a running worker task while a
+  job is in progress.
+- Manual equivalent: find the running task and stop it:
 
   ```
   aws ecs list-tasks --cluster <worker-cluster> --service-name <worker-service>
@@ -65,13 +63,12 @@ ECS replaces the task; the replacement recovers the in-flight job the same way.
 The crash/recovery lifecycle is logged with greppable markers so you can follow it end to end. In order,
 you should see:
 
-| Marker | What it means |
-| --- | --- |
-| `CRASH-INJECTION ARMED at '<point>'` | the worker started in crash-test mode (logged once at startup) |
-| `CRASH-INJECTION firing at '<point>'` | the crash just happened - the worker is halting (exit 137) |
-| `prototype job <uuid> starting ... as a hard claim` | a replacement worker took over and is redoing incomplete partitions |
-| `finished with status COMPLETED` | the job's batch run completed on the replacement |
-| `assembly for job <uuid>: ... new JobOutput row(s)` | the final output was assembled and delivered |
+- CRASH-INJECTION ARMED at '<point>' - the worker started in crash-test mode (logged once at startup).
+- CRASH-INJECTION firing at '<point>' - the crash just happened, the worker is halting (exit 137).
+- prototype job <uuid> starting ... as a hard claim - a replacement worker took over and is redoing
+  incomplete partitions.
+- finished with status COMPLETED - the job's batch run completed on the replacement.
+- assembly for job <uuid>: ... new JobOutput row(s) - the final output was assembled and delivered.
 
 A quick way to pull the whole story for a job:
 
@@ -79,18 +76,17 @@ A quick way to pull the whole story for a job:
 grep -E "CRASH-INJECTION|starting for contract|finished with status|assembly for job" <worker-logs>
 ```
 
-(A graceful shutdown claims the job as a `soft` resume instead of a `hard` one - same job, no lost work,
-resumed from the last checkpoint.)
+A graceful shutdown claims the job as a soft resume instead of a hard one - same job, no lost work,
+resumed from the last checkpoint.
 
 ## What to verify after recovery
 
 For the job that was interrupted:
 
-- Job status ends `SUCCESSFUL` (not stuck `IN_PROGRESS` or `FAILED`).
-- Output has **every beneficiary exactly once** - no missing benes, no duplicates.
+- Job status ends SUCCESSFUL (not stuck IN_PROGRESS or FAILED).
+- Output has every beneficiary exactly once - no missing benes, no duplicates.
 - No torn lines in the output files (every line is a complete resource).
-- No duplicate `job_output` rows for the job.
+- No duplicate job_output rows for the job.
 
-These are the same guarantees the integration tests assert
-(`assertEveryBeneExactlyOnceInOutput` and the crash-point tests); this runbook confirms they hold on a
-real container too.
+These are the same guarantees the integration tests assert (assertEveryBeneExactlyOnceInOutput and the
+crash-point tests); this runbook confirms they hold on a real container too.

--- a/docs/prototype-crash-testing.md
+++ b/docs/prototype-crash-testing.md
@@ -5,7 +5,9 @@ The pause/resume prototype worker has recovery paths for crashes at each stage o
 in-process. This runbook is for the other half: proving a **deployed** worker container recovers from a
 real crash without corrupting or duplicating output.
 
-Crash injection is off by default and is only meant for `dev`/`test`. **Never arm it in prod.**
+Crash injection is off by default and is only meant for `dev`/`test`. As a backstop the injector reads
+`execution.env` and **refuses to arm in prod or sandbox** even if the properties are set, so it can only
+ever crash a dev/test worker.
 
 ## How the injector works
 
@@ -17,6 +19,8 @@ properties:
 | --- | --- | --- |
 | `pause-resume.prototype.crash-probability` | `PAUSE_RESUME_PROTOTYPE_CRASH_PROBABILITY` | Chance (0-1) of crashing each time the armed point is hit. `0` = off. |
 | `pause-resume.prototype.crash-at` | `PAUSE_RESUME_PROTOTYPE_CRASH_AT` | Which point crashes: `process`, `read`, `write`, or `assemble`. |
+
+An unrecognised `crash-at`, or a prod/sandbox `execution.env`, leaves the injector disarmed and logs why.
 
 A small probability (e.g. `0.01`) crashes somewhere in the middle of a large job, which is the
 interesting case for recovery. `1.0` crashes at the first opportunity.
@@ -65,18 +69,18 @@ you should see:
 | --- | --- |
 | `CRASH-INJECTION ARMED at '<point>'` | the worker started in crash-test mode (logged once at startup) |
 | `CRASH-INJECTION firing at '<point>'` | the crash just happened - the worker is halting (exit 137) |
-| `RECOVERY for job <uuid>: HARD RECOVERY` | a replacement worker fenced the dead one and is redoing incomplete partitions |
+| `prototype job <uuid> starting ... as a hard claim` | a replacement worker took over and is redoing incomplete partitions |
 | `finished with status COMPLETED` | the job's batch run completed on the replacement |
 | `assembly for job <uuid>: ... new JobOutput row(s)` | the final output was assembled and delivered |
 
 A quick way to pull the whole story for a job:
 
 ```
-grep -E "CRASH-INJECTION|RECOVERY for job|finished with status|assembly for job" <worker-logs>
+grep -E "CRASH-INJECTION|starting for contract|finished with status|assembly for job" <worker-logs>
 ```
 
-(A graceful shutdown logs `SOFT RESUME` instead of `HARD RECOVERY` - same job, no lost work, resumed
-from the last checkpoint.)
+(A graceful shutdown claims the job as a `soft` resume instead of a `hard` one - same job, no lost work,
+resumed from the last checkpoint.)
 
 ## What to verify after recovery
 

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> {
 
     private final CoverageV3Service coverageV3Service;
+    private final CrashInjector crashInjector;
     private final String contract;
     private final long startPatientId; // exclusive lower bound of this partition
     private final long endPatientId;   // inclusive upper bound of this partition
@@ -38,12 +39,14 @@ public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> 
 
     public BeneficiaryItemReader(
             CoverageV3Service coverageV3Service,
+            CrashInjector crashInjector,
             @Value("#{stepExecutionContext['contractNumber']}") String contract,
             @Value("#{stepExecutionContext['startPatientId']}") long startPatientId,
             @Value("#{stepExecutionContext['endPatientId']}") long endPatientId,
             @Value("#{jobParameters['fenceToken']}") long fenceToken,
             @Value("${eob.job.patient.queue.page.size}") int pageSize) {
         this.coverageV3Service = coverageV3Service;
+        this.crashInjector = crashInjector;
         this.contract = contract;
         this.startPatientId = startPatientId;
         this.endPatientId = endPatientId;
@@ -68,6 +71,7 @@ public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> 
 
     @Override
     public CoverageSummary read() {
+        crashInjector.maybeCrash("read");
         while (buffer.isEmpty() && !exhausted) {
             fetchNextPage();
         }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/BeneficiaryItemReader.java
@@ -71,7 +71,7 @@ public class BeneficiaryItemReader implements ItemStreamReader<CoverageSummary> 
 
     @Override
     public CoverageSummary read() {
-        crashInjector.maybeCrash("read");
+        crashInjector.maybeCrash(CrashPoint.READ);
         while (buffer.isEmpty() && !exhausted) {
             fetchNextPage();
         }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -7,10 +7,6 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Dev-only crash injection so we can exercise the worker's recovery paths in a real, deployed
- * container. It is off unless crash-probability is set above zero, so it does nothing in normal
- * operation.
- *
  * crash-at picks which point in the pipeline dies (process, read, write, assemble) so a run can be
  * crashed one stage at a time. This is deliberately blunt - it halts the JVM, so the worker dies
  * exactly like a real crash with no shutdown hooks or cleanup. See docs/prototype-crash-testing.md.

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -1,0 +1,52 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Dev-only crash injection so we can exercise the worker's recovery paths in a real, deployed
+ * container. It is off unless crash-probability is set above zero, so it does nothing in normal
+ * operation.
+ *
+ * crash-at picks which point in the pipeline dies (process, read, write, assemble) so a run can be
+ * crashed one stage at a time. This is deliberately blunt - it halts the JVM, so the worker dies
+ * exactly like a real crash with no shutdown hooks or cleanup. See docs/prototype-crash-testing.md.
+ */
+@Slf4j
+@Component
+public class CrashInjector {
+
+    private final String crashAt;
+    private final double crashProbability;
+
+    public CrashInjector(
+            @Value("${pause-resume.prototype.crash-at:process}") String crashAt,
+            @Value("${pause-resume.prototype.crash-probability:0}") double crashProbability) {
+        this.crashAt = crashAt == null ? "" : crashAt.trim();
+        this.crashProbability = crashProbability;
+        if (crashProbability > 0) {
+            // Loud on purpose: if you see this in a deployed worker's logs, it is going to crash itself.
+            log.warn("CRASH-INJECTION ARMED at '{}' with probability {} - this worker will halt itself, "
+                    + "FOR RECOVERY TESTING ONLY", this.crashAt, crashProbability);
+        }
+    }
+
+    /** Halt the worker if injection is armed for this point. A no-op unless crash-probability is set. */
+    public void maybeCrash(String point) {
+        if (crashProbability <= 0 || !crashAt.equalsIgnoreCase(point)) {
+            return;
+        }
+        if (ThreadLocalRandom.current().nextDouble() < crashProbability) {
+            halt(point);
+        }
+    }
+
+    /** Split out from the decision so tests can check what would fire without killing the JVM. */
+    void halt(String point) {
+        log.error("CRASH-INJECTION firing at '{}': halting worker now (exit 137) to test recovery", point);
+        Runtime.getRuntime().halt(137);
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -6,11 +6,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Dev/test-only crash injection for exercising the worker's recovery paths on a real deployed container.
- * Off unless crash-probability is set, and it refuses to arm in prod or sandbox. crash-at picks which
+ * Off unless crash-probability is set, and it only arms in dev/test/local. crash-at picks which
  * {@link CrashPoint} in the pipeline dies, so a run can be crashed one stage at a time. Deliberately blunt
  * - it halts the JVM, so the worker dies like a real crash with no cleanup. See docs/prototype-crash-testing.md.
  */
@@ -31,24 +32,31 @@ public class CrashInjector {
         this.crashAt = point.orElse(null);
 
         boolean requested = crashProbability > 0;
-        boolean protectedEnv = isProtectedEnv(executionEnv);
+        boolean safeEnv = isSafeEnv(executionEnv);
         if (requested && point.isEmpty()) {
             log.warn("CRASH-INJECTION disabled: crash-at '{}' is not one of {}", crashAt, Arrays.toString(CrashPoint.values()));
         }
-        if (requested && protectedEnv) {
-            log.warn("CRASH-INJECTION disabled: refusing to arm in '{}', crash testing is for dev/test only", executionEnv);
+        if (requested && !safeEnv) {
+            log.warn("CRASH-INJECTION disabled: refusing to arm in '{}', crash testing only runs in dev/test/local", executionEnv);
         }
 
-        this.armed = requested && point.isPresent() && !protectedEnv;
+        this.armed = requested && point.isPresent() && safeEnv;
         if (armed) {
             log.warn("CRASH-INJECTION ARMED at '{}' with probability {} - this worker will halt itself, "
                     + "FOR RECOVERY TESTING ONLY", this.crashAt.configValue(), crashProbability);
         }
     }
 
-    private static boolean isProtectedEnv(String executionEnv) {
-        String env = executionEnv == null ? "" : executionEnv.toLowerCase();
-        return env.contains("prod") || env.contains("sandbox");
+    // Only dev, test (deployed as ab2d-east-impl), and local may crash. Anything else - prod, sandbox, or
+    // an env we don't recognise - is denied, so a bad or missing value fails closed.
+    private static final Set<String> SAFE_ENVS = Set.of("local", "dev", "test", "impl");
+
+    private static boolean isSafeEnv(String executionEnv) {
+        if (executionEnv == null) {
+            return false;
+        }
+        String env = executionEnv.toLowerCase();
+        return SAFE_ENVS.stream().anyMatch(env::contains);
     }
 
     public void maybeCrash(CrashPoint point) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -41,19 +41,16 @@ public class CrashInjector {
 
         this.armed = requested && point.isPresent() && !protectedEnv;
         if (armed) {
-            // Loud on purpose: if you see this in a deployed worker's logs, it is going to crash itself.
             log.warn("CRASH-INJECTION ARMED at '{}' with probability {} - this worker will halt itself, "
                     + "FOR RECOVERY TESTING ONLY", this.crashAt.configValue(), crashProbability);
         }
     }
 
-    /** A prod or sandbox worker must never crash itself, no matter what the properties say. */
     private static boolean isProtectedEnv(String executionEnv) {
         String env = executionEnv == null ? "" : executionEnv.toLowerCase();
         return env.contains("prod") || env.contains("sandbox");
     }
 
-    /** Halt the worker if injection is armed for this point. A no-op unless armed for testing. */
     public void maybeCrash(CrashPoint point) {
         if (!armed || crashAt != point) {
             return;
@@ -63,7 +60,7 @@ public class CrashInjector {
         }
     }
 
-    /** Split out from the decision so tests can check what would fire without killing the JVM. */
+    // package-private so tests can stub it instead of actually halting the JVM
     void halt(CrashPoint point) {
         log.error("CRASH-INJECTION firing at '{}': halting worker now (exit 137) to test recovery", point.configValue());
         Runtime.getRuntime().halt(137);

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -30,7 +30,6 @@ public class CrashInjector {
         this.crashProbability = crashProbability;
         Optional<CrashPoint> point = CrashPoint.from(crashAt);
         this.crashAt = point.orElse(null);
-
         boolean requested = crashProbability > 0;
         boolean safeEnv = isSafeEnv(executionEnv);
         if (requested && point.isEmpty()) {
@@ -39,7 +38,6 @@ public class CrashInjector {
         if (requested && !safeEnv) {
             log.warn("CRASH-INJECTION disabled: refusing to arm in '{}', crash testing only runs in dev/test/local", executionEnv);
         }
-
         this.armed = requested && point.isPresent() && safeEnv;
         if (armed) {
             log.warn("CRASH-INJECTION ARMED at '{}' with probability {} - this worker will halt itself, "
@@ -50,7 +48,6 @@ public class CrashInjector {
     // Only dev, test (deployed as ab2d-east-impl), and local may crash. Anything else - prod, sandbox, or
     // an env we don't recognise - is denied, so a bad or missing value fails closed.
     private static final Set<String> SAFE_ENVS = Set.of("local", "dev", "test", "impl");
-
     private static boolean isSafeEnv(String executionEnv) {
         if (executionEnv == null) {
             return false;

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashInjector.java
@@ -4,35 +4,58 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * crash-at picks which point in the pipeline dies (process, read, write, assemble) so a run can be
- * crashed one stage at a time. This is deliberately blunt - it halts the JVM, so the worker dies
- * exactly like a real crash with no shutdown hooks or cleanup. See docs/prototype-crash-testing.md.
+ * Dev/test-only crash injection for exercising the worker's recovery paths on a real deployed container.
+ * Off unless crash-probability is set, and it refuses to arm in prod or sandbox. crash-at picks which
+ * {@link CrashPoint} in the pipeline dies, so a run can be crashed one stage at a time. Deliberately blunt
+ * - it halts the JVM, so the worker dies like a real crash with no cleanup. See docs/prototype-crash-testing.md.
  */
 @Slf4j
 @Component
 public class CrashInjector {
 
-    private final String crashAt;
+    private final CrashPoint crashAt;
     private final double crashProbability;
+    private final boolean armed;
 
     public CrashInjector(
             @Value("${pause-resume.prototype.crash-at:process}") String crashAt,
-            @Value("${pause-resume.prototype.crash-probability:0}") double crashProbability) {
-        this.crashAt = crashAt == null ? "" : crashAt.trim();
+            @Value("${pause-resume.prototype.crash-probability:0}") double crashProbability,
+            @Value("${execution.env:local}") String executionEnv) {
         this.crashProbability = crashProbability;
-        if (crashProbability > 0) {
+        Optional<CrashPoint> point = CrashPoint.from(crashAt);
+        this.crashAt = point.orElse(null);
+
+        boolean requested = crashProbability > 0;
+        boolean protectedEnv = isProtectedEnv(executionEnv);
+        if (requested && point.isEmpty()) {
+            log.warn("CRASH-INJECTION disabled: crash-at '{}' is not one of {}", crashAt, Arrays.toString(CrashPoint.values()));
+        }
+        if (requested && protectedEnv) {
+            log.warn("CRASH-INJECTION disabled: refusing to arm in '{}', crash testing is for dev/test only", executionEnv);
+        }
+
+        this.armed = requested && point.isPresent() && !protectedEnv;
+        if (armed) {
             // Loud on purpose: if you see this in a deployed worker's logs, it is going to crash itself.
             log.warn("CRASH-INJECTION ARMED at '{}' with probability {} - this worker will halt itself, "
-                    + "FOR RECOVERY TESTING ONLY", this.crashAt, crashProbability);
+                    + "FOR RECOVERY TESTING ONLY", this.crashAt.configValue(), crashProbability);
         }
     }
 
-    /** Halt the worker if injection is armed for this point. A no-op unless crash-probability is set. */
-    public void maybeCrash(String point) {
-        if (crashProbability <= 0 || !crashAt.equalsIgnoreCase(point)) {
+    /** A prod or sandbox worker must never crash itself, no matter what the properties say. */
+    private static boolean isProtectedEnv(String executionEnv) {
+        String env = executionEnv == null ? "" : executionEnv.toLowerCase();
+        return env.contains("prod") || env.contains("sandbox");
+    }
+
+    /** Halt the worker if injection is armed for this point. A no-op unless armed for testing. */
+    public void maybeCrash(CrashPoint point) {
+        if (!armed || crashAt != point) {
             return;
         }
         if (ThreadLocalRandom.current().nextDouble() < crashProbability) {
@@ -41,8 +64,8 @@ public class CrashInjector {
     }
 
     /** Split out from the decision so tests can check what would fire without killing the JVM. */
-    void halt(String point) {
-        log.error("CRASH-INJECTION firing at '{}': halting worker now (exit 137) to test recovery", point);
+    void halt(CrashPoint point) {
+        log.error("CRASH-INJECTION firing at '{}': halting worker now (exit 137) to test recovery", point.configValue());
         Runtime.getRuntime().halt(137);
     }
 }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashPoint.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashPoint.java
@@ -1,0 +1,40 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import java.util.Optional;
+
+/**
+ * The points in the pipeline where a crash can be injected for recovery testing. The config value
+ * pause-resume.prototype.crash-at is matched against these by name, case-insensitively.
+ */
+public enum CrashPoint {
+
+    /** While turning a bene's claims into ndjson. */
+    PROCESS,
+
+    /** While reading the next bene out of the partition. */
+    READ,
+
+    /** While writing a chunk to the output file. */
+    WRITE,
+
+    /** While assembling the finished per-partition files into the delivered output. */
+    ASSEMBLE;
+
+    /** The name a worker uses to select this point, e.g. "write". */
+    public String configValue() {
+        return name().toLowerCase();
+    }
+
+    /** The point named by a crash-at value, or empty if it names nothing we recognise. */
+    public static Optional<CrashPoint> from(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        for (CrashPoint point : values()) {
+            if (point.name().equalsIgnoreCase(value.trim())) {
+                return Optional.of(point);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashPoint.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/CrashPoint.java
@@ -8,19 +8,11 @@ import java.util.Optional;
  */
 public enum CrashPoint {
 
-    /** While turning a bene's claims into ndjson. */
     PROCESS,
-
-    /** While reading the next bene out of the partition. */
     READ,
-
-    /** While writing a chunk to the output file. */
     WRITE,
-
-    /** While assembling the finished per-partition files into the delivered output. */
     ASSEMBLE;
 
-    /** The name a worker uses to select this point, e.g. "write". */
     public String configValue() {
         return name().toLowerCase();
     }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
@@ -11,7 +11,6 @@ import gov.cms.ab2d.worker.processor.PatientClaimsProcessor;
 import gov.cms.ab2d.worker.processor.PatientClaimsRequest;
 import gov.cms.ab2d.worker.processor.SerializedEobs;
 import gov.cms.ab2d.worker.service.ContractWorkerClient;
-import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
@@ -19,9 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
-@Slf4j
 @Component
 @StepScope
 public class EobItemProcessor implements ItemProcessor<CoverageSummary, SerializedEobs> {
@@ -30,20 +27,19 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
     private final PatientClaimsRequest request;
     private final FhirVersion version;
     private final long itemDelayMs;
-    // remove this later
-    private final double crashProbability;
+    private final CrashInjector crashInjector;
 
     public EobItemProcessor(
             PatientClaimsProcessor patientClaimsProcessor,
             JobRepository jobRepository,
             ContractWorkerClient contractWorkerClient,
             SearchConfig searchConfig,
+            CrashInjector crashInjector,
             @Value("#{jobParameters['jobUuid']}") String jobUuid,
-            @Value("${pause-resume.prototype.item-delay-ms:0}") long itemDelayMs,
-            @Value("${pause-resume.prototype.crash-probability:0}") double crashProbability) {
+            @Value("${pause-resume.prototype.item-delay-ms:0}") long itemDelayMs) {
         this.patientClaimsProcessor = patientClaimsProcessor;
         this.itemDelayMs = itemDelayMs;
-        this.crashProbability = crashProbability;
+        this.crashInjector = crashInjector;
         Job job = jobRepository.findByJobUuid(jobUuid);
         this.version = job.getFhirVersion();
         ContractDTO contract = contractWorkerClient.getContractByContractNumber(job.getContractNumber());
@@ -65,12 +61,7 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
 
     @Override
     public SerializedEobs process(CoverageSummary patient) throws InterruptedException {
-        // dev test code - simulates a hard crash by just throwing the process in the trash
-        // remove this later
-        if (crashProbability > 0 && ThreadLocalRandom.current().nextDouble() < crashProbability) {
-            log.error("Simulating hard crash. Goodbye.");
-            Runtime.getRuntime().halt(137);
-        }
+        crashInjector.maybeCrash("process");
 
         // optional artificial slowdown so a running job stays alive long enough to interrupt in tests
         if (itemDelayMs > 0) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/EobItemProcessor.java
@@ -61,7 +61,7 @@ public class EobItemProcessor implements ItemProcessor<CoverageSummary, Serializ
 
     @Override
     public SerializedEobs process(CoverageSummary patient) throws InterruptedException {
-        crashInjector.maybeCrash("process");
+        crashInjector.maybeCrash(CrashPoint.PROCESS);
 
         // optional artificial slowdown so a running job stays alive long enough to interrupt in tests
         if (itemDelayMs > 0) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
@@ -19,10 +19,13 @@ public class NdjsonCompositeWriter implements ItemStreamWriter<SerializedEobs> {
 
     private final FlatFileItemWriter<String> dataWriter;
     private final FlatFileItemWriter<String> errorWriter;
+    private final CrashInjector crashInjector;
 
-    public NdjsonCompositeWriter(FlatFileItemWriter<String> dataWriter, FlatFileItemWriter<String> errorWriter) {
+    public NdjsonCompositeWriter(FlatFileItemWriter<String> dataWriter, FlatFileItemWriter<String> errorWriter,
+                                 CrashInjector crashInjector) {
         this.dataWriter = dataWriter;
         this.errorWriter = errorWriter;
+        this.crashInjector = crashInjector;
     }
 
     @Override
@@ -48,6 +51,7 @@ public class NdjsonCompositeWriter implements ItemStreamWriter<SerializedEobs> {
 
     @Override
     public void write(@NonNull Chunk<? extends SerializedEobs> chunk) throws Exception {
+        crashInjector.maybeCrash("write");
         List<String> dataLines = chunk.getItems().stream().flatMap(item -> item.dataLines().stream()).toList();
         List<String> errorLines = chunk.getItems().stream().flatMap(item -> item.errorLines().stream()).toList();
         if (!dataLines.isEmpty()) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
@@ -51,12 +51,13 @@ public class NdjsonCompositeWriter implements ItemStreamWriter<SerializedEobs> {
 
     @Override
     public void write(@NonNull Chunk<? extends SerializedEobs> chunk) throws Exception {
-        crashInjector.maybeCrash(CrashPoint.WRITE);
         List<String> dataLines = chunk.getItems().stream().flatMap(item -> item.dataLines().stream()).toList();
         List<String> errorLines = chunk.getItems().stream().flatMap(item -> item.errorLines().stream()).toList();
         if (!dataLines.isEmpty()) {
             dataWriter.write(new Chunk<>(dataLines));
         }
+        // crash between the two writers, so the data and error files are left out of sync
+        crashInjector.maybeCrash(CrashPoint.WRITE);
         if (!errorLines.isEmpty()) {
             errorWriter.write(new Chunk<>(errorLines));
         }

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonCompositeWriter.java
@@ -51,7 +51,7 @@ public class NdjsonCompositeWriter implements ItemStreamWriter<SerializedEobs> {
 
     @Override
     public void write(@NonNull Chunk<? extends SerializedEobs> chunk) throws Exception {
-        crashInjector.maybeCrash("write");
+        crashInjector.maybeCrash(CrashPoint.WRITE);
         List<String> dataLines = chunk.getItems().stream().flatMap(item -> item.dataLines().stream()).toList();
         List<String> errorLines = chunk.getItems().stream().flatMap(item -> item.errorLines().stream()).toList();
         if (!dataLines.isEmpty()) {

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/NdjsonWriterConfig.java
@@ -26,6 +26,7 @@ public class NdjsonWriterConfig {
     @StepScope
     public ItemStreamWriter<SerializedEobs> ndjsonItemWriter(
             SearchConfig searchConfig,
+            CrashInjector crashInjector,
             @Value("#{jobParameters['jobUuid']}") String jobUuid,
             @Value("#{jobParameters['fenceToken']}") long fenceToken,
             @Value("#{stepExecutionContext['contractNumber']}") String contract,
@@ -46,7 +47,7 @@ public class NdjsonWriterConfig {
                 streamingDir.resolve(PrototypePartitionNaming.fileName(contract, partitionIndex, fenceToken,
                         PrototypePartitionNaming.ERROR_STREAM)),
                 PrototypePartitionNaming.errorWriterName(partitionIndex, fenceToken));
-        return new NdjsonCompositeWriter(dataWriter, errorWriter);
+        return new NdjsonCompositeWriter(dataWriter, errorWriter, crashInjector);
     }
 
     /**

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -82,10 +82,14 @@ public class PrototypeJobRecovery {
         Optional<Long> adopted = jobLease.tryAdoptCleanSuspend(jobUuid, owner);
         if (adopted.isPresent()) {
             // The token did not move, so the files and checkpoint keys already line up. Nothing to repair.
+            log.info("RECOVERY for job {}: SOFT RESUME on token {} - clean suspend adopted, nothing to redo",
+                    jobUuid, adopted.get());
             return new Ownership(adopted.get(), true);
         }
 
         long fenceToken = jobLease.bump(jobUuid, owner);
+        log.info("RECOVERY for job {}: HARD RECOVERY on new token {} - a crashed or stale worker was fenced, "
+                + "incomplete partitions will be redone", jobUuid, fenceToken);
         // Copy-forward runs first, to see if there are any UNKNOWN statuses
         // If no, it copies the old partition work to the new file
         // If yes, it doesn't copy anything forward, the partition will be restarted

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeJobRecovery.java
@@ -82,14 +82,10 @@ public class PrototypeJobRecovery {
         Optional<Long> adopted = jobLease.tryAdoptCleanSuspend(jobUuid, owner);
         if (adopted.isPresent()) {
             // The token did not move, so the files and checkpoint keys already line up. Nothing to repair.
-            log.info("RECOVERY for job {}: SOFT RESUME on token {} - clean suspend adopted, nothing to redo",
-                    jobUuid, adopted.get());
             return new Ownership(adopted.get(), true);
         }
 
         long fenceToken = jobLease.bump(jobUuid, owner);
-        log.info("RECOVERY for job {}: HARD RECOVERY on new token {} - a crashed or stale worker was fenced, "
-                + "incomplete partitions will be redone", jobUuid, fenceToken);
         // Copy-forward runs first, to see if there are any UNKNOWN statuses
         // If no, it copies the old partition work to the new file
         // If yes, it doesn't copy anything forward, the partition will be restarted

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
@@ -35,12 +35,14 @@ public class PrototypeOutputAssembler {
     private final SearchConfig searchConfig;
     private final JobOutputRepository jobOutputRepository;
     private final PrototypeBatchMetadataRepository batchMeta;
+    private final CrashInjector crashInjector;
 
     public PrototypeOutputAssembler(SearchConfig searchConfig, JobOutputRepository jobOutputRepository,
-                                    PrototypeBatchMetadataRepository batchMeta) {
+                                    PrototypeBatchMetadataRepository batchMeta, CrashInjector crashInjector) {
         this.searchConfig = searchConfig;
         this.jobOutputRepository = jobOutputRepository;
         this.batchMeta = batchMeta;
+        this.crashInjector = crashInjector;
     }
 
     /**
@@ -65,6 +67,8 @@ public class PrototypeOutputAssembler {
             log.info("assembly for job {}: no completed partitions - empty result, no output files", jobUuid);
             return;
         }
+
+        crashInjector.maybeCrash("assemble");
 
         Path streamingDir = searchConfig.getStreamingDir(jobUuid).toPath();
         Path finishedDir = searchConfig.getFinishedDir(jobUuid).toPath();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
@@ -68,7 +68,7 @@ public class PrototypeOutputAssembler {
             return;
         }
 
-        crashInjector.maybeCrash("assemble");
+        crashInjector.maybeCrash(CrashPoint.ASSEMBLE);
 
         Path streamingDir = searchConfig.getStreamingDir(jobUuid).toPath();
         Path finishedDir = searchConfig.getFinishedDir(jobUuid).toPath();

--- a/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
+++ b/worker/src/main/java/gov/cms/ab2d/worker/processor/prototype/PrototypeOutputAssembler.java
@@ -68,8 +68,6 @@ public class PrototypeOutputAssembler {
             return;
         }
 
-        crashInjector.maybeCrash(CrashPoint.ASSEMBLE);
-
         Path streamingDir = searchConfig.getStreamingDir(jobUuid).toPath();
         Path finishedDir = searchConfig.getFinishedDir(jobUuid).toPath();
         Path jobRoot = Path.of(searchConfig.getEfsMount(), jobUuid);
@@ -162,6 +160,8 @@ public class PrototypeOutputAssembler {
                 }
                 Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING);
                 promoted.add(dest);
+                // crash mid-promotion, so a restart has to finish a half-promoted assembly idempotently
+                crashInjector.maybeCrash(CrashPoint.ASSEMBLE);
             } else if (Files.isRegularFile(dest)) {
                 if (!required && Files.size(dest) == 0) {
                     continue;

--- a/worker/src/main/resources/application.properties
+++ b/worker/src/main/resources/application.properties
@@ -21,6 +21,8 @@ pause-resume.prototype.item-delay-ms=0
 # DEV CRASH TESTING - sets the probability that the worker just crashes
 # for testing purposes only
 pause-resume.prototype.crash-probability=0
+# which pipeline point crashes when crash-probability is set: process, read, write, or assemble
+pause-resume.prototype.crash-at=process
 # granularity for pause/resume checkpointing, and the widest fan-out one partition can reach
 pause-resume.prototype.chunk-size=100
 # number of partitions processed concurrently

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/AbstractPrototypeRecoveryIntegrationTest.java
@@ -181,18 +181,7 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
 
         // paging mock
         when(coverageV3Service.pageCoverageByPatientRange(eq(CONTRACT), anyLong(), anyLong(), any(), anyInt()))
-                .thenAnswer(inv -> {
-                    long start = inv.getArgument(1);
-                    long end = inv.getArgument(2);
-                    Optional<Long> cursor = inv.getArgument(3);
-                    long from = cursor.orElse(start);
-                    List<CoverageSummary> page = allBenes.stream()
-                            .filter(cs -> patientId(cs) > from && patientId(cs) <= end)
-                            .sorted((a, b) -> Long.compare(patientId(a), patientId(b)))
-                            .collect(Collectors.toList());
-                    // page size (1000) always covers a partition, so there is never a second page
-                    return new CoveragePagingResult(page, null);
-                });
+                .thenAnswer(this::pageFor);
 
         // BFD mock
         when(patientClaimsProcessor.getEobBundleResources(any(), any())).thenAnswer(inv -> oneEobFor(inv.getArgument(1)));
@@ -203,6 +192,20 @@ abstract class AbstractPrototypeRecoveryIntegrationTest extends JobCleanup {
         jobCleanup();
         dataSetup.cleanup();
         pdpClientRepository.deleteAll();
+    }
+
+    /** One page of coverage for the paging mock. Shared so a read-failure test can reuse it after throwing. */
+    protected CoveragePagingResult pageFor(org.mockito.invocation.InvocationOnMock inv) {
+        long start = inv.getArgument(1);
+        long end = inv.getArgument(2);
+        Optional<Long> cursor = inv.getArgument(3);
+        long from = cursor.orElse(start);
+        List<CoverageSummary> page = allBenes.stream()
+                .filter(cs -> patientId(cs) > from && patientId(cs) <= end)
+                .sorted((a, b) -> Long.compare(patientId(a), patientId(b)))
+                .collect(Collectors.toList());
+        // page size (1000) always covers a partition, so there is never a second page
+        return new CoveragePagingResult(page, null);
     }
 
     /** One ExplanationOfBenefit per beneficiary, recording the call in processedLog. */

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -1,7 +1,5 @@
 package gov.cms.ab2d.worker.processor.prototype;
-
 import org.junit.jupiter.api.Test;
-
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -1,0 +1,50 @@
+package gov.cms.ab2d.worker.processor.prototype;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The injector actually halts the JVM, so these tests spy the halt out and just check the decision:
+ * is it off by default, does it only fire at the configured point, and is the point match forgiving.
+ */
+class CrashInjectorTest {
+
+    @Test
+    void offByDefaultSoNothingCrashes() {
+        CrashInjector injector = spy(new CrashInjector("process", 0));
+        doNothing().when(injector).halt(anyString());
+
+        injector.maybeCrash("process");
+
+        verify(injector, never()).halt(anyString());
+    }
+
+    @Test
+    void crashesOnlyAtTheConfiguredPoint() {
+        CrashInjector injector = spy(new CrashInjector("write", 1.0));
+        doNothing().when(injector).halt(anyString());
+
+        injector.maybeCrash("read");
+        injector.maybeCrash("process");
+        verify(injector, never()).halt(anyString());
+
+        injector.maybeCrash("write");
+        verify(injector, times(1)).halt("write");
+    }
+
+    @Test
+    void pointMatchIsCaseInsensitive() {
+        CrashInjector injector = spy(new CrashInjector("ASSEMBLE", 1.0));
+        doNothing().when(injector).halt(anyString());
+
+        injector.maybeCrash("assemble");
+
+        verify(injector, times(1)).halt("assemble");
+    }
+}

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -1,6 +1,8 @@
 package gov.cms.ab2d.worker.processor.prototype;
+
 import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.anyString;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -9,40 +11,71 @@ import static org.mockito.Mockito.verify;
 
 /**
  * The injector actually halts the JVM, so these tests spy the halt out and just check the decision:
- * is it off by default, does it only fire at the configured point, and is the point match forgiving.
+ * is it off by default, does it only fire at the configured point, is the config value forgiving, and
+ * does it refuse to arm where it must never crash.
  */
 class CrashInjectorTest {
 
     @Test
     void offByDefaultSoNothingCrashes() {
-        CrashInjector injector = spy(new CrashInjector("process", 0));
-        doNothing().when(injector).halt(anyString());
+        CrashInjector injector = spy(new CrashInjector("process", 0, "test"));
+        doNothing().when(injector).halt(any());
 
-        injector.maybeCrash("process");
+        injector.maybeCrash(CrashPoint.PROCESS);
 
-        verify(injector, never()).halt(anyString());
+        verify(injector, never()).halt(any());
     }
 
     @Test
     void crashesOnlyAtTheConfiguredPoint() {
-        CrashInjector injector = spy(new CrashInjector("write", 1.0));
-        doNothing().when(injector).halt(anyString());
+        CrashInjector injector = spy(new CrashInjector("write", 1.0, "test"));
+        doNothing().when(injector).halt(any());
 
-        injector.maybeCrash("read");
-        injector.maybeCrash("process");
-        verify(injector, never()).halt(anyString());
+        injector.maybeCrash(CrashPoint.READ);
+        injector.maybeCrash(CrashPoint.PROCESS);
+        verify(injector, never()).halt(any());
 
-        injector.maybeCrash("write");
-        verify(injector, times(1)).halt("write");
+        injector.maybeCrash(CrashPoint.WRITE);
+        verify(injector, times(1)).halt(CrashPoint.WRITE);
     }
 
     @Test
-    void pointMatchIsCaseInsensitive() {
-        CrashInjector injector = spy(new CrashInjector("ASSEMBLE", 1.0));
-        doNothing().when(injector).halt(anyString());
+    void configValueIsCaseInsensitive() {
+        CrashInjector injector = spy(new CrashInjector("ASSEMBLE", 1.0, "test"));
+        doNothing().when(injector).halt(any());
 
-        injector.maybeCrash("assemble");
+        injector.maybeCrash(CrashPoint.ASSEMBLE);
 
-        verify(injector, times(1)).halt("assemble");
+        verify(injector, times(1)).halt(CrashPoint.ASSEMBLE);
+    }
+
+    @Test
+    void unknownConfigValueDoesNotArm() {
+        CrashInjector injector = spy(new CrashInjector("banana", 1.0, "test"));
+        doNothing().when(injector).halt(any());
+
+        injector.maybeCrash(CrashPoint.WRITE);
+
+        verify(injector, never()).halt(any());
+    }
+
+    @Test
+    void refusesToArmInProd() {
+        CrashInjector injector = spy(new CrashInjector("write", 1.0, "ab2d-east-prod"));
+        doNothing().when(injector).halt(any());
+
+        injector.maybeCrash(CrashPoint.WRITE);
+
+        verify(injector, never()).halt(any());
+    }
+
+    @Test
+    void refusesToArmInSandbox() {
+        CrashInjector injector = spy(new CrashInjector("write", 1.0, "ab2d-sbx-sandbox"));
+        doNothing().when(injector).halt(any());
+
+        injector.maybeCrash(CrashPoint.WRITE);
+
+        verify(injector, never()).halt(any());
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -74,4 +74,14 @@ class CrashInjectorTest {
 
         verify(injector, never()).halt(any());
     }
+
+    @Test
+    void refusesToArmInAnUnrecognisedEnv() {
+        CrashInjector injector = spy(new CrashInjector("write", 1.0, "somewhere-new"));
+        doNothing().when(injector).halt(any());
+
+        injector.maybeCrash(CrashPoint.WRITE);
+
+        verify(injector, never()).halt(any());
+    }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -3,7 +3,6 @@ package gov.cms.ab2d.worker.processor.prototype;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -18,9 +17,7 @@ class CrashInjectorTest {
     void offByDefaultSoNothingCrashes() {
         CrashInjector injector = spy(new CrashInjector("process", 0, "test"));
         doNothing().when(injector).halt(any());
-
         injector.maybeCrash(CrashPoint.PROCESS);
-
         verify(injector, never()).halt(any());
     }
 
@@ -28,11 +25,9 @@ class CrashInjectorTest {
     void crashesOnlyAtTheConfiguredPoint() {
         CrashInjector injector = spy(new CrashInjector("write", 1.0, "test"));
         doNothing().when(injector).halt(any());
-
         injector.maybeCrash(CrashPoint.READ);
         injector.maybeCrash(CrashPoint.PROCESS);
         verify(injector, never()).halt(any());
-
         injector.maybeCrash(CrashPoint.WRITE);
         verify(injector, times(1)).halt(CrashPoint.WRITE);
     }
@@ -41,9 +36,7 @@ class CrashInjectorTest {
     void configValueIsCaseInsensitive() {
         CrashInjector injector = spy(new CrashInjector("ASSEMBLE", 1.0, "test"));
         doNothing().when(injector).halt(any());
-
         injector.maybeCrash(CrashPoint.ASSEMBLE);
-
         verify(injector, times(1)).halt(CrashPoint.ASSEMBLE);
     }
 
@@ -51,9 +44,7 @@ class CrashInjectorTest {
     void unknownConfigValueDoesNotArm() {
         CrashInjector injector = spy(new CrashInjector("banana", 1.0, "test"));
         doNothing().when(injector).halt(any());
-
         injector.maybeCrash(CrashPoint.WRITE);
-
         verify(injector, never()).halt(any());
     }
 
@@ -62,9 +53,7 @@ class CrashInjectorTest {
     void refusesToArmOutsideDevTestLocal(String executionEnv) {
         CrashInjector injector = spy(new CrashInjector("write", 1.0, executionEnv));
         doNothing().when(injector).halt(any());
-
         injector.maybeCrash(CrashPoint.WRITE);
-
         verify(injector, never()).halt(any());
     }
 }

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -9,11 +9,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/**
- * The injector actually halts the JVM, so these tests spy the halt out and just check the decision:
- * is it off by default, does it only fire at the configured point, is the config value forgiving, and
- * does it refuse to arm where it must never crash.
- */
+/** halt() is stubbed out so we can check the arm/fire decision without killing the test JVM. */
 class CrashInjectorTest {
 
     @Test

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/CrashInjectorTest.java
@@ -1,6 +1,8 @@
 package gov.cms.ab2d.worker.processor.prototype;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -55,29 +57,10 @@ class CrashInjectorTest {
         verify(injector, never()).halt(any());
     }
 
-    @Test
-    void refusesToArmInProd() {
-        CrashInjector injector = spy(new CrashInjector("write", 1.0, "ab2d-east-prod"));
-        doNothing().when(injector).halt(any());
-
-        injector.maybeCrash(CrashPoint.WRITE);
-
-        verify(injector, never()).halt(any());
-    }
-
-    @Test
-    void refusesToArmInSandbox() {
-        CrashInjector injector = spy(new CrashInjector("write", 1.0, "ab2d-sbx-sandbox"));
-        doNothing().when(injector).halt(any());
-
-        injector.maybeCrash(CrashPoint.WRITE);
-
-        verify(injector, never()).halt(any());
-    }
-
-    @Test
-    void refusesToArmInAnUnrecognisedEnv() {
-        CrashInjector injector = spy(new CrashInjector("write", 1.0, "somewhere-new"));
+    @ParameterizedTest
+    @ValueSource(strings = {"ab2d-east-prod", "ab2d-sbx-sandbox", "an-env-we-dont-know"})
+    void refusesToArmOutsideDevTestLocal(String executionEnv) {
+        CrashInjector injector = spy(new CrashInjector("write", 1.0, executionEnv));
         doNothing().when(injector).halt(any());
 
         injector.maybeCrash(CrashPoint.WRITE);

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.when;
  * Crash recovery integration tests that force failure at each distinct step of the pipeline and then
  * recovers it. The steps are:
  *      partitioning - fail mid-partition, on recovery the partitioning step should restart entirely
+ *      reading      - fail while paging beneficiaries, the chunk rolls back and reading resumes cleanly
  *      processing   - fail while running the job processor, chunk rolls back, restarts from the prior chunk
  *      file writing - fail while writing a file. Recovery ensures no duplicate or corrupted output
  *      assembly     - fail while assembling the finished files. Recovery continues assembly idempotently
@@ -61,6 +63,31 @@ class PrototypeCrashPointIntegrationTest extends AbstractPrototypeRecoveryIntegr
 
         assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a partitioning crash should recover on a later pickup");
         assertTrue(thrown.get(), "the partitioning failure should actually have been injected");
+        assertEveryBeneExactlyOnceInOutput(uuid);
+    }
+
+    @Test
+    @DisplayName("Crash during reading: a transient paging failure is retried and every bene is still delivered once")
+    void crashDuringReadingRecovers() throws Exception {
+        Job job = createSubmittedV3Job("crash-reading");
+        String uuid = job.getJobUuid();
+
+        // Fail the first page fetch, then serve pages normally. The chunk rolls back and the reader resumes.
+        AtomicBoolean thrown = new AtomicBoolean(false);
+        when(coverageV3Service.pageCoverageByPatientRange(eq(CONTRACT), anyLong(), anyLong(), any(), anyInt()))
+                .thenAnswer(inv -> {
+                    if (thrown.compareAndSet(false, true)) {
+                        log.info("=== injecting transient reading failure for {} ===", uuid);
+                        throw new org.springframework.web.client.ResourceAccessException(
+                                "injected transient read failure");
+                    }
+                    return pageFor(inv);
+                });
+
+        Job result = processUntilSuccessful(uuid, 3);
+
+        assertEquals(JobStatus.SUCCESSFUL, result.getStatus(), "a transient read blip should recover");
+        assertTrue(thrown.get(), "the reading failure should actually have been injected");
         assertEveryBeneExactlyOnceInOutput(uuid);
     }
 

--- a/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
+++ b/worker/src/test/java/gov/cms/ab2d/worker/processor/prototype/PrototypeCrashPointIntegrationTest.java
@@ -29,14 +29,13 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
- * Crash recovery integration tests that force failure at each distinct step of the pipeline and then
- * recovers it. The steps are:
- *      partitioning - fail mid-partition, on recovery the partitioning step should restart entirely
+ * Crash recovery integration tests that force a failure at a distinct step of the pipeline and then let
+ * the job recover. The steps are:
+ *      partitioning - fail mid-partition. Partitioning has no resume, so on restart the whole step re-runs.
  *      reading      - fail while paging beneficiaries, the chunk rolls back and reading resumes cleanly
  *      processing   - fail while running the job processor, chunk rolls back, restarts from the prior chunk
  *      file writing - fail while writing a file. Recovery ensures no duplicate or corrupted output
  *      assembly     - fail while assembling the finished files. Recovery continues assembly idempotently
- *
  */
 class PrototypeCrashPointIntegrationTest extends AbstractPrototypeRecoveryIntegrationTest {
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7374

## 🛠 Changes

Adds crash/fault injection to the pause-resume prototype worker so recovery pathways can be validated on a real deployed container, not just in-process tests.

- CrashInjector - a small, config-driven component that halts the worker (Runtime.halt(137)) at a chosen pipeline point. Replaces the single hardcoded crash hook that was inline in EobItemProcessor. Controlled by:
  - pause-resume.prototype.crash-probability (0 = off)
  - pause-resume.prototype.crash-at - a CrashPoint enum value: process, read, write, or assemble
- Wired into four points: EobItemProcessor (process), BeneficiaryItemReader (read), NdjsonCompositeWriter (between the data and error writes), and PrototypeOutputAssembler (mid promoteWinners, so a restart has to finish a half-promoted assembly idempotently).
- Safety: validates crash-at against the enum, and only arms in dev/test/local by reading execution.env. Prod, sandbox, and any unrecognised env are denied, so a bad value fails closed.
- Tests: CrashInjectorTest (off by default, fires only at the configured point, case-insensitive config, unknown value disarms, and a parameterized guard proving prod/sandbox/unknown never arm), plus a new crashDuringReadingRecovers case filling the one previously-uncovered stage.
- Runbook: docs/prototype-crash-testing.md - how to crash a deployed worker (env-var injector or AWS FIS / ecs stop-task), the log markers to watch, and what to verify after recovery.

Default behaviour is unchanged: crash-probability=0 means every injection point is a no-op unless explicitly armed in a dev/test worker.

## ℹ️ Context

We want confidence that a worker can safely restart a job in a deployed environment without data corruption or faulty output, including crashes mid-file-write and mid-assembly. Unit and integration tests already cover many recovery cases in-process; this adds a way to exercise recovery on a real container and follow the crash then recovery then clean-completion story in the logs (the processor already logs the fresh/soft/hard claim on pickup).

No new dependencies, security controls, or data flows. Crash injection is off by default and can only ever run in dev/test/local.

## 🧪 Validation

<img width="905" height="384" alt="image" src="https://github.com/user-attachments/assets/094d7053-413c-4029-a0da-3dd8ec307a59" />
<img width="953" height="371" alt="image" src="https://github.com/user-attachments/assets/bbb51c4c-d726-4fc0-889a-ec4e9ada230d" />

