### PR TITLE
AB2D-7435  Investigate why total-benes-served-update workflow is not stable

### DIFF
--- a/.github/workflows/resources/total-benes-served.sql
+++ b/.github/workflows/resources/total-benes-served.sql
@@ -1,1 +1,1 @@
-SET statement_timeout='7h'; CALL find_benes_served();
+SET statement_timeout='7h'; CALL find_benes_served_optimized();

--- a/.github/workflows/total-benes-served-update.yml
+++ b/.github/workflows/total-benes-served-update.yml
@@ -2,6 +2,9 @@ name: total-benes-served-update
 run-name: total-benes-served-update prod
 
 on:
+  push:
+    branches:
+      - fix_total_benes_served_update_workflow
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * 3,5'  # Tuesday and Thursday at 11pm EST (UTC-5)

--- a/.github/workflows/total-benes-served-update.yml
+++ b/.github/workflows/total-benes-served-update.yml
@@ -36,20 +36,25 @@ jobs:
 
       - name: Install psql
         run: |
-          sudo dnf install postgresql16 -y
+          sudo dnf install postgresql16 -y --setopt=retries=5 --setopt=timeout=30
 
       - name: Conduct update of total benes served
         run: |
           COUNT_QUERY="SELECT statistic_value FROM ab2d.ab2d_statistics WHERE statistic_name = 'total_benes_served';"
 
           echo "Procedure started"
-          COUNT_BEFORE=$(psql -t --command="${COUNT_QUERY}" | xargs)
+          START_SECONDS=${SECONDS}
+
+          COUNT_BEFORE=$(psql -tA --command="${COUNT_QUERY}")
           echo "Count before: ${COUNT_BEFORE}"
 
-          SQL_TOTAL_BENE_SERVED=$(envsubst < .github/workflows/resources/total-benes-served.sql)
-          psql -t --command="${SQL_TOTAL_BENE_SERVED}"
+          # ON_ERROR_STOP is required: without it psql prints SQL errors and still
+          # exits 0, so a failed procedure reports as a green run that silently
+          # leaves the statistic stale.
+          psql -v ON_ERROR_STOP=1 -f .github/workflows/resources/total-benes-served.sql
 
-          COUNT_AFTER=$(psql -t --command="${COUNT_QUERY}" | xargs)
+          COUNT_AFTER=$(psql -tA --command="${COUNT_QUERY}")
           echo "Count after: ${COUNT_AFTER}"
           echo "Difference: $((COUNT_AFTER - COUNT_BEFORE))"
+          echo "Elapsed: $(( (SECONDS - START_SECONDS) / 60 )) minutes"
           echo "Procedure completed"

--- a/common/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/common/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -203,3 +203,5 @@ databaseChangeLog:
       file: db/changelog/v2026/add_int_lock_expired_after.sql
   - include:
       file: db/changelog/v2026/alter_historic_mbis_type.sql
+  - include:
+      file: db/changelog/v2026/optimize_find_benes_served_procedure.sql

--- a/common/src/main/resources/db/changelog/v2026/optimize_find_benes_served_procedure.sql
+++ b/common/src/main/resources/db/changelog/v2026/optimize_find_benes_served_procedure.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE PROCEDURE ab2d.find_benes_served()
+CREATE OR REPLACE PROCEDURE ab2d.find_benes_served_optimized()
     LANGUAGE plpgsql
 AS
 $$

--- a/common/src/main/resources/db/changelog/v2026/optimize_find_benes_served_procedure.sql
+++ b/common/src/main/resources/db/changelog/v2026/optimize_find_benes_served_procedure.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE PROCEDURE ab2d.find_benes_served()
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    ubc BIGINT;
+    max_year INT := date_part('year', current_timestamp)::int;
+BEGIN
+
+WITH contract_last_run AS MATERIALIZED (
+    SELECT contract_number, MAX(created_at) AS last_run
+    FROM ab2d.job_view
+    WHERE status = 'SUCCESSFUL'
+      AND (contract_number LIKE 'S%' OR contract_number LIKE 'E%')
+    GROUP BY contract_number
+),
+benes_served AS (
+    SELECT DISTINCT cov.beneficiary_id
+    FROM ab2d.coverage_view cov
+             INNER JOIN ab2d.bcp_view bcp ON bcp.bcp_id = cov.bene_coverage_period_id
+             INNER JOIN contract_last_run clr ON clr.contract_number = cov.contract
+    WHERE bcp.status = 'SUCCESSFUL'
+      AND cov.year BETWEEN 2020 AND max_year
+      AND bcp.year BETWEEN 2020 AND max_year
+      AND make_timestamptz(cov.year, cov.month, 1, 0, 0, 0, 'America/New_York') < clr.last_run
+)
+SELECT COUNT(*) INTO ubc FROM benes_served;
+
+RAISE NOTICE 'Total unique benes served: %', ubc;
+
+IF ubc IS NULL OR ubc = 0 THEN
+    RAISE EXCEPTION 'find_benes_served() computed % unique benes; refusing to overwrite total_benes_served', ubc;
+END IF;
+
+UPDATE ab2d.ab2d_statistics
+SET statistic_value = ubc
+WHERE statistic_name = 'total_benes_served';
+END
+$$;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7435

## 🛠 Changes

I rewrote `find_benes_served()` so it scans the coverage data once instead of scanning the same partitions again for each contract. This reduced the runtime from 291 minutes to 31 minutes and returned the same result: 34,421,221.

This fixes the intermittent workflow failures, which happened because the job sometimes ran longer than the runner’s hard limit of about 310 minutes and was killed.

## ℹ️ Context

The total-benes-served-update workflow fails intermittently. We need to find the root cause and fix the procedure.

## 🧪 Validation

Old: https://github.com/CMSgov/ab2d/actions/runs/34560629957
Updated: https://github.com/CMSgov/ab2d/actions/runs/34663760386
